### PR TITLE
Added customstorage for workspace and page saving.

### DIFF
--- a/how-to/customize-workspace/client/src/browser.ts
+++ b/how-to/customize-workspace/client/src/browser.ts
@@ -16,18 +16,18 @@ import {
 import { getDefaultToolbarButtons } from "./buttons";
 import { getGlobalMenu, getPageMenu, getViewMenu } from "./menu";
 import { PlatformStorage } from "./platform-storage";
+import { DEFAULT_STORAGE_KEYS, IPlatformStorage } from "./platform-storage-shapes";
 import { getSettings } from "./settings";
-
-const pageBoundsStorage = new PlatformStorage("page-bounds", "Page Bounds");
 
 async function savePageBounds(pageId: string) {
 	const bounds = await getPageBounds(pageId);
-
-	await pageBoundsStorage.saveToStorage<OpenFin.Bounds>(pageId, bounds);
+	const boundsStorage = await PlatformStorage.getStorage(DEFAULT_STORAGE_KEYS.PageBounds);
+	await boundsStorage.saveToStorage<OpenFin.Bounds>(pageId, bounds);
 }
 
 async function deletePageBounds(pageId: string) {
-	await pageBoundsStorage.clearStorageEntry(pageId);
+	const boundsStorage = await PlatformStorage.getStorage(DEFAULT_STORAGE_KEYS.PageBounds);
+	await boundsStorage.deleteFromStorage(pageId);
 }
 
 export async function getPage(pageId: string) {
@@ -50,7 +50,8 @@ export async function getPageBounds(pageId: string, fromStorage = false): Promis
 	let bounds: OpenFin.Bounds = null;
 
 	if (fromStorage) {
-		bounds = await pageBoundsStorage.getFromStorage<OpenFin.Bounds>(pageId);
+		const boundsStorage = await PlatformStorage.getStorage(DEFAULT_STORAGE_KEYS.PageBounds);
+		bounds = await boundsStorage.getFromStorage<OpenFin.Bounds>(pageId);
 	} else {
 		const platform = getCurrentSync();
 		const pages = await platform.Browser.getAllAttachedPages();
@@ -72,7 +73,12 @@ export async function getPageBounds(pageId: string, fromStorage = false): Promis
 }
 
 export async function launchPage(page: Page, bounds?: OpenFin.Bounds) {
-	const customBounds = bounds || (await pageBoundsStorage.getFromStorage<OpenFin.Bounds>(page.pageId));
+	let customBounds = bounds;
+	if (customBounds === undefined) {
+		const boundsStorage = await PlatformStorage.getStorage(DEFAULT_STORAGE_KEYS.PageBounds);
+		customBounds = await boundsStorage.getFromStorage<OpenFin.Bounds>(page.pageId);
+	}
+
 	const platform = getCurrentSync();
 	const newWindow: BrowserCreateWindowRequest = {
 		workspacePlatform: {
@@ -138,6 +144,10 @@ export async function getDefaultWindowOptions() {
 
 export const overrideCallback: BrowserOverrideCallback = async (WorkspacePlatformProvider) => {
 	class Override extends WorkspacePlatformProvider {
+		private pageStorage: IPlatformStorage;
+
+		private workspaceStorage: IPlatformStorage;
+
 		public async getSnapshot(...args: [undefined, OpenFin.ClientIdentity]) {
 			const snapshot = await super.getSnapshot(...args);
 			return snapshot;
@@ -150,65 +160,157 @@ export const overrideCallback: BrowserOverrideCallback = async (WorkspacePlatfor
 		public async getSavedWorkspaces(query?: string): Promise<Workspace[]> {
 			// you can add your own custom implementation here if you are storing your workspaces
 			// in non-default location (e.g. on the server instead of locally)
+			if (PlatformStorage.isRegistered(DEFAULT_STORAGE_KEYS.Workspace)) {
+				if (this.workspaceStorage === undefined) {
+					this.workspaceStorage = await PlatformStorage.getStorage(DEFAULT_STORAGE_KEYS.Workspace);
+				}
+				console.log(`Returning saved workspaces from custom storage for query: ${query}.`);
+				return this.workspaceStorage.getAllStoredEntries<Workspace>(query);
+			}
+			console.log(`Returning saved workspaces from default storage for query: ${query}.`);
 			return super.getSavedWorkspaces(query);
 		}
 
 		public async getSavedWorkspace(id: string): Promise<Workspace> {
 			// you can add your own custom implementation here if you are storing your workspaces
 			// in non-default location (e.g. on the server instead of locally)
+			if (PlatformStorage.isRegistered(DEFAULT_STORAGE_KEYS.Workspace)) {
+				if (this.workspaceStorage === undefined) {
+					this.workspaceStorage = await PlatformStorage.getStorage(DEFAULT_STORAGE_KEYS.Workspace);
+				}
+				console.log(`Returning saved workspace from custom storage for workspace id: ${id}.`);
+				return this.workspaceStorage.getFromStorage<Workspace>(id);
+			}
+			console.log(`Returning saved workspace from default storage for workspace id: ${id}.`);
 			return super.getSavedWorkspace(id);
 		}
 
 		public async createSavedWorkspace(req: CreateSavedWorkspaceRequest): Promise<void> {
 			// you can add your own custom implementation here if you are storing your workspaces
 			// in non-default location (e.g. on the server instead of locally)
+			if (PlatformStorage.isRegistered(DEFAULT_STORAGE_KEYS.Workspace)) {
+				if (this.workspaceStorage === undefined) {
+					this.workspaceStorage = await PlatformStorage.getStorage(DEFAULT_STORAGE_KEYS.Workspace);
+				}
+				console.log(`Saving workspace to custom storage for workspace id: ${req.workspace.workspaceId}.`);
+				return this.workspaceStorage.saveToStorage<Workspace>(req.workspace.workspaceId, req.workspace);
+			}
+			console.log(`Saving workspace to default storage for workspace id: ${req.workspace.workspaceId}.`);
 			return super.createSavedWorkspace(req);
 		}
 
 		public async updateSavedWorkspace(req: UpdateSavedWorkspaceRequest): Promise<void> {
 			// you can add your own custom implementation here if you are storing your workspaces
 			// in non-default location (e.g. on the server instead of locally)
+			if (PlatformStorage.isRegistered(DEFAULT_STORAGE_KEYS.Workspace)) {
+				if (this.workspaceStorage === undefined) {
+					this.workspaceStorage = await PlatformStorage.getStorage(DEFAULT_STORAGE_KEYS.Workspace);
+				}
+				console.log(
+					`Saving updated workspace to custom storage for workspace id: ${req.workspace.workspaceId}.`
+				);
+				return this.workspaceStorage.saveToStorage<Workspace>(req.workspace.workspaceId, req.workspace);
+			}
+			console.log(
+				`Saving updated workspace to default storage for workspace id: ${req.workspace.workspaceId}.`
+			);
 			return super.updateSavedWorkspace(req);
 		}
 
 		public async deleteSavedWorkspace(id: string): Promise<void> {
 			// you can add your own custom implementation here if you are storing your workspaces
 			// in non-default location (e.g. on the server instead of locally)
+			if (PlatformStorage.isRegistered(DEFAULT_STORAGE_KEYS.Workspace)) {
+				if (this.workspaceStorage === undefined) {
+					this.workspaceStorage = await PlatformStorage.getStorage(DEFAULT_STORAGE_KEYS.Workspace);
+				}
+				console.log(`Deleting workspace from custom storage for workspace id: ${id}.`);
+				return this.workspaceStorage.deleteFromStorage(id);
+			}
+			console.log(`Deleting workspace from default storage for workspace id: ${id}.`);
 			return super.deleteSavedWorkspace(id);
 		}
 
 		public async getSavedPages(query?: string): Promise<Page[]> {
 			// you can add your own custom implementation here if you are storing your pages
 			// in non-default location (e.g. on the server instead of locally)
+			if (PlatformStorage.isRegistered(DEFAULT_STORAGE_KEYS.Page)) {
+				if (this.pageStorage === undefined) {
+					this.pageStorage = await PlatformStorage.getStorage(DEFAULT_STORAGE_KEYS.Page);
+				}
+				console.log(`Returning saved pages from custom storage for query: ${query}.`);
+				return this.pageStorage.getAllStoredEntries<Page>(query);
+			}
+			console.log(`Returning saved pages from default storage for query: ${query}.`);
 			return super.getSavedPages(query);
 		}
 
 		public async getSavedPage(id: string): Promise<Page> {
 			// you can add your own custom implementation here if you are storing your pages
 			// in non-default location (e.g. on the server instead of locally)
+			if (PlatformStorage.isRegistered(DEFAULT_STORAGE_KEYS.Page)) {
+				if (this.pageStorage === undefined) {
+					this.pageStorage = await PlatformStorage.getStorage(DEFAULT_STORAGE_KEYS.Page);
+				}
+				console.log(`Returning saved page with id ${id} from custom storage.`);
+				return this.pageStorage.getFromStorage<Page>(id);
+			}
+			console.log(`Returning saved page with id ${id} from default storage.`);
 			return super.getSavedPage(id);
 		}
 
 		public async createSavedPage(req: CreateSavedPageRequest): Promise<void> {
-			// you can add your own custom implementation here if you are storing your pages
-			// in non-default location (e.g. on the server instead of locally)
+			// always save page bounds regardless of storage for pages
 			await savePageBounds(req.page.pageId);
 
-			return super.createSavedPage(req);
+			// you can add your own custom implementation here if you are storing your pages
+			// in non-default location (e.g. on the server instead of locally)
+			if (PlatformStorage.isRegistered(DEFAULT_STORAGE_KEYS.Page)) {
+				if (this.pageStorage === undefined) {
+					this.pageStorage = await PlatformStorage.getStorage(DEFAULT_STORAGE_KEYS.Page);
+				}
+				console.log(`creating saved page and saving to custom storage. PageId: ${req.page.pageId}`);
+				await this.pageStorage.saveToStorage(req.page.pageId, req.page);
+			} else {
+				console.log(`creating saved page and saving to default storage. PageId: ${req.page.pageId}`);
+				await super.createSavedPage(req);
+			}
 		}
 
 		public async updateSavedPage(req: UpdateSavedPageRequest): Promise<void> {
+			// save page bounds even if using default storage for pages.
+			await savePageBounds(req.pageId);
+
 			// you can add your own custom implementation here if you are storing your pages
 			// in non-default location (e.g. on the server instead of locally)
-			await savePageBounds(req.pageId);
-			return super.updateSavedPage(req);
+			if (PlatformStorage.isRegistered(DEFAULT_STORAGE_KEYS.Page)) {
+				if (this.pageStorage === undefined) {
+					this.pageStorage = await PlatformStorage.getStorage(DEFAULT_STORAGE_KEYS.Page);
+				}
+				console.log(`updating saved page and saving to custom storage with page id: ${req.page.pageId}.`);
+				await this.pageStorage.saveToStorage(req.page.pageId, req.page);
+			} else {
+				console.log(`updating saved page and saving to default storage with page id: ${req.page.pageId}.`);
+				await super.updateSavedPage(req);
+			}
 		}
 
 		public async deleteSavedPage(id: string): Promise<void> {
+			// save page bounds even if using default storage for pages.
+			await deletePageBounds(id);
+
 			// you can add your own custom implementation here if you are storing your pages
 			// in non-default location (e.g. on the server instead of locally)
-			await deletePageBounds(id);
-			return super.deleteSavedPage(id);
+			if (PlatformStorage.isRegistered(DEFAULT_STORAGE_KEYS.Page)) {
+				if (this.pageStorage === undefined) {
+					this.pageStorage = await PlatformStorage.getStorage(DEFAULT_STORAGE_KEYS.Page);
+				}
+				console.log(`deleting saved page from custom storage. PageId: ${id}.`);
+				await this.pageStorage.deleteFromStorage(id);
+			} else {
+				console.log(`deleting saved page from default storage. PageId: ${id}.`);
+				await super.deleteSavedPage(id);
+			}
 		}
 
 		public async openGlobalContextMenu(req: OpenGlobalContextMenuPayload, callerIdentity: OpenFin.Identity) {

--- a/how-to/customize-workspace/client/src/platform-local-storage.ts
+++ b/how-to/customize-workspace/client/src/platform-local-storage.ts
@@ -1,0 +1,79 @@
+import { IPlatformStorage } from "./platform-storage-shapes";
+
+export class PlatformLocalStorage implements IPlatformStorage {
+	private readonly storageTypeName: string;
+
+	private readonly storageKey: string;
+
+	constructor(storageId: string, storageType: string) {
+		this.storageTypeName = storageType;
+		this.storageKey = `${fin.me.identity.uuid.toLowerCase().replaceAll(" ", "")}-${storageId}`;
+	}
+
+	public async getFromStorage<T>(id: string): Promise<T> {
+		if (id === undefined) {
+			console.error(`No id was specified for getting a ${this.storageTypeName} entry.`);
+			return null;
+		}
+		const store = this.getCompleteStore<T>();
+		const savedEntry = store[id];
+		if (savedEntry === undefined || savedEntry === null) {
+			console.error(`No ${this.storageTypeName} entry was found for id ${id}.`);
+			return null;
+		}
+		return savedEntry;
+	}
+
+	public async saveToStorage<T>(id: string, entry: T) {
+		if (entry === undefined) {
+			console.error(`You need to provide a id for the ${this.storageTypeName} entry you wish to save.`);
+		} else {
+			const store = this.getCompleteStore<T>();
+
+			store[id] = entry;
+
+			this.setCompleteStore(store);
+		}
+	}
+
+	public async getAllStoredEntries<T>(query?: string): Promise<T[]> {
+		const store = this.getCompleteStore<T>();
+		if (Object.keys(store).length === 0) {
+			console.log(`Storage has no ${this.storageTypeName} entries.`);
+			return [];
+		}
+
+		return Object.values(store);
+	}
+
+	public async deleteFromStorage(id: string) {
+		if (id === undefined) {
+			console.error(`An id to clear the saved ${this.storageTypeName} was not provided.`);
+		} else {
+			const store = this.getCompleteStore();
+			const entry = store[id];
+
+			if (entry !== undefined) {
+				delete store[id];
+				this.setCompleteStore(store);
+			} else {
+				console.error(`You tried to delete a non-existent ${this.storageTypeName} with id ${id}`);
+			}
+		}
+	}
+
+	private getCompleteStore<T>() {
+		const store = localStorage.getItem(this.storageKey);
+		if (store === null) {
+			console.log(`Storage has no ${this.storageTypeName} entries. Creating store.`);
+			this.setCompleteStore({});
+			return {};
+		}
+
+		return JSON.parse(store) as { [key: string]: T };
+	}
+
+	private setCompleteStore<T>(store: { [key: string]: T }) {
+		localStorage.setItem(this.storageKey, JSON.stringify(store));
+	}
+}

--- a/how-to/customize-workspace/client/src/platform-local-storage.ts
+++ b/how-to/customize-workspace/client/src/platform-local-storage.ts
@@ -1,34 +1,34 @@
 import { IPlatformStorage } from "./platform-storage-shapes";
 
-export class PlatformLocalStorage implements IPlatformStorage {
-	private readonly storageTypeName: string;
+export class PlatformLocalStorage<T> implements IPlatformStorage<T> {
+	private readonly _storageTypeName: string;
 
-	private readonly storageKey: string;
+	private readonly _storageKey: string;
 
 	constructor(storageId: string, storageType: string) {
-		this.storageTypeName = storageType;
-		this.storageKey = `${fin.me.identity.uuid.toLowerCase().replaceAll(" ", "")}-${storageId}`;
+		this._storageTypeName = storageType;
+		this._storageKey = `${fin.me.identity.uuid.toLowerCase().replaceAll(" ", "")}-${storageId}`;
 	}
 
-	public async getFromStorage<T>(id: string): Promise<T> {
+	public async get(id: string): Promise<T> {
 		if (id === undefined) {
-			console.error(`No id was specified for getting a ${this.storageTypeName} entry.`);
+			console.error(`No id was specified for getting a ${this._storageTypeName} entry.`);
 			return null;
 		}
-		const store = this.getCompleteStore<T>();
+		const store = this.getCompleteStore();
 		const savedEntry = store[id];
 		if (savedEntry === undefined || savedEntry === null) {
-			console.error(`No ${this.storageTypeName} entry was found for id ${id}.`);
+			console.error(`No ${this._storageTypeName} entry was found for id ${id}.`);
 			return null;
 		}
 		return savedEntry;
 	}
 
-	public async saveToStorage<T>(id: string, entry: T) {
-		if (entry === undefined) {
-			console.error(`You need to provide a id for the ${this.storageTypeName} entry you wish to save.`);
+	public async set(id: string, entry: T): Promise<void> {
+		if (id === undefined) {
+			console.error(`You need to provide a id for the ${this._storageTypeName} entry you wish to save.`);
 		} else {
-			const store = this.getCompleteStore<T>();
+			const store = this.getCompleteStore();
 
 			store[id] = entry;
 
@@ -36,19 +36,19 @@ export class PlatformLocalStorage implements IPlatformStorage {
 		}
 	}
 
-	public async getAllStoredEntries<T>(query?: string): Promise<T[]> {
-		const store = this.getCompleteStore<T>();
+	public async getAll(query?: string): Promise<T[]> {
+		const store = this.getCompleteStore();
 		if (Object.keys(store).length === 0) {
-			console.log(`Storage has no ${this.storageTypeName} entries.`);
+			console.log(`Storage has no ${this._storageTypeName} entries.`);
 			return [];
 		}
 
 		return Object.values(store);
 	}
 
-	public async deleteFromStorage(id: string) {
+	public async remove(id: string): Promise<void> {
 		if (id === undefined) {
-			console.error(`An id to clear the saved ${this.storageTypeName} was not provided.`);
+			console.error(`An id to clear the saved ${this._storageTypeName} was not provided.`);
 		} else {
 			const store = this.getCompleteStore();
 			const entry = store[id];
@@ -57,15 +57,15 @@ export class PlatformLocalStorage implements IPlatformStorage {
 				delete store[id];
 				this.setCompleteStore(store);
 			} else {
-				console.error(`You tried to delete a non-existent ${this.storageTypeName} with id ${id}`);
+				console.error(`You tried to delete a non-existent ${this._storageTypeName} with id ${id}`);
 			}
 		}
 	}
 
-	private getCompleteStore<T>() {
-		const store = localStorage.getItem(this.storageKey);
+	private getCompleteStore() {
+		const store = localStorage.getItem(this._storageKey);
 		if (store === null) {
-			console.log(`Storage has no ${this.storageTypeName} entries. Creating store.`);
+			console.log(`Storage has no ${this._storageTypeName} entries. Creating store.`);
 			this.setCompleteStore({});
 			return {};
 		}
@@ -73,7 +73,7 @@ export class PlatformLocalStorage implements IPlatformStorage {
 		return JSON.parse(store) as { [key: string]: T };
 	}
 
-	private setCompleteStore<T>(store: { [key: string]: T }) {
-		localStorage.setItem(this.storageKey, JSON.stringify(store));
+	private setCompleteStore(store: { [key: string]: T }) {
+		localStorage.setItem(this._storageKey, JSON.stringify(store));
 	}
 }

--- a/how-to/customize-workspace/client/src/platform-storage-shapes.ts
+++ b/how-to/customize-workspace/client/src/platform-storage-shapes.ts
@@ -1,0 +1,34 @@
+export interface IPlatformStorage {
+	/**
+	 * Get items that are stored
+	 * @param id The identity of the stored object
+	 * @returns The stored type or null if nothing was found.
+	 */
+	getFromStorage<T>(id: string): Promise<T>;
+
+	/**
+	 * Save an item against storage
+	 * @param id The identity of the item to store or update
+	 * @returns Nothing.
+	 */
+	saveToStorage<T>(id: string, entry: T): Promise<void>;
+
+	/**
+	 * Get all the saved entries
+	 * @returns All available entries.
+	 */
+	getAllStoredEntries<T>(query?: string): Promise<T[]>;
+
+	/**
+	 * Delete an entry from storage
+	 * @param id The identity of the item to clear
+	 * @returns Nothing.
+	 */
+	deleteFromStorage(id: string): Promise<void>;
+}
+
+export const DEFAULT_STORAGE_KEYS = {
+	Page: "page",
+	PageBounds: "page-bounds",
+	Workspace: "workspace"
+};

--- a/how-to/customize-workspace/client/src/platform-storage-shapes.ts
+++ b/how-to/customize-workspace/client/src/platform-storage-shapes.ts
@@ -1,30 +1,31 @@
-export interface IPlatformStorage {
+export interface IPlatformStorage<T> {
 	/**
 	 * Get items that are stored
 	 * @param id The identity of the stored object
 	 * @returns The stored type or null if nothing was found.
 	 */
-	getFromStorage<T>(id: string): Promise<T>;
+	get(id: string): Promise<T>;
 
 	/**
 	 * Save an item against storage
 	 * @param id The identity of the item to store or update
 	 * @returns Nothing.
 	 */
-	saveToStorage<T>(id: string, entry: T): Promise<void>;
+	set(id: string, entry: T): Promise<void>;
 
 	/**
 	 * Get all the saved entries
+	 * @param query Optional parameter that can be used to filter the result set
 	 * @returns All available entries.
 	 */
-	getAllStoredEntries<T>(query?: string): Promise<T[]>;
+	getAll(query?: string): Promise<T[]>;
 
 	/**
 	 * Delete an entry from storage
 	 * @param id The identity of the item to clear
 	 * @returns Nothing.
 	 */
-	deleteFromStorage(id: string): Promise<void>;
+	remove(id: string): Promise<void>;
 }
 
 export const DEFAULT_STORAGE_KEYS = {

--- a/how-to/customize-workspace/client/src/platform-storage.ts
+++ b/how-to/customize-workspace/client/src/platform-storage.ts
@@ -1,46 +1,52 @@
 import { IPlatformStorage } from "./platform-storage-shapes";
 
 export class PlatformStorage {
-	private static readonly storageImplementations = new Map<string, IPlatformStorage>();
+	private static readonly _storageImplementations = new Map<string, IPlatformStorage<unknown>>();
 
-	private static readonly storageRegister = new Map<
+	private static readonly _storageRegister = new Map<
 		string,
-		(options?: unknown) => Promise<IPlatformStorage>
+		(options?: unknown) => Promise<IPlatformStorage<unknown>>
 	>();
 
-	public static register(name: string, onStorageCreation: (options?: unknown) => Promise<IPlatformStorage>) {
-		if (this.storageRegister.has(name)) {
+	public static register(
+		name: string,
+		onStorageCreation: (options?: unknown) => Promise<IPlatformStorage<unknown>>
+	) {
+		if (this._storageRegister.has(name)) {
 			console.error(`You have tried to register platform storage using a name that already exists`);
 		} else {
-			this.storageRegister.set(name, onStorageCreation);
+			this._storageRegister.set(name, onStorageCreation);
 			console.log(`The storage implementation ${name} has been registered`);
 		}
 	}
 
 	public static isRegistered(name: string): boolean {
-		return this.storageRegister.has(name);
+		return this._storageRegister.has(name);
 	}
 
 	public static deregister(name: string) {
-		if (this.storageRegister.has(name)) {
-			this.storageRegister.delete(name);
+		if (this._storageRegister.has(name)) {
+			this._storageRegister.delete(name);
 			console.log(`Removed storage implementation ${name} from register.`);
 		}
 
-		if (this.storageImplementations.has(name)) {
+		if (this._storageImplementations.has(name)) {
 			console.warn(`The storage implementation ${name} has a registered instance which will not be cleared.`);
 		}
 	}
 
-	public static async getStorage(name: string, initializationOptions?: unknown): Promise<IPlatformStorage> {
-		if (this.storageImplementations.has(name)) {
-			return this.storageImplementations.get(name);
-		} else if (this.storageRegister.has(name)) {
-			const implementation = this.storageRegister.get(name);
+	public static async getStorage<T>(
+		name: string,
+		initializationOptions?: unknown
+	): Promise<IPlatformStorage<T>> {
+		if (this._storageImplementations.has(name)) {
+			return this._storageImplementations.get(name) as IPlatformStorage<T>;
+		} else if (this._storageRegister.has(name)) {
+			const implementation = this._storageRegister.get(name);
 			const instance = await implementation(initializationOptions);
-			this.storageImplementations.set(name, instance);
-			return instance;
+			this._storageImplementations.set(name, instance);
+			return instance as IPlatformStorage<T>;
 		}
-		console.error(`You have specified a storage implementation: ${name}  that has not been registered`);
+		console.error(`You have specified a storage implementation: ${name} that has not been registered`);
 	}
 }

--- a/how-to/customize-workspace/client/src/platform-storage.ts
+++ b/how-to/customize-workspace/client/src/platform-storage.ts
@@ -1,62 +1,46 @@
+import { IPlatformStorage } from "./platform-storage-shapes";
+
 export class PlatformStorage {
-	private readonly storageTypeName: string;
+	private static readonly storageImplementations = new Map<string, IPlatformStorage>();
 
-	private readonly storageKey: string;
+	private static readonly storageRegister = new Map<
+		string,
+		(options?: unknown) => Promise<IPlatformStorage>
+	>();
 
-	constructor(storageId: string, storageType: string) {
-		this.storageTypeName = storageType;
-		this.storageKey = `${fin.me.identity.uuid.toLowerCase().replaceAll(" ", "")}-${storageId}`;
-	}
-
-	public async getFromStorage<T>(id: string): Promise<T> {
-		if (id === undefined) {
-			console.error(`No id was specified for getting a ${this.storageTypeName} entry.`);
-			return null;
-		}
-		const store = await this.getAllStoredEntries<T>();
-		const savedEntry = store[id];
-		if (savedEntry === undefined || savedEntry === null) {
-			console.error(`No ${this.storageTypeName} entry was found for id ${id}.`);
-			return null;
-		}
-		return savedEntry;
-	}
-
-	public async saveToStorage<T>(id: string, entry: T) {
-		if (entry === undefined) {
-			console.error(`You need to provide a id for the ${this.storageTypeName} entry you wish to save.`);
+	public static register(name: string, onStorageCreation: (options?: unknown) => Promise<IPlatformStorage>) {
+		if (this.storageRegister.has(name)) {
+			console.error(`You have tried to register platform storage using a name that already exists`);
 		} else {
-			const store = await this.getAllStoredEntries<T>();
-
-			store[id] = entry;
-
-			localStorage.setItem(this.storageKey, JSON.stringify(store));
+			this.storageRegister.set(name, onStorageCreation);
+			console.log(`The storage implementation ${name} has been registered`);
 		}
 	}
 
-	public async getAllStoredEntries<T>(): Promise<{ [key: string]: T }> {
-		const store = localStorage.getItem(this.storageKey);
-		if (store === null) {
-			console.log(`Storage has no ${this.storageTypeName} entries.`);
-			return {};
-		}
-
-		return JSON.parse(store) as { [key: string]: T };
+	public static isRegistered(name: string): boolean {
+		return this.storageRegister.has(name);
 	}
 
-	public async clearStorageEntry(id: string) {
-		if (id === undefined) {
-			console.error(`An id to clear the saved ${this.storageTypeName} was not provided.`);
-		} else {
-			const store = await this.getAllStoredEntries();
-			const entry = store[id];
-
-			if (entry !== undefined) {
-				delete store[id];
-				localStorage.setItem(this.storageKey, JSON.stringify(store));
-			} else {
-				console.error(`You tried to delete a non-existent ${this.storageTypeName} with id ${id}`);
-			}
+	public static deregister(name: string) {
+		if (this.storageRegister.has(name)) {
+			this.storageRegister.delete(name);
+			console.log(`Removed storage implementation ${name} from register.`);
 		}
+
+		if (this.storageImplementations.has(name)) {
+			console.warn(`The storage implementation ${name} has a registered instance which will not be cleared.`);
+		}
+	}
+
+	public static async getStorage(name: string, initializationOptions?: unknown): Promise<IPlatformStorage> {
+		if (this.storageImplementations.has(name)) {
+			return this.storageImplementations.get(name);
+		} else if (this.storageRegister.has(name)) {
+			const implementation = this.storageRegister.get(name);
+			const instance = await implementation(initializationOptions);
+			this.storageImplementations.set(name, instance);
+			return instance;
+		}
+		console.error(`You have specified a storage implementation: ${name}  that has not been registered`);
 	}
 }

--- a/how-to/customize-workspace/client/src/platform.ts
+++ b/how-to/customize-workspace/client/src/platform.ts
@@ -4,14 +4,39 @@ import Transport from "openfin-adapter/src/transport/transport";
 import { getActions } from "./actions";
 import { getDefaultWindowOptions, overrideCallback } from "./browser";
 import { PlatformInteropBroker } from "./interopbroker";
+import { PlatformLocalStorage } from "./platform-local-storage";
+import { PlatformStorage } from "./platform-storage";
+import { DEFAULT_STORAGE_KEYS } from "./platform-storage-shapes";
 import { getSettings, getThemes } from "./settings";
+
+function registerAvailableStorage() {
+	PlatformStorage.register(
+		DEFAULT_STORAGE_KEYS.PageBounds,
+		async (options) =>
+			new Promise((resolve, reject) =>
+				resolve(new PlatformLocalStorage(DEFAULT_STORAGE_KEYS.PageBounds, "PageBounds"))
+			)
+	);
+	PlatformStorage.register(
+		DEFAULT_STORAGE_KEYS.Page,
+		async (options) =>
+			new Promise((resolve, reject) => resolve(new PlatformLocalStorage(DEFAULT_STORAGE_KEYS.Page, "Page")))
+	);
+	PlatformStorage.register(
+		DEFAULT_STORAGE_KEYS.Workspace,
+		async (options) =>
+			new Promise((resolve, reject) =>
+				resolve(new PlatformLocalStorage(DEFAULT_STORAGE_KEYS.Workspace, "Workspace"))
+			)
+	);
+}
 
 export async function init() {
 	const settings = await getSettings();
 
 	console.log("Initialising platform");
 	const browser: BrowserInitConfig = {};
-
+	registerAvailableStorage();
 	if (settings.browserProvider !== undefined) {
 		browser.defaultWindowOptions = await getDefaultWindowOptions();
 

--- a/how-to/customize-workspace/client/src/platform.ts
+++ b/how-to/customize-workspace/client/src/platform.ts
@@ -12,22 +12,15 @@ import { getSettings, getThemes } from "./settings";
 function registerAvailableStorage() {
 	PlatformStorage.register(
 		DEFAULT_STORAGE_KEYS.PageBounds,
-		async (options) =>
-			new Promise((resolve, reject) =>
-				resolve(new PlatformLocalStorage(DEFAULT_STORAGE_KEYS.PageBounds, "PageBounds"))
-			)
+		async (options) => new PlatformLocalStorage(DEFAULT_STORAGE_KEYS.PageBounds, "PageBounds")
 	);
 	PlatformStorage.register(
 		DEFAULT_STORAGE_KEYS.Page,
-		async (options) =>
-			new Promise((resolve, reject) => resolve(new PlatformLocalStorage(DEFAULT_STORAGE_KEYS.Page, "Page")))
+		async (options) => new PlatformLocalStorage(DEFAULT_STORAGE_KEYS.Page, "Page")
 	);
 	PlatformStorage.register(
 		DEFAULT_STORAGE_KEYS.Workspace,
-		async (options) =>
-			new Promise((resolve, reject) =>
-				resolve(new PlatformLocalStorage(DEFAULT_STORAGE_KEYS.Workspace, "Workspace"))
-			)
+		async (options) => new PlatformLocalStorage(DEFAULT_STORAGE_KEYS.Workspace, "Workspace")
 	);
 }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"package-for-github": "node ./scripts/package.js --location github",
 		"package-for-aws": "node ./scripts/package.js --location aws",
 		"prettier": "prettier --config .prettierrc --write .",
-		"eslint": "eslint . --ext .js,.mjs,.ts",
+		"eslint": "eslint . --ext .js,.mjs,.ts --fix",
 		"validate": "npm run prettier & npm run eslint"
 	},
 	"workspaces": [

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"package-for-github": "node ./scripts/package.js --location github",
 		"package-for-aws": "node ./scripts/package.js --location aws",
 		"prettier": "prettier --config .prettierrc --write .",
-		"eslint": "eslint . --ext .js,.mjs,.ts --fix",
+		"eslint": "eslint . --ext .js,.mjs,.ts",
 		"validate": "npm run prettier & npm run eslint"
 	},
 	"workspaces": [


### PR DESCRIPTION
Added the concept of platform storage where you can register a storage provider that supports an interface. These storage mechanisms are not launched automatically but on-demand (in case there are a few and they are expensive).

The platform can register implementations and then other parts of the platform can fetch the storage mechanism for a particular thing (e.g. pages) without caring if it is local or hosted (which is why apis are async).

Customize workspace includes a sample storage implementation using localstorage and registers these for page and workspace saving. 

The workspace platform provider uses these if any have been registered otherwise it falls back to the default implementation).