### PR TITLE
Add support for integration provider query params

### DIFF
--- a/how-to/customize-home-templates/client/src/integrations-shapes.ts
+++ b/how-to/customize-home-templates/client/src/integrations-shapes.ts
@@ -106,9 +106,14 @@ export interface IntegrationModule<T> {
 	 * The module is being registered.
 	 * @param integrationManager The manager for the integration.
 	 * @param integration The integration details.
+	 * @param startupQueryParams The query params passed to app at startup.
 	 * @returns Nothing.
 	 */
-	register?(integrationManager: IntegrationManager, integration: Integration<T>): Promise<void>;
+	register?(
+		integrationManager: IntegrationManager,
+		integration: Integration<T>,
+		queryParams?: unknown
+	): Promise<void>;
 
 	/**
 	 * The module is being deregistered.

--- a/how-to/customize-home-templates/client/src/integrations.ts
+++ b/how-to/customize-home-templates/client/src/integrations.ts
@@ -19,6 +19,8 @@ const homeIntegrations: {
 	integration: Integration<unknown>;
 }[] = [];
 
+let startupQueryParams: unknown;
+
 /**
  * Register all the workspace integrations.
  * @param integrationManager The integration manager.
@@ -47,7 +49,7 @@ export async function register(
 						integration
 					});
 					if (homeIntegration.register) {
-						await homeIntegration.register(integrationManager, integration);
+						await homeIntegration.register(integrationManager, integration, startupQueryParams);
 					}
 				} else {
 					console.error("Missing module in integration providers", integration.id);
@@ -191,4 +193,12 @@ export async function itemSelection(
  */
 export function addKnownIntegrationProvider(id: string, module: IntegrationModule<unknown>): void {
 	knownIntegrationProviders[id] = module;
+}
+
+/**
+ * Set the startup query params.
+ * @param queryParams The id of the module.
+ */
+export function setQueryParams(queryParams?: unknown): void {
+	startupQueryParams = queryParams;
 }

--- a/how-to/customize-home-templates/client/src/integrations/async/integration-provider.ts
+++ b/how-to/customize-home-templates/client/src/integrations/async/integration-provider.ts
@@ -36,11 +36,13 @@ export class AsyncIntegrationProvider implements IntegrationModule<AsyncSettings
 	 * The module is being registered.
 	 * @param integrationManager The manager for the integration.
 	 * @param integration The integration details.
+	 * @param startupQueryParams The query params passed to app at startup.
 	 * @returns Nothing.
 	 */
 	public async register(
 		integrationManager: IntegrationManager,
-		integration: Integration<AsyncSettings>
+		integration: Integration<AsyncSettings>,
+		startupQueryParams: unknown
 	): Promise<void> {
 		this._integrationManager = integrationManager;
 	}

--- a/how-to/customize-home-templates/client/src/integrations/emoji/integration-provider.ts
+++ b/how-to/customize-home-templates/client/src/integrations/emoji/integration-provider.ts
@@ -51,11 +51,13 @@ export class EmojiIntegrationProvider implements IntegrationModule<EmojiSettings
 	 * The module is being registered.
 	 * @param integrationManager The manager for the integration.
 	 * @param integration The integration details.
+	 * @param startupQueryParams The query params passed to app at startup.
 	 * @returns Nothing.
 	 */
 	public async register(
 		integrationManager: IntegrationManager,
-		integration: Integration<EmojiSettings>
+		integration: Integration<EmojiSettings>,
+		startupQueryParams: unknown
 	): Promise<void> {
 		this._integrationManager = integrationManager;
 	}

--- a/how-to/customize-home-templates/client/src/integrations/quote/integration-provider.ts
+++ b/how-to/customize-home-templates/client/src/integrations/quote/integration-provider.ts
@@ -48,11 +48,13 @@ export class QuoteIntegrationProvider implements IntegrationModule<QuoteSettings
 	 * The module is being registered.
 	 * @param integrationManager The manager for the integration.
 	 * @param integration The integration details.
+	 * @param startupQueryParams The query params passed to app at startup.
 	 * @returns Nothing.
 	 */
 	public async register(
 		integrationManager: IntegrationManager,
-		integration: Integration<QuoteSettings>
+		integration: Integration<QuoteSettings>,
+		startupQueryParams: unknown
 	): Promise<void> {
 		this._integrationManager = integrationManager;
 

--- a/how-to/customize-workspace/client/src/integrations-shapes.ts
+++ b/how-to/customize-workspace/client/src/integrations-shapes.ts
@@ -106,9 +106,14 @@ export interface IntegrationModule<T> {
 	 * The module is being registered.
 	 * @param integrationManager The manager for the integration.
 	 * @param integration The integration details.
+	 * @param startupQueryParams The query params passed to app at startup.
 	 * @returns Nothing.
 	 */
-	register?(integrationManager: IntegrationManager, integration: Integration<T>): Promise<void>;
+	register?(
+		integrationManager: IntegrationManager,
+		integration: Integration<T>,
+		startupQueryParams?: unknown
+	): Promise<void>;
 
 	/**
 	 * The module is being deregistered.

--- a/how-to/customize-workspace/client/src/integrations.ts
+++ b/how-to/customize-workspace/client/src/integrations.ts
@@ -19,6 +19,8 @@ const homeIntegrations: {
 	integration: Integration<unknown>;
 }[] = [];
 
+let startupQueryParams: unknown;
+
 /**
  * Register all the workspace integrations.
  * @param integrationManager The integration manager.
@@ -47,7 +49,7 @@ export async function register(
 						integration
 					});
 					if (homeIntegration.register) {
-						await homeIntegration.register(integrationManager, integration);
+						await homeIntegration.register(integrationManager, integration, startupQueryParams);
 					}
 				} else {
 					console.error("Missing module in integration providers", integration.id);
@@ -191,4 +193,12 @@ export async function itemSelection(
  */
 export function addKnownIntegrationProvider(id: string, module: IntegrationModule<unknown>): void {
 	knownIntegrationProviders[id] = module;
+}
+
+/**
+ * Set the startup query params.
+ * @param queryParams The id of the module.
+ */
+export function setQueryParams(queryParams?: unknown): void {
+	startupQueryParams = queryParams;
 }

--- a/how-to/customize-workspace/client/src/integrations/salesforce/integration-provider.ts
+++ b/how-to/customize-workspace/client/src/integrations/salesforce/integration-provider.ts
@@ -77,11 +77,13 @@ export class SalesForceIntegrationProvider implements IntegrationModule<Salesfor
 	 * The module is being registered.
 	 * @param integrationManager The manager for the integration.
 	 * @param integration The integration details.
+	 * @param startupQueryParams The query params passed to app at startup.
 	 * @returns Nothing.
 	 */
 	public async register(
 		integrationManager: IntegrationManager,
-		integration: Integration<SalesforceSettings>
+		integration: Integration<SalesforceSettings>,
+		startupQueryParams: unknown
 	): Promise<void> {
 		this._integrationManager = integrationManager;
 		console.log("Registering SalesForce");

--- a/how-to/customize-workspace/client/src/share.ts
+++ b/how-to/customize-workspace/client/src/share.ts
@@ -2,6 +2,7 @@ import { getCurrentSync, Page } from "@openfin/workspace-platform";
 import { create, IndicatorColor, NotificationOptions } from "@openfin/workspace/notifications";
 import { launchPage } from "./browser";
 import { requestResponse } from "./endpoint";
+import { setQueryParams } from "./integrations";
 import { getSettings } from "./settings";
 import { getWorkspace } from "./workspace";
 
@@ -290,6 +291,7 @@ async function queryOnLaunch(userAppConfigArgs?: { shareId: string }) {
 	if (userAppConfigArgs?.shareId !== undefined) {
 		await loadSharedEntry(userAppConfigArgs?.shareId);
 	}
+	setQueryParams(userAppConfigArgs);
 }
 
 async function queryWhileRunning(event: { userAppConfigArgs?: { shareId: string } }) {


### PR DESCRIPTION
Integration providers can now consume query params in the register method that are passed when the app is launched.