### PR TITLE
Remove github startlink for salesforce example

### DIFF
--- a/how-to/integrate-with-salesforce/README.md
+++ b/how-to/integrate-with-salesforce/README.md
@@ -15,7 +15,6 @@ This application you are about to install is an example of configuring and integ
 To run this sample you can:
 
 * Clone this repo and follow the instructions below. This will let you customize the sample to learn more about our APIs.
-* Launch the Github hosted version of this sample to interact with it by going to the following link: <a href="https://start.openfin.co/?manifest=https%3A%2F%2Fbuilt-on-openfin.github.io%2Fworkspace-starter%2Fmain%2Fintegrate-with-salesforce%2Fmanifest.fin.json" target="_blank">Github Workspace Starter Integrate With Salesforce</a>
 
 ---
 

--- a/how-to/integrate-with-salesforce/public/manifest.fin.json
+++ b/how-to/integrate-with-salesforce/public/manifest.fin.json
@@ -37,7 +37,7 @@
     "company": "OpenFin",
     "description": "An way of showing examples of what OpenFin can do.",
     "icon": "http://localhost:8080/favicon.ico",
-    "name": "Integrate With Salesforce - Latest",
+    "name": "Integrate With Salesforce - v5",
     "target": ["desktop", "start-menu"]
   },
   "customSettings": {


### PR DESCRIPTION
The example requires a custom salesforce org and consumer key so needs to be setup locally to be run.