### PR TITLE
Created a toggle class web component to easily switch style

### DIFF
--- a/how-to/common/public/components/fin-toggle-class.js
+++ b/how-to/common/public/components/fin-toggle-class.js
@@ -1,10 +1,6 @@
 customElements.define(
   "fin-toggle-class",
-  class ToggleClass extends HTMLElement {
-    constructor() {
-      super();
-    }
-
+  class ToggleClass extends HTMLButtonElement {
     /**
      * Runs each time the element is appended to or moved in the DOM
      */
@@ -83,7 +79,10 @@ customElements.define(
 
         this.innerHTML = result.image;
         this.title = "Click to toggle style";
-        this.style.cursor = "pointer";
+        this.style.height = "40px";
+		this.style.width = "40px";
+		this.style.padding = "0px";
+		this.style.textAlign = "center";
       }
     }
 
@@ -120,5 +119,6 @@ customElements.define(
     onclick() {
       this.applySettings(true);
     }
-  }
+  },
+ {extends: 'button'}
 );

--- a/how-to/common/public/components/fin-toggle-class.js
+++ b/how-to/common/public/components/fin-toggle-class.js
@@ -1,0 +1,124 @@
+customElements.define(
+  "fin-toggle-class",
+  class ToggleClass extends HTMLElement {
+    constructor() {
+      super();
+    }
+
+    /**
+     * Runs each time the element is appended to or moved in the DOM
+     */
+    connectedCallback() {
+      this.sync();
+      this.applySettings(false);
+      this.addEventListener("click", this.onclick);
+    }
+
+    /**
+     * Runs when the element is removed from the DOM
+     */
+    disconnectedCallback() {
+      this.removeEventListener("click", this.onclick);
+    }
+
+    sync() {
+      if (window.fin !== undefined) {
+        this.key = "fin-toggle-class-" + fin.me.identity.uuid;
+
+        const sync = this.getAttribute("sync") || "true";
+        if (sync.toLowerCase() !== "false") {
+          const key = this.key;
+          window.addEventListener("storage", (event) => {
+            if (event.key === key) {
+              this.applySettings(false);
+            }
+          });
+        } else {
+          this.key += "-" + fin.me.identity.name;
+        }
+      }
+    }
+
+    applySettings(toggle) {
+      if (window.fin !== undefined) {
+        const firstClass = this.getAttribute("first-class") || "theme-dark";
+        const secondClass = this.getAttribute("second-class") || "theme-light";
+        const height = this.getAttribute("height") || "24px";
+        const width = this.getAttribute("width") || "24px";
+        const firstImage = this.getAttribute("first-image");
+        const secondImage = this.getAttribute("second-image");
+        const target = this.getAttribute("target") || "body";
+        const key = this.key;
+
+        const defaultFirstImage = `<svg stroke="white" fill="white" style="width:${width};height:${height}" stroke-width="0" viewBox="0 0 24 24" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0z"></path><path d="M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zM2 13h2c.55 0 1-.45 1-1s-.45-1-1-1H2c-.55 0-1 .45-1 1s.45 1 1 1zm18 0h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1zM11 2v2c0 .55.45 1 1 1s1-.45 1-1V2c0-.55-.45-1-1-1s-1 .45-1 1zm0 18v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1s-1 .45-1 1zM5.99 4.58a.996.996 0 00-1.41 0 .996.996 0 000 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41L5.99 4.58zm12.37 12.37a.996.996 0 00-1.41 0 .996.996 0 000 1.41l1.06 1.06c.39.39 1.03.39 1.41 0a.996.996 0 000-1.41l-1.06-1.06zm1.06-10.96a.996.996 0 000-1.41.996.996 0 00-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06zM7.05 18.36a.996.996 0 000-1.41.996.996 0 00-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06z"></path></svg>`;
+        const defaultSecondImage = `<svg stroke="currentColor" style="width:${width};height:${height}" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z"></path><path d="M14 2c1.82 0 3.53.5 5 1.35-2.99 1.73-5 4.95-5 8.65s2.01 6.92 5 8.65A9.973 9.973 0 0114 22C8.48 22 4 17.52 4 12S8.48 2 14 2z"></path></svg>`;
+
+        const getTargetElement = document.querySelector(target);
+        let classToApply = localStorage.getItem(key);
+        const resolvedFirstImage =
+          firstImage !== null
+            ? `<img src="${firstImage}" height="${height}" width="${width}>`
+            : defaultFirstImage;
+        const resolvedSecondImage =
+          secondImage !== null
+            ? `<img src="${secondImage}" height="${height}" width="${width}>`
+            : defaultSecondImage;
+
+        const result = this.getToggledValue(
+          toggle,
+          classToApply,
+          firstClass,
+          secondClass,
+          resolvedFirstImage,
+          resolvedSecondImage
+        );
+
+        if (getTargetElement !== undefined && getTargetElement !== null) {
+          if (!getTargetElement.classList.contains(result.classToAdd)) {
+            getTargetElement.classList.add(result.classToAdd);
+            getTargetElement.classList.remove(result.classToRemove);
+          }
+          localStorage.setItem(key, result.classToAdd);
+        }
+
+        this.innerHTML = result.image;
+        this.title = "Click to toggle style";
+        this.style.cursor = "pointer";
+      }
+    }
+
+    getToggledValue(
+      toggle,
+      currentClass,
+      firstClass,
+      secondClass,
+      firstImage,
+      secondImage
+    ) {
+      let result = {
+        classToAdd: firstClass,
+        classToRemove: secondClass,
+        image: firstImage,
+      };
+
+      if (toggle === true) {
+        if (currentClass === firstClass) {
+          result.classToAdd = secondClass;
+          result.classToRemove = firstClass;
+          result.image = secondImage;
+        }
+      } else {
+        result.classToAdd = currentClass;
+        result.classToRemove =
+          currentClass === firstClass ? secondClass : firstClass;
+        result.image = currentClass === firstClass ? firstImage : secondImage;
+      }
+
+      return result;
+    }
+
+    onclick() {
+      this.applySettings(true);
+    }
+  }
+);

--- a/how-to/common/public/components/fin-toggle-class.md
+++ b/how-to/common/public/components/fin-toggle-class.md
@@ -1,0 +1,22 @@
+# <fin-toggle-class> - A web component to toggle between two css classes via an image
+
+This is a very basic webcomponent that lets you specify the following attributes:
+
+* first-class - the name of the first class you want to toggle between (first class is used as the default) (default is theme-dark)
+* second-class - the name of the second class you want to toggle between (default is theme-light)
+* first-image - the path to an image you wish to show when the first class is applied (if no path is provided then an embedded svg of a sun is shown)
+* second-image - the path to an image you wish to show when the second class is applied (if no path is provided then an embedded svg of a moon is shown)
+* height - the default height applied against the image (default is 32px)
+* width - the default width applied against the image (default is 32px)
+* target - the element you wish to apply the css class to (default is the body element)
+* sync - whether this view (where the webcomponent is placed) should react to changes to other windows which are also using this webcomponet (default is true so when one window is changed they all change. Set sync="false" if you want to isolate one from the others).
+
+The web component saves the selection so that it is applied when any page using the component is launched or reloaded. It uses the uuid of the application as part of the key to store the selection unless sync="false" then it uses the uuid of the application and the name of the page it is on (in order to isolate itself but still remember the user's selection).
+
+## Example usage:
+
+```javascript
+        <script src="../../../components/fin-toggle-class.js" defer></script>
+
+        <fin-toggle-class></fin-toggle-class>
+```

--- a/how-to/common/public/components/fin-toggle-class.md
+++ b/how-to/common/public/components/fin-toggle-class.md
@@ -1,4 +1,4 @@
-# <fin-toggle-class> - A web component to toggle between two css classes via an image
+# <button is="fin-toggle-class"></button> - A web component to toggle between two css classes via a button with an inline image
 
 This is a very basic webcomponent that lets you specify the following attributes:
 
@@ -13,10 +13,12 @@ This is a very basic webcomponent that lets you specify the following attributes
 
 The web component saves the selection so that it is applied when any page using the component is launched or reloaded. It uses the uuid of the application as part of the key to store the selection unless sync="false" then it uses the uuid of the application and the name of the page it is on (in order to isolate itself but still remember the user's selection).
 
+The type is a button to aid in accessibility.
+
 ## Example usage:
 
 ```javascript
         <script src="../../../components/fin-toggle-class.js" defer></script>
 
-        <fin-toggle-class></fin-toggle-class>
+        <button is="fin-toggle-class"></button>
 ```

--- a/how-to/common/public/views/fdc3/context/fdc3-broadcast-view.html
+++ b/how-to/common/public/views/fdc3/context/fdc3-broadcast-view.html
@@ -9,6 +9,7 @@
         <title>Broadcast View - FDC3</title>
         <script type="module" src="./fdc3-broadcast-view.js"></script>
         <link rel="stylesheet" href="../../../style/app.css" />
+        <script src="../../../components/fin-toggle-class.js" defer></script>
 </head>
 
 <body class="col fill gap20">
@@ -18,6 +19,7 @@
       <h1 class="tag">Broadcast and Listen To Context</h1>
     </div>
     <div class="row middle gap20">
+      <fin-toggle-class></fin-toggle-class>
       <image src="../../../images/icon-blue.png"
              alt="OpenFin"
              height="40px"></image>

--- a/how-to/common/public/views/fdc3/context/fdc3-broadcast-view.html
+++ b/how-to/common/public/views/fdc3/context/fdc3-broadcast-view.html
@@ -18,8 +18,8 @@
       <h1>FDC3 Broadcast</h1>
       <h1 class="tag">Broadcast and Listen To Context</h1>
     </div>
-    <div class="row middle gap20">
-      <fin-toggle-class></fin-toggle-class>
+    <div class="row middle gap10">
+      <button is="fin-toggle-class"></button>
       <image src="../../../images/icon-blue.png"
              alt="OpenFin"
              height="40px"></image>

--- a/how-to/common/public/views/fdc3/intent/fdc3-intent-view.html
+++ b/how-to/common/public/views/fdc3/intent/fdc3-intent-view.html
@@ -8,6 +8,7 @@
         content="width=device-width, initial-scale=1" />
         <title>Intent View - FDC3</title>
         <script type="module" src="./fdc3-intent-view.js"></script>
+        <script src="../../../components/fin-toggle-class.js" defer></script>
         <link rel="stylesheet" href="../../../style/app.css" />
 </head>
 
@@ -18,6 +19,7 @@
       <h1 class="tag">Raise and listen to Intents</h1>
     </div>
     <div class="row middle gap20">
+      <fin-toggle-class></fin-toggle-class>
       <image src="../../../images/icon-blue.png"
              alt="OpenFin"
              height="40px"></image>

--- a/how-to/common/public/views/fdc3/intent/fdc3-intent-view.html
+++ b/how-to/common/public/views/fdc3/intent/fdc3-intent-view.html
@@ -18,8 +18,8 @@
       <h1>FDC3 Intents</h1>
       <h1 class="tag">Raise and listen to Intents</h1>
     </div>
-    <div class="row middle gap20">
-      <fin-toggle-class></fin-toggle-class>
+    <div class="row middle gap10">
+      <button is="fin-toggle-class"></button>
       <image src="../../../images/icon-blue.png"
              alt="OpenFin"
              height="40px"></image>

--- a/how-to/common/public/views/interop/context/interop-broadcast-view.html
+++ b/how-to/common/public/views/interop/context/interop-broadcast-view.html
@@ -18,8 +18,8 @@
       <h1>Interop SetContext</h1>
       <h1 class="tag">Set and Listen To Context</h1>
     </div>
-    <div class="row middle gap20">
-      <fin-toggle-class></fin-toggle-class>
+    <div class="row middle gap10">
+      <button is="fin-toggle-class"></button>
       <image src="../../../images/icon-blue.png"
              alt="OpenFin"
              height="40px"></image>

--- a/how-to/common/public/views/interop/context/interop-broadcast-view.html
+++ b/how-to/common/public/views/interop/context/interop-broadcast-view.html
@@ -8,6 +8,7 @@
         content="width=device-width, initial-scale=1" />
         <title>SetContext View - Interop</title>
         <script type="module" src="./interop-broadcast-view.js"></script>
+        <script src="../../../components/fin-toggle-class.js" defer></script>
         <link rel="stylesheet" href="../../../style/app.css" />
 </head>
 
@@ -18,6 +19,7 @@
       <h1 class="tag">Set and Listen To Context</h1>
     </div>
     <div class="row middle gap20">
+      <fin-toggle-class></fin-toggle-class>
       <image src="../../../images/icon-blue.png"
              alt="OpenFin"
              height="40px"></image>

--- a/how-to/common/public/views/interop/intent/interop-intent-view.html
+++ b/how-to/common/public/views/interop/intent/interop-intent-view.html
@@ -8,6 +8,7 @@
         content="width=device-width, initial-scale=1" />
         <title>Intent View - Interop</title>
         <script type="module" src="./interop-intent-view.js"></script>
+        <script src="../../../components/fin-toggle-class.js" defer></script>
         <link rel="stylesheet" href="../../../style/app.css" />
 </head>
 
@@ -18,6 +19,7 @@
       <h1 class="tag">Fire and listen to Intents</h1>
     </div>
     <div class="row middle gap20">
+      <fin-toggle-class></fin-toggle-class>
       <image src="../../../images/icon-blue.png"
              alt="OpenFin"
              height="40px"></image>

--- a/how-to/common/public/views/interop/intent/interop-intent-view.html
+++ b/how-to/common/public/views/interop/intent/interop-intent-view.html
@@ -18,8 +18,8 @@
       <h1>Interop Intents</h1>
       <h1 class="tag">Fire and listen to Intents</h1>
     </div>
-    <div class="row middle gap20">
-      <fin-toggle-class></fin-toggle-class>
+    <div class="row middle gap10">
+      <button is="fin-toggle-class"></button>
       <image src="../../../images/icon-blue.png"
              alt="OpenFin"
              height="40px"></image>


### PR DESCRIPTION
If someone is using a dark or light theme the web component now switches class and listens to storage events so it updates existing views if one of them changes.

This is a very basic webcomponent that lets you specify the following attributes:

* first-class - the name of the first class you want to toggle between (first class is used as the default) (default is theme-dark)
* second-class - the name of the second class you want to toggle between (default is theme-light)
* first-image - the path to an image you wish to show when the first class is applied (if no path is provided then an embedded svg of a sun is shown)
* second-image - the path to an image you wish to show when the second class is applied (if no path is provided then an embedded svg of a moon is shown)
* height - the default height applied against the image (default is 32px)
* width - the default width applied against the image (default is 32px)
* target - the element you wish to apply the css class to (default is the body element)
* sync - whether this view (where the webcomponent is placed) should react to changes to other windows which are also using this webcomponet (default is true so when one window is changed they all change. Set sync="false" if you want to isolate one from the others).

The web component saves the selection so that it is applied when any page using the component is launched or reloaded. It uses the uuid of the application as part of the key to store the selection unless sync="false" then it uses the uuid of the application and the name of the page it is on (in order to isolate itself but still remember the user's selection).

Applied to the context and intent related views to allow a user to pick a colour scheme that makes it easier for them to read.