### PR TITLE
Fix import of fin object

### DIFF
--- a/how-to/integrate-with-sso/client/src/auth.ts
+++ b/how-to/integrate-with-sso/client/src/auth.ts
@@ -1,3 +1,4 @@
+import { fin } from "@openfin/core";
 import * as auth0 from "auth0-js";
 import { AuthSettings } from "./shapes";
 
@@ -266,7 +267,7 @@ function pollTimerStart(isAuthenticated: boolean) {
       } else {
         informationCallback("Access token still valid");
       }
-      }, authSettings.verifyPollMs);
+    }, authSettings.verifyPollMs);
   }
 }
 


### PR DESCRIPTION
`fin` object was being picked up from global packages when in mono repo mode, but could not be found with individual package installs.