### PR TITLE
Update shortcut and github installer so that main = latest release

### DIFF
--- a/how-to/integrate-with-salesforce/README.md
+++ b/how-to/integrate-with-salesforce/README.md
@@ -15,7 +15,7 @@ This application you are about to install is an example of configuring and integ
 To run this sample you can:
 
 * Clone this repo and follow the instructions below. This will let you customize the sample to learn more about our APIs.
-* Launch the Github hosted version of this sample to interact with it by going to the following link: <a href="https://start.openfin.co/?manifest=https%3A%2F%2Fbuilt-on-openfin.github.io%2Fworkspace-starter%2Fworkspace%2Fv5.0.0%2Fintegrate-with-salesforce%2Fmanifest.fin.json" target="_blank">Github Workspace Starter Integrate With Salesforce</a>
+* Launch the Github hosted version of this sample to interact with it by going to the following link: <a href="https://start.openfin.co/?manifest=https%3A%2F%2Fbuilt-on-openfin.github.io%2Fworkspace-starter%2Fmain%2Fintegrate-with-salesforce%2Fmanifest.fin.json" target="_blank">Github Workspace Starter Integrate With Salesforce</a>
 
 ---
 

--- a/how-to/integrate-with-salesforce/public/manifest.fin.json
+++ b/how-to/integrate-with-salesforce/public/manifest.fin.json
@@ -37,7 +37,7 @@
     "company": "OpenFin",
     "description": "An way of showing examples of what OpenFin can do.",
     "icon": "http://localhost:8080/favicon.ico",
-    "name": "Integrate With Salesforce - v5",
+    "name": "Integrate With Salesforce - Latest",
     "target": ["desktop", "start-menu"]
   },
   "customSettings": {

--- a/how-to/register-with-home/README.md
+++ b/how-to/register-with-home/README.md
@@ -15,7 +15,7 @@ This application you are about to install is a simple example of plugging in you
 To run this sample you can:
 
 * Clone this repo and follow the instructions below. This will let you customize the sample to learn more about our APIs.
-* Launch the Github hosted version of this sample to interact with it by going to the following link: <a href="https://start.openfin.co/?manifest=https%3A%2F%2Fbuilt-on-openfin.github.io%2Fworkspace-starter%2Fworkspace%2Fv5.0.0%2Fregister-with-home%2Fmanifest.fin.json" target="_blank">Github Workspace Starter Register With Home</a>
+* Launch the Github hosted version of this sample to interact with it by going to the following link: <a href="https://start.openfin.co/?manifest=https%3A%2F%2Fbuilt-on-openfin.github.io%2Fworkspace-starter%2Fmain%2Fregister-with-home%2Fmanifest.fin.json" target="_blank">Github Workspace Starter Register With Home</a>
 
 ---
 

--- a/how-to/register-with-home/public/manifest.fin.json
+++ b/how-to/register-with-home/public/manifest.fin.json
@@ -38,7 +38,7 @@
     "company": "OpenFin",
     "description": "An way of showing examples of what OpenFin can do.",
     "icon": "http://localhost:8080/favicon.ico",
-    "name": "Register With Home - v5",
+    "name": "Register With Home - Latest",
     "target": ["desktop", "start-menu"]
   },
   "customSettings": {

--- a/how-to/register-with-store/README.md
+++ b/how-to/register-with-store/README.md
@@ -17,7 +17,7 @@ This application also shows you how to use the new @openfin/workspace-platform n
 To run this sample you can:
 
 * Clone this repo and follow the instructions below. This will let you customize the sample to learn more about our APIs.
-* Launch the Github hosted version of this sample to interact with it by going to the following link: <a href="https://start.openfin.co/?manifest=https%3A%2F%2Fbuilt-on-openfin.github.io%2Fworkspace-starter%2Fworkspace%2Fv5.0.0%2Fregister-with-store%2Fmanifest.fin.json" target="_blank">Github Workspace Starter Register With Store</a>
+* Launch the Github hosted version of this sample to interact with it by going to the following link: <a href="https://start.openfin.co/?manifest=https%3A%2F%2Fbuilt-on-openfin.github.io%2Fworkspace-starter%2Fmain%2Fregister-with-store%2Fmanifest.fin.json" target="_blank">Github Workspace Starter Register With Store</a>
 
 ---
 

--- a/how-to/register-with-store/public/manifest.fin.json
+++ b/how-to/register-with-store/public/manifest.fin.json
@@ -39,7 +39,7 @@
     "company": "OpenFin",
     "description": "An way of showing examples of what OpenFin can do.",
     "icon": "http://localhost:8080/favicon.ico",
-    "name": "Register With Store - v5",
+    "name": "Register With Store - Latest",
     "target": ["desktop", "start-menu"]
   },
   "appAssets": [


### PR DESCRIPTION
Versioned branches should always point to a versioned manifest with a shortcut that represents the version. The installer link should point to that versioned manifest. Main changes over time and if someone wants to run latest (without pinning via DOS) the main branch is updated over time to point to the latest version of these samples through main branch manifests.