### PR TITLE
Add additional manifestType examples

### DIFF
--- a/how-to/common/client/src/windows/hidden-window/hidden.ts
+++ b/how-to/common/client/src/windows/hidden-window/hidden.ts
@@ -1,0 +1,67 @@
+import { fin } from "@openfin/core";
+import {
+	create,
+	IndicatorColor,
+	NotificationOptions,
+	addEventListener as addNotificationEventListener
+} from "@openfin/workspace/notifications";
+
+async function notifyOfLoad() {
+	const notification: NotificationOptions = {
+		body: "The hidden window has been launched.",
+		buttons: [
+			{
+				title: "Close Hidden Window",
+				type: "button",
+				cta: false,
+				onClick: {
+					task: "Close"
+				}
+			},
+			{
+				title: "Show Hidden Window",
+				type: "button",
+				cta: true,
+				onClick: {
+					task: "Show"
+				}
+			}
+		],
+		priority: 1,
+		indicator: {
+			color: IndicatorColor.GREEN,
+			text: "Hidden Window Loaded"
+		},
+		category: "hidden",
+		title: "Hidden Window Loaded",
+		template: "markdown"
+	};
+	await create(notification);
+}
+
+async function init() {
+	addNotificationEventListener("notification-action", async (event) => {
+		const action = event?.result?.task;
+
+		switch (action) {
+			case "Close": {
+				const me = fin.Window.wrapSync(fin.me.identity);
+				await me.close(true);
+				break;
+			}
+			default: {
+				console.log("Action triggered:", action);
+				await fin.me.show(true);
+				break;
+			}
+		}
+	});
+
+	await notifyOfLoad();
+}
+
+window.addEventListener("DOMContentLoaded", async () => {
+	console.log("Script loaded");
+
+	await init();
+});

--- a/how-to/common/client/webpack.config.js
+++ b/how-to/common/client/webpack.config.js
@@ -1,22 +1,31 @@
 const path = require('path');
 
-module.exports = {
-	entry: './client/src/index.ts',
-	devtool: 'inline-source-map',
-	module: {
-		rules: [
-			{
-				test: /\.tsx?$/,
-				use: 'ts-loader',
-				exclude: /node_modules/
-			}
-		]
-	},
-	resolve: {
-		extensions: ['.tsx', '.ts', '.js']
-	},
-	output: {
-		filename: 'common.bundle.js',
-		path: path.resolve(__dirname, '..', 'public', 'js')
+module.exports = [
+	{
+		entry: './client/src/windows/hidden-window/hidden.ts',
+		devtool: 'inline-source-map',
+		module: {
+			rules: [
+				{
+					test: /\.tsx?$/,
+					use: 'ts-loader',
+					exclude: /node_modules/
+				}
+			]
+		},
+		resolve: {
+			extensions: ['.tsx', '.ts', '.js']
+		},
+		externals: { fin: 'fin' },
+		output: {
+			filename: 'common.windows.hidden.bundle.js',
+			library: {
+				type: 'module'
+			},
+			path: path.resolve(__dirname, '..', 'public', 'js')
+		},
+		experiments: {
+			outputModule: true
+		}
 	}
-};
+];

--- a/how-to/common/package.json
+++ b/how-to/common/package.json
@@ -17,6 +17,7 @@
 	"author": "",
 	"license": "SEE LICENSE IN LICENSE.MD",
 	"dependencies": {
+		"@openfin/core": "^25.68.26",
 		"@openfin/workspace": "8.1.7",
 		"@openfin/workspace-platform": "8.1.7"
 	},

--- a/how-to/common/public/apps.json
+++ b/how-to/common/public/apps.json
@@ -722,10 +722,10 @@
 		"tags": ["page", "openfin", "tools"]
 	},
 	{
-		"appId": "openfin-versions",
-		"name": "openfin-versions",
-		"title": "OpenFin Versions",
-		"description": "Launch the OpenFin Versions page to see the different versions of our rvm, container, workspace, adapter and intergration offerings.",
+		"appId": "openfin-versions-workspace",
+		"name": "openfin-versions-workspace",
+		"title": "OpenFin Versions - Workspace",
+		"description": "Launch the OpenFin Workspace Versions page. This launches the url as a view to demonstrate the capability. This is an example of a inline-view entry in the app catalog.",
 		"manifest": {
 			"url": "https://developer.openfin.co/versions/?product=Runtime#/?product=Workspace",
 			"name": "openfin-versions"
@@ -742,6 +742,46 @@
 		"intents": [],
 		"images": [],
 		"tags": ["versions", "view"]
+	},
+	{
+		"appId": "openfin-versions-runtime",
+		"name": "openfin-versions-runtime",
+		"title": "OpenFin Versions - Runtime",
+		"description": "Launch the OpenFin Runtime Versions page. This launches in a classic window to demonstrate the capability. This is a example of an inline-window entry in the app catalog.",
+		"manifest": {
+			"url": "https://developer.openfin.co/versions/?product=Runtime"
+		},
+		"manifestType": "inline-window",
+		"icons": [
+			{
+				"src": "http://localhost:8080/common/images/icon-blue.png"
+			}
+		],
+		"contactEmail": "contact@example.com",
+		"supportEmail": "support@example.com",
+		"publisher": "OpenFin",
+		"intents": [],
+		"images": [],
+		"tags": ["versions", "window"]
+	},
+	{
+		"appId": "openfin-versions-integrations",
+		"name": "openfin-versions-integrations",
+		"title": "OpenFin Versions - Integrations",
+		"description": "Launch the OpenFin Integrations Versions page. This launches the url into the desktop browser to demonstrate the capability. This is an example of a desktop-browser entry in the app catalog.",
+		"manifest": "https://developer.openfin.co/versions/?product=Runtime#/?product=Integrations",
+		"manifestType": "desktop-browser",
+		"icons": [
+			{
+				"src": "http://localhost:8080/common/images/icon-blue.png"
+			}
+		],
+		"contactEmail": "contact@example.com",
+		"supportEmail": "support@example.com",
+		"publisher": "OpenFin",
+		"intents": [],
+		"images": [],
+		"tags": ["versions", "desktop-browser"]
 	},
 	{
 		"appId": "preload-tradingview-view",
@@ -998,5 +1038,24 @@
 			}
 		],
 		"tags": ["page", "openfin", "manager", "fcd3"]
+	},
+	{
+		"appId": "hidden-window-example",
+		"name": "hidden-window-example",
+		"title": "Hidden/Headless Window Example",
+		"manifestType": "window",
+		"description": "An example of launching a window that will not be captured as part of a saved workspace and will run headless in the background. This window generates a notification to show that it can be a window with a specific purpose (listening for notifications to create). The notification lets you show or close the hidden window. Only one instance can be running at a time. This window could be launched as part of your bootstrapping logic or in reaction to a particular event. It is listed in home as a way of launching the example.",
+		"manifest": "http://localhost:8080/common/windows/hidden-window/hidden.json",
+		"icons": [
+			{
+				"src": "http://localhost:8080/common/images/icon-blue.png"
+			}
+		],
+		"contactEmail": "contact@example.com",
+		"supportEmail": "support@example.com",
+		"publisher": "OpenFin",
+		"intents": [],
+		"images": [],
+		"tags": ["window", "headless"]
 	}
 ]

--- a/how-to/common/public/windows/hidden-window/hidden.html
+++ b/how-to/common/public/windows/hidden-window/hidden.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<meta name="description" content="" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Headless window example</title>
+		<link rel="stylesheet" href="../../style/app.css" />
+		<script type="module" src="../../js/common.windows.hidden.bundle.js" defer></script>
+	</head>
+
+	<body class="col fill gap20">
+		<header class="row spread middle">
+			<div class="col">
+				<h1>Hidden Window Example</h1>
+			</div>
+			<div class="row middle gap10">
+				<image src="../../images/icon-blue.png" alt="OpenFin" height="40px"></image>
+			</div>
+		</header>
+		<main class="row fill gap20">
+			<h1 class="tag">
+				An example launched from a snapshot to demonstrate a background window pushing a notification.
+			</h1>
+		</main>
+		<footer></footer>
+	</body>
+</html>

--- a/how-to/common/public/windows/hidden-window/hidden.json
+++ b/how-to/common/public/windows/hidden-window/hidden.json
@@ -1,0 +1,12 @@
+{
+	"autoShow": false,
+	"backgroundThrottling": false,
+	"includeInSnapshots": false,
+	"name": "hidden-window-example",
+	"showTaskbarIcon": false,
+	"fdc3InteropApi": "1.2",
+	"height": 500,
+	"width": 800,
+	"url": "http://localhost:8080/common/windows/hidden-window/hidden.html",
+	"processAffinity": "custom-affinity"
+}

--- a/how-to/customize-workspace/client/src/home.ts
+++ b/how-to/customize-workspace/client/src/home.ts
@@ -75,6 +75,14 @@ function mapAppEntriesToSearchEntries(apps: App[]): HomeSearchResult[] {
 				entry.label = "View";
 				entry.actions = [action];
 			}
+			if (apps[i].manifestType === "window" || apps[i].manifestType === "inline-window") {
+				entry.label = "Window";
+				entry.actions = [action];
+			}
+			if (apps[i].manifestType === "desktop-browser") {
+				entry.label = "Desktop Browser Url";
+				entry.actions = [action];
+			}
 			if (apps[i].manifestType === "snapshot") {
 				entry.label = "Snapshot";
 				action.name = "Launch Snapshot";

--- a/how-to/customize-workspace/public/manifest.fin.json
+++ b/how-to/customize-workspace/public/manifest.fin.json
@@ -76,7 +76,16 @@
 			"includeCredentialOnSourceRequest": "include",
 			"cacheDurationInMinutes": 1,
 			"appAssetTag": "appasset",
-			"manifestTypes": ["view", "snapshot", "manifest", "external", "inline-view"]
+			"manifestTypes": [
+				"view",
+				"snapshot",
+				"manifest",
+				"external",
+				"inline-view",
+				"window",
+				"inline-window",
+				"desktop-browser"
+			]
 		},
 		"endpointProvider": {
 			"endpoints": [

--- a/how-to/customize-workspace/public/second.manifest.fin.json
+++ b/how-to/customize-workspace/public/second.manifest.fin.json
@@ -69,7 +69,16 @@
 			"includeCredentialOnSourceRequest": "include",
 			"cacheDurationInMinutes": 1,
 			"appAssetTag": "appasset",
-			"manifestTypes": ["view", "snapshot", "manifest", "external", "inline-view"]
+			"manifestTypes": [
+				"view",
+				"snapshot",
+				"manifest",
+				"external",
+				"inline-view",
+				"window",
+				"inline-window",
+				"desktop-browser"
+			]
 		},
 		"endpointProvider": {
 			"endpoints": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
 			"version": "8.0.0",
 			"license": "SEE LICENSE IN LICENSE.MD",
 			"dependencies": {
+				"@openfin/core": "^25.68.26",
 				"@openfin/workspace": "8.1.7",
 				"@openfin/workspace-platform": "8.1.7"
 			},
@@ -9305,6 +9306,7 @@
 		"openfin-workspace--common": {
 			"version": "file:how-to/common",
 			"requires": {
+				"@openfin/core": "^25.68.26",
 				"@openfin/workspace": "8.1.7",
 				"@openfin/workspace-platform": "8.1.7",
 				"@types/express": "^4.17.11",


### PR DESCRIPTION
Add additional examples to show:

* How you can launch a headless window to do background processing
* How you can launch a classic window from home (inline definition or via a manifest json file)
* How you can launch the desktop browser if needed (maybe a site that is only compatible with an older desktop browser).

You need to run npm run setup to update and build the common folder (which has the hidden window code).

The only sample that demonstrates this is the customize-workspace sample as it is giving an example of launching custom manifest types. New manifest types:

* window
* inline-window
* desktop-browser

The manifests in customize-workspace have been updated to opt into displaying these manifest types.