### PR TITLE
Added ability to have platform code define init options behaviour

### DIFF
--- a/how-to/customize-workspace/client/src/bootstrapper.ts
+++ b/how-to/customize-workspace/client/src/bootstrapper.ts
@@ -15,9 +15,7 @@ import {
 	register as registerHome,
 	show as showHome
 } from "./home";
-import {
-	init as registerInitOptionsListener
-} from "./init-options";
+import { init as registerInitOptionsListener } from "./init-options";
 import { deregister as deregisterIntegration, register as registerIntegration } from "./integrations";
 import { launchSnapshot } from "./launch";
 import { manifestTypes } from "./manifest-types";

--- a/how-to/customize-workspace/client/src/bootstrapper.ts
+++ b/how-to/customize-workspace/client/src/bootstrapper.ts
@@ -125,7 +125,6 @@ export async function init() {
 		await registerNotifications();
 	}
 
-	await registerInitOptionsListener(settings?.initOptionsProvider);
 	await registerShare();
 
 	// If the autoShow options is not set, default to the first registered component.
@@ -172,4 +171,8 @@ export async function init() {
 		await deregisterNotifications();
 		await fin.Platform.getCurrentSync().quit();
 	});
+
+	// Once the platform is started and everything is bootstrapped initialize the init options
+	// listener so that it is ready to handle initial params or subsequent requests.
+	await registerInitOptionsListener(settings?.initOptionsProvider);
 }

--- a/how-to/customize-workspace/client/src/bootstrapper.ts
+++ b/how-to/customize-workspace/client/src/bootstrapper.ts
@@ -15,6 +15,9 @@ import {
 	register as registerHome,
 	show as showHome
 } from "./home";
+import {
+	init as registerInitOptionsListener
+} from "./init-options";
 import { deregister as deregisterIntegration, register as registerIntegration } from "./integrations";
 import { launchSnapshot } from "./launch";
 import { manifestTypes } from "./manifest-types";
@@ -124,6 +127,7 @@ export async function init() {
 		await registerNotifications();
 	}
 
+	await registerInitOptionsListener();
 	await registerShare();
 
 	// If the autoShow options is not set, default to the first registered component.

--- a/how-to/customize-workspace/client/src/bootstrapper.ts
+++ b/how-to/customize-workspace/client/src/bootstrapper.ts
@@ -125,7 +125,7 @@ export async function init() {
 		await registerNotifications();
 	}
 
-	await registerInitOptionsListener();
+	await registerInitOptionsListener(settings?.initOptionsProvider);
 	await registerShare();
 
 	// If the autoShow options is not set, default to the first registered component.

--- a/how-to/customize-workspace/client/src/init-options-shapes.ts
+++ b/how-to/customize-workspace/client/src/init-options-shapes.ts
@@ -17,5 +17,5 @@ export interface InitOptionsProviderOptions {
 }
 
 export interface UserAppConfigArgs {
-	[key: string]: string | boolean | number;
+	[key: string]: string;
 }

--- a/how-to/customize-workspace/client/src/init-options-shapes.ts
+++ b/how-to/customize-workspace/client/src/init-options-shapes.ts
@@ -1,0 +1,17 @@
+export interface InitOptionsHandler {
+	init(data?: unknown): Promise<void>;
+	action<T>(requestedAction: string, payload?: T): Promise<void>;
+}
+export interface InitOptionsModule {
+	handler: InitOptionsHandler;
+}
+
+export interface InitOptionsModuleDefinition {
+	id: string;
+	url: string;
+	data?: unknown;
+	supportedActions: string[];
+}
+export interface InitOptionsProviderOptions {
+	modules?: InitOptionsModuleDefinition[];
+}

--- a/how-to/customize-workspace/client/src/init-options-shapes.ts
+++ b/how-to/customize-workspace/client/src/init-options-shapes.ts
@@ -15,3 +15,7 @@ export interface InitOptionsModuleDefinition {
 export interface InitOptionsProviderOptions {
 	modules?: InitOptionsModuleDefinition[];
 }
+
+export interface UserAppConfigArgs {
+	[key: string]: string | boolean | number;
+}

--- a/how-to/customize-workspace/client/src/init-options.ts
+++ b/how-to/customize-workspace/client/src/init-options.ts
@@ -2,129 +2,163 @@ import { fin } from "@openfin/core";
 import { getCurrentSync } from "@openfin/workspace-platform";
 const actionListeners: Map<string, Map<string, (payload: unknown) => Promise<void>>> = new Map();
 const actionListenerMap: { [key: string]: string } = {};
-const listeners: Map<string,
-Map<string, (initOptions: { [key: string]: string|boolean|number }) => Promise<void>>> = new Map();
+const listeners: Map<
+	string,
+	Map<string, (initOptions: { [key: string]: string | boolean | number }) => Promise<void>>
+> = new Map();
 const listenerMap: { [key: string]: string } = {};
 let initialized = false;
 const actionParamName = "action";
-const actionPayloadName = "payload";
 
-function extractPayloadFromParams<T>(initParams?: InitParams): T | undefined {
+function extractPayloadFromParams<T>(initOptions?: {
+	[key: string]: string | number | boolean;
+}): T | undefined {
 	try {
-		if (typeof initParams?.payload === "string") {
-			const plainJson = atob(initParams?.payload);
+		if (typeof initOptions?.payload === "string") {
+			const plainJson = atob(initOptions?.payload);
 			const payload = JSON.parse(plainJson) as T;
 			console.log("Extracted payload", payload);
 			return payload;
 		}
 	} catch (err) {
-		console.error("Error decoding payload, it should be Base64 encoded", initParams, err);
+		console.error("Error decoding payload, it should be Base64 encoded", initOptions, err);
 	}
 }
 
-async function notifyActionListeners(initOptions: { [key: string]: string | boolean | number}) {
-    const action = initOptions[actionParamName] as string;
-    const payloadAsBase64 = initOptions[actionPayloadName] as string; 
-    const availableListeners = actionListeners.get(action);
-    if (availableListeners !== undefined && availableListeners !== null) {
-        const payload = 
-    }
-    const subscriberIds = Array.from(subscribers.keys());
-	subscriberIds.reverse();
+async function notifyActionListeners(initOptions: { [key: string]: string | boolean | number }) {
+	const action = initOptions[actionParamName] as string;
+	const payload = extractPayloadFromParams(initOptions);
+	const availableListeners = actionListeners.get(action);
+	if (availableListeners !== undefined && availableListeners !== null && payload !== undefined) {
+		const subscriberIds = Array.from(availableListeners.keys());
 
-	for (let i = 0; i < subscriberIds.length; i++) {
-		const subscriberId = subscriberIds[i];
-		logInfo(
-			`Example Auth: Notifying subscriber with subscription Id: ${subscriberId} of event type: ${eventType}`
+		for (let i = 0; i < subscriberIds.length; i++) {
+			const subscriberId = subscriberIds[i];
+			console.log(
+				`Init Options: Notifying subscriber with subscription Id: ${subscriberId} of action: ${action}`
+			);
+			await availableListeners.get(subscriberId)(payload);
+		}
+	}
+}
+
+async function notifyListeners(initOptions: { [key: string]: string | boolean | number }) {
+	const customParamIds = Array.from(listeners.keys());
+	let listenerId: string;
+	for (let i = 0; i < customParamIds.length; i++) {
+		if (initOptions[customParamIds[i]] !== undefined) {
+			listenerId = customParamIds[i];
+			break;
+		}
+	}
+	if (listenerId !== undefined) {
+		console.log(
+			`Init param has been passed and it has a matching listener (${listenerId}). Passing on init options to listeners`
 		);
-		await subscribers.get(subscriberId)();
+		const availableListeners = listeners.get(listenerId);
+		if (availableListeners !== undefined && availableListeners !== null) {
+			const subscriberIds = Array.from(availableListeners.keys());
+
+			for (let l = 0; l < subscriberIds.length; l++) {
+				const subscriberId = subscriberIds[l];
+				console.log(
+					`Init Options: Notifying subscriber with subscription Id: ${subscriberId} of request: ${listenerId}`
+				);
+				await availableListeners.get(subscriberId)(initOptions);
+			}
+		}
 	}
 }
 
 async function queryOnLaunch(userAppConfigArgs?: { shareId: string }) {
 	console.log("Received during startup:", userAppConfigArgs);
-    if (userAppConfigArgs[actionParamName] !== undefined) {
-        await notifyActionListeners(userAppConfigArgs);
-    } else {
-        await notifyListeners(userAppConfigArgs);
-    }
+	if (userAppConfigArgs[actionParamName] !== undefined) {
+		await notifyActionListeners(userAppConfigArgs);
+	} else {
+		await notifyListeners(userAppConfigArgs);
+	}
 }
 
 async function queryWhileRunning(event: { userAppConfigArgs?: { shareId: string } }) {
 	if (event?.userAppConfigArgs?.shareId !== undefined) {
 		console.log(event.userAppConfigArgs);
 		if (event.userAppConfigArgs[actionParamName] !== undefined) {
-            await notifyActionListeners(event.userAppConfigArgs);
-        } else {
-            await notifyListeners(event.userAppConfigArgs);
-        }
+			await notifyActionListeners(event.userAppConfigArgs);
+		} else {
+			await notifyListeners(event.userAppConfigArgs);
+		}
 	}
 }
 
 export async function init() {
-    if (initialized) {
-        return;
-    }
-    initialized = true;
-    // eslint-disable-next-line @typescript-eslint/dot-notation
-    fin["desktop"].main(queryOnLaunch);
+	if (initialized) {
+		return;
+	}
+	initialized = true;
+	// eslint-disable-next-line @typescript-eslint/dot-notation
+	fin["desktop"].main(queryOnLaunch);
 	const platform = getCurrentSync();
 	await platform.Application.addListener("run-requested", queryWhileRunning);
 }
 
-export function registerActionListener<T>(action: string, actionHandler: (payload: T) => Promise<void>): string {
-    const key = crypto.randomUUID();
-    if (!actionListeners.has(action)) {
-        actionListeners.set(action, new Map());
-    }
-    const handlers = actionListeners.get(action);
-    handlers.set(key, actionHandler);
+export function registerActionListener<T>(
+	action: string,
+	actionHandler: (payload: T) => Promise<void>
+): string {
+	const key = crypto.randomUUID();
+	if (!actionListeners.has(action)) {
+		actionListeners.set(action, new Map());
+	}
+	const handlers = actionListeners.get(action);
+	handlers.set(key, actionHandler);
 	actionListeners.set(action, handlers);
-    actionListenerMap[key] = action;
-    return key;
+	actionListenerMap[key] = action;
+	return key;
 }
 
-export function registerListener(paramName: string,
-    handler: (initOptions: {[key: string]: string|number|boolean}) => Promise<void>): string {
-    if (paramName === actionParamName) {
-        console.warn("Please use registerActionListener if you wish to listen for an action.");
-        return null;
-    }
-    const key = crypto.randomUUID();
-    if (!listeners.has(paramName)) {
-        listeners.set(paramName, new Map());
-    }
-    const handlers = listeners.get(paramName);
-    handlers.set(key, handler);
-    listeners.set(paramName, handlers);
-    listenerMap[key] = paramName;
-    return key;
+export function registerListener(
+	paramName: string,
+	handler: (initOptions: { [key: string]: string | number | boolean }) => Promise<void>
+): string {
+	if (paramName === actionParamName) {
+		console.warn("Please use registerActionListener if you wish to listen for an action.");
+		return null;
+	}
+	const key = crypto.randomUUID();
+	if (!listeners.has(paramName)) {
+		listeners.set(paramName, new Map());
+	}
+	const handlers = listeners.get(paramName);
+	handlers.set(key, handler);
+	listeners.set(paramName, handlers);
+	listenerMap[key] = paramName;
+	return key;
 }
 
 export function removeListener(id: string): boolean {
-    let removed = false;
-    if (listenerMap[id] !== undefined) {
-        const paramName = listenerMap[id];
-        const listener = listeners.get(paramName);
-        delete listenerMap[id];
-        if (listener?.has(id)) {
-            listener.delete(id);
-            removed = true;
-        }
-    }
-    return removed;
+	let removed = false;
+	if (listenerMap[id] !== undefined) {
+		const paramName = listenerMap[id];
+		const listener = listeners.get(paramName);
+		delete listenerMap[id];
+		if (listener?.has(id)) {
+			listener.delete(id);
+			removed = true;
+		}
+	}
+	return removed;
 }
 
 export function removeActionListener(id: string): boolean {
-    let removed = false;
-    if (actionListenerMap[id] !== undefined) {
-        const action = actionListenerMap[id];
-        const actionListener = actionListeners.get(action);
-        delete actionListenerMap[id];
-        if (actionListener?.has(id)) {
-            actionListener.delete(id);
-            removed = true;
-        }
-    }
-    return removed;
+	let removed = false;
+	if (actionListenerMap[id] !== undefined) {
+		const action = actionListenerMap[id];
+		const actionListener = actionListeners.get(action);
+		delete actionListenerMap[id];
+		if (actionListener?.has(id)) {
+			actionListener.delete(id);
+			removed = true;
+		}
+	}
+	return removed;
 }

--- a/how-to/customize-workspace/client/src/init-options.ts
+++ b/how-to/customize-workspace/client/src/init-options.ts
@@ -1,0 +1,130 @@
+import { fin } from "@openfin/core";
+import { getCurrentSync } from "@openfin/workspace-platform";
+const actionListeners: Map<string, Map<string, (payload: unknown) => Promise<void>>> = new Map();
+const actionListenerMap: { [key: string]: string } = {};
+const listeners: Map<string,
+Map<string, (initOptions: { [key: string]: string|boolean|number }) => Promise<void>>> = new Map();
+const listenerMap: { [key: string]: string } = {};
+let initialized = false;
+const actionParamName = "action";
+const actionPayloadName = "payload";
+
+function extractPayloadFromParams<T>(initParams?: InitParams): T | undefined {
+	try {
+		if (typeof initParams?.payload === "string") {
+			const plainJson = atob(initParams?.payload);
+			const payload = JSON.parse(plainJson) as T;
+			console.log("Extracted payload", payload);
+			return payload;
+		}
+	} catch (err) {
+		console.error("Error decoding payload, it should be Base64 encoded", initParams, err);
+	}
+}
+
+async function notifyActionListeners(initOptions: { [key: string]: string | boolean | number}) {
+    const action = initOptions[actionParamName] as string;
+    const payloadAsBase64 = initOptions[actionPayloadName] as string; 
+    const availableListeners = actionListeners.get(action);
+    if (availableListeners !== undefined && availableListeners !== null) {
+        const payload = 
+    }
+    const subscriberIds = Array.from(subscribers.keys());
+	subscriberIds.reverse();
+
+	for (let i = 0; i < subscriberIds.length; i++) {
+		const subscriberId = subscriberIds[i];
+		logInfo(
+			`Example Auth: Notifying subscriber with subscription Id: ${subscriberId} of event type: ${eventType}`
+		);
+		await subscribers.get(subscriberId)();
+	}
+}
+
+async function queryOnLaunch(userAppConfigArgs?: { shareId: string }) {
+	console.log("Received during startup:", userAppConfigArgs);
+    if (userAppConfigArgs[actionParamName] !== undefined) {
+        await notifyActionListeners(userAppConfigArgs);
+    } else {
+        await notifyListeners(userAppConfigArgs);
+    }
+}
+
+async function queryWhileRunning(event: { userAppConfigArgs?: { shareId: string } }) {
+	if (event?.userAppConfigArgs?.shareId !== undefined) {
+		console.log(event.userAppConfigArgs);
+		if (event.userAppConfigArgs[actionParamName] !== undefined) {
+            await notifyActionListeners(event.userAppConfigArgs);
+        } else {
+            await notifyListeners(event.userAppConfigArgs);
+        }
+	}
+}
+
+export async function init() {
+    if (initialized) {
+        return;
+    }
+    initialized = true;
+    // eslint-disable-next-line @typescript-eslint/dot-notation
+    fin["desktop"].main(queryOnLaunch);
+	const platform = getCurrentSync();
+	await platform.Application.addListener("run-requested", queryWhileRunning);
+}
+
+export function registerActionListener<T>(action: string, actionHandler: (payload: T) => Promise<void>): string {
+    const key = crypto.randomUUID();
+    if (!actionListeners.has(action)) {
+        actionListeners.set(action, new Map());
+    }
+    const handlers = actionListeners.get(action);
+    handlers.set(key, actionHandler);
+	actionListeners.set(action, handlers);
+    actionListenerMap[key] = action;
+    return key;
+}
+
+export function registerListener(paramName: string,
+    handler: (initOptions: {[key: string]: string|number|boolean}) => Promise<void>): string {
+    if (paramName === actionParamName) {
+        console.warn("Please use registerActionListener if you wish to listen for an action.");
+        return null;
+    }
+    const key = crypto.randomUUID();
+    if (!listeners.has(paramName)) {
+        listeners.set(paramName, new Map());
+    }
+    const handlers = listeners.get(paramName);
+    handlers.set(key, handler);
+    listeners.set(paramName, handlers);
+    listenerMap[key] = paramName;
+    return key;
+}
+
+export function removeListener(id: string): boolean {
+    let removed = false;
+    if (listenerMap[id] !== undefined) {
+        const paramName = listenerMap[id];
+        const listener = listeners.get(paramName);
+        delete listenerMap[id];
+        if (listener?.has(id)) {
+            listener.delete(id);
+            removed = true;
+        }
+    }
+    return removed;
+}
+
+export function removeActionListener(id: string): boolean {
+    let removed = false;
+    if (actionListenerMap[id] !== undefined) {
+        const action = actionListenerMap[id];
+        const actionListener = actionListeners.get(action);
+        delete actionListenerMap[id];
+        if (actionListener?.has(id)) {
+            actionListener.delete(id);
+            removed = true;
+        }
+    }
+    return removed;
+}

--- a/how-to/customize-workspace/client/src/modules/init-options/interop/action-handler.ts
+++ b/how-to/customize-workspace/client/src/modules/init-options/interop/action-handler.ts
@@ -1,0 +1,65 @@
+import { fin } from "@openfin/core";
+
+interface RaiseIntentPayload {
+	name: string;
+	context: OpenFin.Context;
+}
+
+interface ShareContextPayload {
+	contextGroup: string;
+	context: OpenFin.Context;
+}
+
+async function raiseIntent(payload: RaiseIntentPayload) {
+	const brokerClient = fin.Interop.connectSync(fin.me.identity.uuid, {});
+	console.log(
+		`init options interop handler: received intent to raise. Intent Request ${JSON.stringify(
+			payload,
+			null,
+			4
+		)}.`
+	);
+	await brokerClient.fireIntent(payload);
+}
+
+async function shareContext(payload: ShareContextPayload) {
+	const brokerClient = fin.Interop.connectSync(fin.me.identity.uuid, {});
+	const contextGroups = await brokerClient.getContextGroups();
+	const targetContextGroup = contextGroups.find((group) => group.id === payload.contextGroup);
+	if (targetContextGroup !== undefined) {
+		await brokerClient.joinContextGroup(targetContextGroup.id);
+		console.log(
+			`init options interop handler: received context to send. Context Group ${
+				targetContextGroup.id
+			}. Context: ${JSON.stringify(payload.context, null, 4)}`
+		);
+		await brokerClient.setContext(payload.context);
+	}
+}
+
+export async function init() {
+	// the init function could be passed limits (e.g. only support the following intents or contexts. Only publish to the following context groups etc.)
+	console.log(`The interop init options action handler has been loaded`);
+}
+
+export async function action(
+	requestedAction: string,
+	payload?: RaiseIntentPayload | ShareContextPayload
+): Promise<void> {
+	if (payload === undefined) {
+		console.warn(
+			`Actions passed to the interop init options module require a payload to be passed. Requested action: ${requestedAction} can not be fulfilled.`
+		);
+		return;
+	}
+	switch (requestedAction) {
+		case "raise-intent": {
+			await raiseIntent(payload as RaiseIntentPayload);
+			break;
+		}
+		case "share-context": {
+			await shareContext(payload as ShareContextPayload);
+			break;
+		}
+	}
+}

--- a/how-to/customize-workspace/client/src/modules/init-options/interop/action-handler.ts
+++ b/how-to/customize-workspace/client/src/modules/init-options/interop/action-handler.ts
@@ -39,7 +39,7 @@ async function shareContext(payload: ShareContextPayload) {
 
 export async function init() {
 	// the init function could be passed limits (e.g. only support the following intents or contexts. Only publish to the following context groups etc.)
-	console.log(`The interop init options action handler has been loaded`);
+	console.log(`init options interop handler: The interop init options action handler has been loaded`);
 }
 
 export async function action(
@@ -48,18 +48,22 @@ export async function action(
 ): Promise<void> {
 	if (payload === undefined) {
 		console.warn(
-			`Actions passed to the interop init options module require a payload to be passed. Requested action: ${requestedAction} can not be fulfilled.`
+			`init options interop handler: Actions passed to the interop init options module require a payload to be passed. Requested action: ${requestedAction} can not be fulfilled.`
 		);
 		return;
 	}
-	switch (requestedAction) {
-		case "raise-intent": {
-			await raiseIntent(payload as RaiseIntentPayload);
-			break;
+	try {
+		switch (requestedAction) {
+			case "raise-intent": {
+				await raiseIntent(payload as RaiseIntentPayload);
+				break;
+			}
+			case "share-context": {
+				await shareContext(payload as ShareContextPayload);
+				break;
+			}
 		}
-		case "share-context": {
-			await shareContext(payload as ShareContextPayload);
-			break;
-		}
+	} catch (error) {
+		console.error(`init options interop handler: Error trying to perform action ${requestedAction}.`, error);
 	}
 }

--- a/how-to/customize-workspace/client/src/modules/init-options/interop/index.ts
+++ b/how-to/customize-workspace/client/src/modules/init-options/interop/index.ts
@@ -1,0 +1,1 @@
+export * as handler from "./action-handler";

--- a/how-to/customize-workspace/client/src/shapes.ts
+++ b/how-to/customize-workspace/client/src/shapes.ts
@@ -4,6 +4,7 @@ import { NotificationsPlatform } from "@openfin/workspace/notifications";
 import { AuthProviderOptions } from "./auth-shapes";
 import { ConnectionProviderOptions } from "./connection-shapes";
 import { EndpointProviderOptions } from "./endpoint-shapes";
+import { InitOptionsProviderOptions } from "./init-options-shapes";
 import { IntegrationProviderOptions } from "./integrations-shapes";
 
 interface PlatformProviderOptions {
@@ -168,17 +169,18 @@ interface StorefrontProviderOptions {
 }
 
 export interface CustomSettings {
-	bootstrap?: BootstrapOptions;
-	authProvider?: AuthProviderOptions;
 	appProvider?: AppProviderOptions;
-	connectionProvider?: ConnectionProviderOptions;
-	platformProvider?: PlatformProviderOptions;
+	authProvider?: AuthProviderOptions;
+	bootstrap?: BootstrapOptions;
 	browserProvider?: BrowserProviderOptions;
-	themeProvider?: ThemeProviderOptions;
-	homeProvider?: HomeProviderOptions;
-	storefrontProvider?: StorefrontProviderOptions;
+	connectionProvider?: ConnectionProviderOptions;
 	dockProvider?: DockProviderOptions;
-	notificationProvider?: NotificationProviderOptions;
-	integrationProvider?: IntegrationProviderOptions;
 	endpointProvider?: EndpointProviderOptions;
+	homeProvider?: HomeProviderOptions;
+	initOptionsProvider?: InitOptionsProviderOptions;
+	integrationProvider?: IntegrationProviderOptions;
+	notificationProvider?: NotificationProviderOptions;
+	platformProvider?: PlatformProviderOptions;
+	storefrontProvider?: StorefrontProviderOptions;
+	themeProvider?: ThemeProviderOptions;
 }

--- a/how-to/customize-workspace/client/src/share.ts
+++ b/how-to/customize-workspace/client/src/share.ts
@@ -288,27 +288,6 @@ async function loadSharedEntry(id: string) {
 	}
 }
 
-async function queryOnLaunch(userAppConfigArgs?: { shareId: string }) {
-	console.log("Received during startup:", userAppConfigArgs);
-	if (userAppConfigArgs?.shareId !== undefined) {
-		await loadSharedEntry(userAppConfigArgs?.shareId);
-	}
-}
-
-async function queryWhileRunning(event: { userAppConfigArgs?: { shareId: string } }) {
-	if (event?.userAppConfigArgs?.shareId !== undefined) {
-		console.log(event.userAppConfigArgs);
-		await loadSharedEntry(event.userAppConfigArgs.shareId);
-	}
-}
-
-async function listenForShareRequests() {
-	// eslint-disable-next-line @typescript-eslint/dot-notation
-	fin["desktop"].main(queryOnLaunch);
-	const platform = getCurrentSync();
-	await platform.Application.addListener("run-requested", queryWhileRunning);
-}
-
 export async function register() {
 	if (!shareRegistered) {
 		shareRegistered = true;

--- a/how-to/customize-workspace/client/webpack.config.js
+++ b/how-to/customize-workspace/client/webpack.config.js
@@ -128,5 +128,32 @@ module.exports = [
 		experiments: {
 			outputModule: true
 		}
+	},
+	{
+		entry: './client/src/modules/init-options/interop/index.ts',
+		devtool: 'inline-source-map',
+		module: {
+			rules: [
+				{
+					test: /\.tsx?$/,
+					use: 'ts-loader',
+					exclude: /node_modules/
+				}
+			]
+		},
+		resolve: {
+			extensions: ['.tsx', '.ts', '.js']
+		},
+		externals: { fin: 'fin' },
+		output: {
+			filename: 'interop.bundle.js',
+			library: {
+				type: 'module'
+			},
+			path: path.resolve(__dirname, '..', 'public', 'js', 'modules', 'init-options')
+		},
+		experiments: {
+			outputModule: true
+		}
 	}
 ];

--- a/how-to/customize-workspace/public/manifest.fin.json
+++ b/how-to/customize-workspace/public/manifest.fin.json
@@ -571,6 +571,16 @@
 					"data": {}
 				}
 			]
+		},
+		"initOptionsProvider": {
+			"modules": [
+				{
+					"id": "interop",
+					"url": "http://localhost:8080/js/modules/init-options/interop.bundle.js",
+					"data": {},
+					"supportedActions": ["raise-intent", "share-context"]
+				}
+			]
 		}
 	}
 }

--- a/how-to/customize-workspace/public/second.manifest.fin.json
+++ b/how-to/customize-workspace/public/second.manifest.fin.json
@@ -643,6 +643,70 @@
 				]
 			}
 		},
+		"dockProvider": {
+			"id": "customize-workspace",
+			"title": "Home Starter",
+			"icon": "http://localhost:8080/favicon.ico",
+			"workspaceComponents": {
+				"hideHomeButton": false,
+				"hideWorkspacesButton": false,
+				"hideNotificationsButton": false,
+				"hideStorefrontButton": false
+			},
+			"apps": [
+				{
+					"display": "individual",
+					"tags": ["dock"]
+				},
+				{
+					"display": "group",
+					"tooltip": "FDC3",
+					"tags": ["fdc3"]
+				},
+				{
+					"display": "group",
+					"tooltip": "Manager",
+					"iconUrl": "http://localhost:8080/common/images/icon-gradient.png",
+					"tags": ["manager"]
+				}
+			],
+			"buttons": [
+				{
+					"tooltip": "Google",
+					"iconUrl": "https://www.google.com/favicon.ico",
+					"action": {
+						"id": "launch-view",
+						"customData": {
+							"url": "https://www.google.com"
+						}
+					}
+				},
+				{
+					"tooltip": "Social",
+					"iconUrl": "http://localhost:8080/common/icons/share.svg",
+					"options": [
+						{
+							"tooltip": "Twitter",
+							"action": {
+								"id": "launch-view",
+								"customData": {
+									"url": "https://twitter.com/openfintech"
+								}
+							}
+						},
+						{
+							"tooltip": "YouTube",
+							"action": {
+								"id": "launch-view",
+								"customData": {
+									"url": "https://www.youtube.com/user/OpenFinTech"
+								}
+							}
+						}
+					]
+				}
+			]
+		},
 		"notificationProvider": {
 			"id": "second-customize-workspace",
 			"title": "Second Notification Starter",
@@ -683,6 +747,16 @@
 					"autoStart": false,
 					"moduleUrl": "https://samples.openfin.co/workspace-starter/workspace/vnext/customize-home-templates/js/integrations/emoji.bundle.js",
 					"data": {}
+				}
+			]
+		},
+		"initOptionsProvider": {
+			"modules": [
+				{
+					"id": "interop",
+					"url": "http://localhost:8080/js/modules/init-options/interop.bundle.js",
+					"data": {},
+					"supportedActions": ["raise-intent", "share-context"]
 				}
 			]
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -558,9 +558,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.9.5",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
-			"integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+			"version": "0.10.4",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
+			"integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
 			"dev": true,
 			"dependencies": {
 				"@humanwhocodes/object-schema": "^1.2.1",
@@ -569,6 +569,16 @@
 			},
 			"engines": {
 				"node": ">=10.10.0"
+			}
+		},
+		"node_modules/@humanwhocodes/gitignore-to-minimatch": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
+			"integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
+			"dev": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
 		"node_modules/@humanwhocodes/object-schema": {
@@ -735,17 +745,17 @@
 			}
 		},
 		"node_modules/@openfin/workspace": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@openfin/workspace/-/workspace-9.0.0.tgz",
-			"integrity": "sha512-OEYXi7RIT76gLmpR7LnV+fhsBhy1MacuXkPOuhvD046GbqedyOwe0ufZnaWB7BLDOHZr7Jlwi4vvv8/qurFaDA==",
+			"version": "9.0.4",
+			"resolved": "https://registry.npmjs.org/@openfin/workspace/-/workspace-9.0.4.tgz",
+			"integrity": "sha512-V11AHlkn4iH1MOqXAEUpZBwgaR4rfTOHrv1w1trK1rucLoCK833wKUFdAvcU6nz0/qB0AzreKny3pElTkX54GQ==",
 			"dependencies": {
 				"openfin-notifications": "^1.15.0"
 			}
 		},
 		"node_modules/@openfin/workspace-platform": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@openfin/workspace-platform/-/workspace-platform-9.0.0.tgz",
-			"integrity": "sha512-7T/2XBdQPzw9fn6ug0KwN5U65MazVl/Pgo1VvIGzfnPZ87IzyJnXc9XzmPxDSEpM0i1qBeYhZyupdPRTM9I4ng=="
+			"version": "9.0.4",
+			"resolved": "https://registry.npmjs.org/@openfin/workspace-platform/-/workspace-platform-9.0.4.tgz",
+			"integrity": "sha512-DykrbkOtnLlKIUSm+YLIoe6VUnW+cquDIyLqhykVe4LANEvOF9Qi6PHdeKo1/SG/IPMW3adZL7OD4S+wRACHvw=="
 		},
 		"node_modules/@types/auth0-js": {
 			"version": "9.14.6",
@@ -808,9 +818,9 @@
 			}
 		},
 		"node_modules/@types/express-serve-static-core": {
-			"version": "4.17.29",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz",
-			"integrity": "sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==",
+			"version": "4.17.30",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
+			"integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*",
@@ -836,9 +846,9 @@
 			"dev": true
 		},
 		"node_modules/@types/mime": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-			"integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.0.tgz",
+			"integrity": "sha512-fccbsHKqFDXClBZTDLA43zl0+TbxyIwyzIzwwhvoJvhNjOErCdeX2xJbURimv2EbSVUGav001PaCJg4mZxMl4w==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -871,25 +881,25 @@
 			"dev": true
 		},
 		"node_modules/@types/serve-static": {
-			"version": "1.13.10",
-			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
-			"integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
+			"integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
 			"dev": true,
 			"dependencies": {
-				"@types/mime": "^1",
+				"@types/mime": "*",
 				"@types/node": "*"
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.31.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.31.0.tgz",
-			"integrity": "sha512-VKW4JPHzG5yhYQrQ1AzXgVgX8ZAJEvCz0QI6mLRX4tf7rnFfh5D8SKm0Pq6w5PyNfAWJk6sv313+nEt3ohWMBQ==",
+			"version": "5.32.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.32.0.tgz",
+			"integrity": "sha512-CHLuz5Uz7bHP2WgVlvoZGhf0BvFakBJKAD/43Ty0emn4wXWv5k01ND0C0fHcl/Im8Td2y/7h44E9pca9qAu2ew==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.31.0",
-				"@typescript-eslint/type-utils": "5.31.0",
-				"@typescript-eslint/utils": "5.31.0",
+				"@typescript-eslint/scope-manager": "5.32.0",
+				"@typescript-eslint/type-utils": "5.32.0",
+				"@typescript-eslint/utils": "5.32.0",
 				"debug": "^4.3.4",
 				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.2.0",
@@ -915,15 +925,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.31.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.31.0.tgz",
-			"integrity": "sha512-UStjQiZ9OFTFReTrN+iGrC6O/ko9LVDhreEK5S3edmXgR396JGq7CoX2TWIptqt/ESzU2iRKXAHfSF2WJFcWHw==",
+			"version": "5.32.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.32.0.tgz",
+			"integrity": "sha512-IxRtsehdGV9GFQ35IGm5oKKR2OGcazUoiNBxhRV160iF9FoyuXxjY+rIqs1gfnd+4eL98OjeGnMpE7RF/NBb3A==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.31.0",
-				"@typescript-eslint/types": "5.31.0",
-				"@typescript-eslint/typescript-estree": "5.31.0",
+				"@typescript-eslint/scope-manager": "5.32.0",
+				"@typescript-eslint/types": "5.32.0",
+				"@typescript-eslint/typescript-estree": "5.32.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -943,14 +953,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.31.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.31.0.tgz",
-			"integrity": "sha512-8jfEzBYDBG88rcXFxajdVavGxb5/XKXyvWgvD8Qix3EEJLCFIdVloJw+r9ww0wbyNLOTYyBsR+4ALNGdlalLLg==",
+			"version": "5.32.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.32.0.tgz",
+			"integrity": "sha512-KyAE+tUON0D7tNz92p1uetRqVJiiAkeluvwvZOqBmW9z2XApmk5WSMV9FrzOroAcVxJZB3GfUwVKr98Dr/OjOg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.31.0",
-				"@typescript-eslint/visitor-keys": "5.31.0"
+				"@typescript-eslint/types": "5.32.0",
+				"@typescript-eslint/visitor-keys": "5.32.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -961,13 +971,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.31.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.31.0.tgz",
-			"integrity": "sha512-7ZYqFbvEvYXFn9ax02GsPcEOmuWNg+14HIf4q+oUuLnMbpJ6eHAivCg7tZMVwzrIuzX3QCeAOqKoyMZCv5xe+w==",
+			"version": "5.32.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.32.0.tgz",
+			"integrity": "sha512-0gSsIhFDduBz3QcHJIp3qRCvVYbqzHg8D6bHFsDMrm0rURYDj+skBK2zmYebdCp+4nrd9VWd13egvhYFJj/wZg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/utils": "5.31.0",
+				"@typescript-eslint/utils": "5.32.0",
 				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
 			},
@@ -988,9 +998,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.31.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.31.0.tgz",
-			"integrity": "sha512-/f/rMaEseux+I4wmR6mfpM2wvtNZb1p9hAV77hWfuKc3pmaANp5dLAZSiE3/8oXTYTt3uV9KW5yZKJsMievp6g==",
+			"version": "5.32.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.32.0.tgz",
+			"integrity": "sha512-EBUKs68DOcT/EjGfzywp+f8wG9Zw6gj6BjWu7KV/IYllqKJFPlZlLSYw/PTvVyiRw50t6wVbgv4p9uE2h6sZrQ==",
 			"dev": true,
 			"peer": true,
 			"engines": {
@@ -1002,14 +1012,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.31.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.31.0.tgz",
-			"integrity": "sha512-3S625TMcARX71wBc2qubHaoUwMEn+l9TCsaIzYI/ET31Xm2c9YQ+zhGgpydjorwQO9pLfR/6peTzS/0G3J/hDw==",
+			"version": "5.32.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.32.0.tgz",
+			"integrity": "sha512-ZVAUkvPk3ITGtCLU5J4atCw9RTxK+SRc6hXqLtllC2sGSeMFWN+YwbiJR9CFrSFJ3w4SJfcWtDwNb/DmUIHdhg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.31.0",
-				"@typescript-eslint/visitor-keys": "5.31.0",
+				"@typescript-eslint/types": "5.32.0",
+				"@typescript-eslint/visitor-keys": "5.32.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -1030,16 +1040,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "5.31.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.31.0.tgz",
-			"integrity": "sha512-kcVPdQS6VIpVTQ7QnGNKMFtdJdvnStkqS5LeALr4rcwx11G6OWb2HB17NMPnlRHvaZP38hL9iK8DdE9Fne7NYg==",
+			"version": "5.32.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.32.0.tgz",
+			"integrity": "sha512-W7lYIAI5Zlc5K082dGR27Fczjb3Q57ECcXefKU/f0ajM5ToM0P+N9NmJWip8GmGu/g6QISNT+K6KYB+iSHjXCQ==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.31.0",
-				"@typescript-eslint/types": "5.31.0",
-				"@typescript-eslint/typescript-estree": "5.31.0",
+				"@typescript-eslint/scope-manager": "5.32.0",
+				"@typescript-eslint/types": "5.32.0",
+				"@typescript-eslint/typescript-estree": "5.32.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			},
@@ -1055,13 +1065,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.31.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.31.0.tgz",
-			"integrity": "sha512-ZK0jVxSjS4gnPirpVjXHz7mgdOsZUHzNYSfTw2yPa3agfbt9YfqaBiBZFSSxeBWnpWkzCxTfUpnzA3Vily/CSg==",
+			"version": "5.32.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.32.0.tgz",
+			"integrity": "sha512-S54xOHZgfThiZ38/ZGTgB2rqx51CMJ5MCfVT2IplK4Q7hgzGfe0nLzLCcenDnc/cSjP568hdeKfeDcBgqNHD/g==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.31.0",
+				"@typescript-eslint/types": "5.32.0",
 				"eslint-visitor-keys": "^3.3.0"
 			},
 			"engines": {
@@ -1432,7 +1442,6 @@
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -1636,9 +1645,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.21.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
-			"integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
+			"version": "4.21.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
+			"integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -1650,10 +1659,10 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001366",
-				"electron-to-chromium": "^1.4.188",
+				"caniuse-lite": "^1.0.30001370",
+				"electron-to-chromium": "^1.4.202",
 				"node-releases": "^2.0.6",
-				"update-browserslist-db": "^1.0.4"
+				"update-browserslist-db": "^1.0.5"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -1710,9 +1719,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001370",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001370.tgz",
-			"integrity": "sha512-3PDmaP56wz/qz7G508xzjx8C+MC2qEm4SYhSEzC9IBROo+dGXFWRuaXkWti0A9tuI00g+toiriVqxtWMgl350g==",
+			"version": "1.0.30001373",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz",
+			"integrity": "sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -1741,9 +1750,9 @@
 			}
 		},
 		"node_modules/chart.js": {
-			"version": "3.8.2",
-			"resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.8.2.tgz",
-			"integrity": "sha512-7rqSlHWMUKFyBDOJvmFGW2lxULtcwaPLegDjX/Nu5j6QybY+GCiQkEY+6cqHw62S5tcwXMD8Y+H5OBGoR7d+ZQ=="
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.9.0.tgz",
+			"integrity": "sha512-SHOC6eCTe3dXe6owLHnO56xTLBbVeMHskkAlgPPVkd6xa0mv3EPhH5azRLg1cucYFsp4UloH/4NjSG0oOIFJtw=="
 		},
 		"node_modules/chrome-trace-event": {
 			"version": "1.0.3",
@@ -1969,9 +1978,9 @@
 			}
 		},
 		"node_modules/core-js-pure": {
-			"version": "3.24.0",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.24.0.tgz",
-			"integrity": "sha512-uzMmW8cRh7uYw4JQtzqvGWRyC2T5+4zipQLQdi2FmiRqP83k3d6F3stv2iAlNhOs6cXN401FCD5TL0vvleuHgA==",
+			"version": "3.24.1",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.24.1.tgz",
+			"integrity": "sha512-r1nJk41QLLPyozHUUPmILCEMtMw24NG4oWK6RbsDdjzQgg9ZvrUsPBj1MnG0wXXp1DCDU6j+wUvEmBSrtRbLXg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"peer": true,
@@ -2107,9 +2116,9 @@
 			"dev": true
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.200",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.200.tgz",
-			"integrity": "sha512-nPyI7oHc8T64oSqRXrAt99gNMpk0SAgPHw/o+hkNKyb5+bcdnFtZcSO9FUJES5cVkVZvo8u4qiZ1gQILl8UXsA=="
+			"version": "1.4.210",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.210.tgz",
+			"integrity": "sha512-kSiX4tuyZijV7Cz0MWVmGT8K2siqaOA4Z66K5dCttPPRh0HicOcOAEj1KlC8O8J1aOS/1M8rGofOzksLKaHWcQ=="
 		},
 		"node_modules/emoji-regex": {
 			"version": "9.2.2",
@@ -2268,13 +2277,14 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.20.0.tgz",
-			"integrity": "sha512-d4ixhz5SKCa1D6SCPrivP7yYVi7nyD6A4vs6HIAul9ujBzcEmZVM3/0NN/yu5nKhmO1wjp5xQ46iRfmDGlOviA==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.21.0.tgz",
+			"integrity": "sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==",
 			"dev": true,
 			"dependencies": {
 				"@eslint/eslintrc": "^1.3.0",
-				"@humanwhocodes/config-array": "^0.9.2",
+				"@humanwhocodes/config-array": "^0.10.4",
+				"@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -2284,14 +2294,17 @@
 				"eslint-scope": "^7.1.1",
 				"eslint-utils": "^3.0.0",
 				"eslint-visitor-keys": "^3.3.0",
-				"espree": "^9.3.2",
+				"espree": "^9.3.3",
 				"esquery": "^1.4.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
+				"find-up": "^5.0.0",
 				"functional-red-black-tree": "^1.0.1",
 				"glob-parent": "^6.0.1",
 				"globals": "^13.15.0",
+				"globby": "^11.1.0",
+				"grapheme-splitter": "^1.0.4",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
@@ -2434,6 +2447,64 @@
 			"dev": true,
 			"dependencies": {
 				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/eslint-module-utils/node_modules/find-up": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+			"integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/eslint-module-utils/node_modules/locate-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/eslint-module-utils/node_modules/p-limit": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"dev": true,
+			"dependencies": {
+				"p-try": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/eslint-module-utils/node_modules/p-locate": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/eslint-module-utils/node_modules/path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/eslint-plugin-import": {
@@ -2784,17 +2855,20 @@
 			}
 		},
 		"node_modules/espree": {
-			"version": "9.3.2",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
-			"integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+			"version": "9.3.3",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
+			"integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
 			"dev": true,
 			"dependencies": {
-				"acorn": "^8.7.1",
+				"acorn": "^8.8.0",
 				"acorn-jsx": "^5.3.2",
 				"eslint-visitor-keys": "^3.3.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/esquery": {
@@ -2991,9 +3065,9 @@
 			"integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
 		},
 		"node_modules/fastest-levenshtein": {
-			"version": "1.0.14",
-			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.14.tgz",
-			"integrity": "sha512-tFfWHjnuUfKE186Tfgr+jtaFc0mZTApEgKDOeyN+FwOqRkO/zK/3h1AiRd8u8CY53owL3CUmGr/oI9p/RdyLTA==",
+			"version": "1.0.16",
+			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+			"integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
 			"dev": true,
 			"engines": {
 				"node": ">= 4.9.1"
@@ -3102,15 +3176,19 @@
 			"dev": true
 		},
 		"node_modules/find-up": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-			"integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 			"dev": true,
 			"dependencies": {
-				"locate-path": "^2.0.0"
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/flat-cache": {
@@ -3344,7 +3422,6 @@
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
 			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
@@ -3364,6 +3441,12 @@
 			"version": "4.2.10",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
 			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+		},
+		"node_modules/grapheme-splitter": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+			"dev": true
 		},
 		"node_modules/has": {
 			"version": "1.0.3",
@@ -3622,15 +3705,18 @@
 			}
 		},
 		"node_modules/is-builtin-module": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.1.0.tgz",
-			"integrity": "sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
+			"integrity": "sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==",
 			"dev": true,
 			"dependencies": {
-				"builtin-modules": "^3.0.0"
+				"builtin-modules": "^3.3.0"
 			},
 			"engines": {
 				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-callable": {
@@ -4022,16 +4108,18 @@
 			}
 		},
 		"node_modules/locate-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-			"integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 			"dev": true,
 			"dependencies": {
-				"p-locate": "^2.0.0",
-				"path-exists": "^3.0.0"
+				"p-locate": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/lodash": {
@@ -4497,27 +4585,33 @@
 			}
 		},
 		"node_modules/p-limit": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 			"dev": true,
 			"dependencies": {
-				"p-try": "^1.0.0"
+				"yocto-queue": "^0.1.0"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-locate": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-			"integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 			"dev": true,
 			"dependencies": {
-				"p-limit": "^1.1.0"
+				"p-limit": "^3.0.2"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-try": {
@@ -4569,12 +4663,12 @@
 			}
 		},
 		"node_modules/path-exists": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 			"dev": true,
 			"engines": {
-				"node": ">=4"
+				"node": ">=8"
 			}
 		},
 		"node_modules/path-is-absolute": {
@@ -4704,15 +4798,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/pkg-dir/node_modules/path-exists": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/pluralize": {
@@ -4957,15 +5042,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/read-pkg-up/node_modules/path-exists": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/read-pkg-up/node_modules/type-fest": {
@@ -5412,7 +5488,6 @@
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -6320,6 +6395,18 @@
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		}
 	},
 	"dependencies": {
@@ -6452,15 +6539,21 @@
 			}
 		},
 		"@humanwhocodes/config-array": {
-			"version": "0.9.5",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
-			"integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+			"version": "0.10.4",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
+			"integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
 			"dev": true,
 			"requires": {
 				"@humanwhocodes/object-schema": "^1.2.1",
 				"debug": "^4.1.1",
 				"minimatch": "^3.0.4"
 			}
+		},
+		"@humanwhocodes/gitignore-to-minimatch": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
+			"integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
+			"dev": true
 		},
 		"@humanwhocodes/object-schema": {
 			"version": "1.2.1",
@@ -6614,17 +6707,17 @@
 			"integrity": "sha512-86jIv5CcNT8qdodrzMQjV4tbhao8JlzNId+bENh9t8pk1SWZ6WKbJPsNrPI9vcwO8NbjAKOgqlTZauzM7DSSLA=="
 		},
 		"@openfin/workspace": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@openfin/workspace/-/workspace-9.0.0.tgz",
-			"integrity": "sha512-OEYXi7RIT76gLmpR7LnV+fhsBhy1MacuXkPOuhvD046GbqedyOwe0ufZnaWB7BLDOHZr7Jlwi4vvv8/qurFaDA==",
+			"version": "9.0.4",
+			"resolved": "https://registry.npmjs.org/@openfin/workspace/-/workspace-9.0.4.tgz",
+			"integrity": "sha512-V11AHlkn4iH1MOqXAEUpZBwgaR4rfTOHrv1w1trK1rucLoCK833wKUFdAvcU6nz0/qB0AzreKny3pElTkX54GQ==",
 			"requires": {
 				"openfin-notifications": "^1.15.0"
 			}
 		},
 		"@openfin/workspace-platform": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@openfin/workspace-platform/-/workspace-platform-9.0.0.tgz",
-			"integrity": "sha512-7T/2XBdQPzw9fn6ug0KwN5U65MazVl/Pgo1VvIGzfnPZ87IzyJnXc9XzmPxDSEpM0i1qBeYhZyupdPRTM9I4ng=="
+			"version": "9.0.4",
+			"resolved": "https://registry.npmjs.org/@openfin/workspace-platform/-/workspace-platform-9.0.4.tgz",
+			"integrity": "sha512-DykrbkOtnLlKIUSm+YLIoe6VUnW+cquDIyLqhykVe4LANEvOF9Qi6PHdeKo1/SG/IPMW3adZL7OD4S+wRACHvw=="
 		},
 		"@types/auth0-js": {
 			"version": "9.14.6",
@@ -6687,9 +6780,9 @@
 			}
 		},
 		"@types/express-serve-static-core": {
-			"version": "4.17.29",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz",
-			"integrity": "sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==",
+			"version": "4.17.30",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
+			"integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
@@ -6715,9 +6808,9 @@
 			"dev": true
 		},
 		"@types/mime": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-			"integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.0.tgz",
+			"integrity": "sha512-fccbsHKqFDXClBZTDLA43zl0+TbxyIwyzIzwwhvoJvhNjOErCdeX2xJbURimv2EbSVUGav001PaCJg4mZxMl4w==",
 			"dev": true
 		},
 		"@types/node": {
@@ -6750,25 +6843,25 @@
 			"dev": true
 		},
 		"@types/serve-static": {
-			"version": "1.13.10",
-			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
-			"integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
+			"integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
 			"dev": true,
 			"requires": {
-				"@types/mime": "^1",
+				"@types/mime": "*",
 				"@types/node": "*"
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "5.31.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.31.0.tgz",
-			"integrity": "sha512-VKW4JPHzG5yhYQrQ1AzXgVgX8ZAJEvCz0QI6mLRX4tf7rnFfh5D8SKm0Pq6w5PyNfAWJk6sv313+nEt3ohWMBQ==",
+			"version": "5.32.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.32.0.tgz",
+			"integrity": "sha512-CHLuz5Uz7bHP2WgVlvoZGhf0BvFakBJKAD/43Ty0emn4wXWv5k01ND0C0fHcl/Im8Td2y/7h44E9pca9qAu2ew==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.31.0",
-				"@typescript-eslint/type-utils": "5.31.0",
-				"@typescript-eslint/utils": "5.31.0",
+				"@typescript-eslint/scope-manager": "5.32.0",
+				"@typescript-eslint/type-utils": "5.32.0",
+				"@typescript-eslint/utils": "5.32.0",
 				"debug": "^4.3.4",
 				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.2.0",
@@ -6778,57 +6871,57 @@
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "5.31.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.31.0.tgz",
-			"integrity": "sha512-UStjQiZ9OFTFReTrN+iGrC6O/ko9LVDhreEK5S3edmXgR396JGq7CoX2TWIptqt/ESzU2iRKXAHfSF2WJFcWHw==",
+			"version": "5.32.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.32.0.tgz",
+			"integrity": "sha512-IxRtsehdGV9GFQ35IGm5oKKR2OGcazUoiNBxhRV160iF9FoyuXxjY+rIqs1gfnd+4eL98OjeGnMpE7RF/NBb3A==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.31.0",
-				"@typescript-eslint/types": "5.31.0",
-				"@typescript-eslint/typescript-estree": "5.31.0",
+				"@typescript-eslint/scope-manager": "5.32.0",
+				"@typescript-eslint/types": "5.32.0",
+				"@typescript-eslint/typescript-estree": "5.32.0",
 				"debug": "^4.3.4"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "5.31.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.31.0.tgz",
-			"integrity": "sha512-8jfEzBYDBG88rcXFxajdVavGxb5/XKXyvWgvD8Qix3EEJLCFIdVloJw+r9ww0wbyNLOTYyBsR+4ALNGdlalLLg==",
+			"version": "5.32.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.32.0.tgz",
+			"integrity": "sha512-KyAE+tUON0D7tNz92p1uetRqVJiiAkeluvwvZOqBmW9z2XApmk5WSMV9FrzOroAcVxJZB3GfUwVKr98Dr/OjOg==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@typescript-eslint/types": "5.31.0",
-				"@typescript-eslint/visitor-keys": "5.31.0"
+				"@typescript-eslint/types": "5.32.0",
+				"@typescript-eslint/visitor-keys": "5.32.0"
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "5.31.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.31.0.tgz",
-			"integrity": "sha512-7ZYqFbvEvYXFn9ax02GsPcEOmuWNg+14HIf4q+oUuLnMbpJ6eHAivCg7tZMVwzrIuzX3QCeAOqKoyMZCv5xe+w==",
+			"version": "5.32.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.32.0.tgz",
+			"integrity": "sha512-0gSsIhFDduBz3QcHJIp3qRCvVYbqzHg8D6bHFsDMrm0rURYDj+skBK2zmYebdCp+4nrd9VWd13egvhYFJj/wZg==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@typescript-eslint/utils": "5.31.0",
+				"@typescript-eslint/utils": "5.32.0",
 				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "5.31.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.31.0.tgz",
-			"integrity": "sha512-/f/rMaEseux+I4wmR6mfpM2wvtNZb1p9hAV77hWfuKc3pmaANp5dLAZSiE3/8oXTYTt3uV9KW5yZKJsMievp6g==",
+			"version": "5.32.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.32.0.tgz",
+			"integrity": "sha512-EBUKs68DOcT/EjGfzywp+f8wG9Zw6gj6BjWu7KV/IYllqKJFPlZlLSYw/PTvVyiRw50t6wVbgv4p9uE2h6sZrQ==",
 			"dev": true,
 			"peer": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "5.31.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.31.0.tgz",
-			"integrity": "sha512-3S625TMcARX71wBc2qubHaoUwMEn+l9TCsaIzYI/ET31Xm2c9YQ+zhGgpydjorwQO9pLfR/6peTzS/0G3J/hDw==",
+			"version": "5.32.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.32.0.tgz",
+			"integrity": "sha512-ZVAUkvPk3ITGtCLU5J4atCw9RTxK+SRc6hXqLtllC2sGSeMFWN+YwbiJR9CFrSFJ3w4SJfcWtDwNb/DmUIHdhg==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@typescript-eslint/types": "5.31.0",
-				"@typescript-eslint/visitor-keys": "5.31.0",
+				"@typescript-eslint/types": "5.32.0",
+				"@typescript-eslint/visitor-keys": "5.32.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -6837,28 +6930,28 @@
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "5.31.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.31.0.tgz",
-			"integrity": "sha512-kcVPdQS6VIpVTQ7QnGNKMFtdJdvnStkqS5LeALr4rcwx11G6OWb2HB17NMPnlRHvaZP38hL9iK8DdE9Fne7NYg==",
+			"version": "5.32.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.32.0.tgz",
+			"integrity": "sha512-W7lYIAI5Zlc5K082dGR27Fczjb3Q57ECcXefKU/f0ajM5ToM0P+N9NmJWip8GmGu/g6QISNT+K6KYB+iSHjXCQ==",
 			"dev": true,
 			"peer": true,
 			"requires": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.31.0",
-				"@typescript-eslint/types": "5.31.0",
-				"@typescript-eslint/typescript-estree": "5.31.0",
+				"@typescript-eslint/scope-manager": "5.32.0",
+				"@typescript-eslint/types": "5.32.0",
+				"@typescript-eslint/typescript-estree": "5.32.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "5.31.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.31.0.tgz",
-			"integrity": "sha512-ZK0jVxSjS4gnPirpVjXHz7mgdOsZUHzNYSfTw2yPa3agfbt9YfqaBiBZFSSxeBWnpWkzCxTfUpnzA3Vily/CSg==",
+			"version": "5.32.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.32.0.tgz",
+			"integrity": "sha512-S54xOHZgfThiZ38/ZGTgB2rqx51CMJ5MCfVT2IplK4Q7hgzGfe0nLzLCcenDnc/cSjP568hdeKfeDcBgqNHD/g==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@typescript-eslint/types": "5.31.0",
+				"@typescript-eslint/types": "5.32.0",
 				"eslint-visitor-keys": "^3.3.0"
 			}
 		},
@@ -7161,8 +7254,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"array.prototype.flat": {
 			"version": "1.3.0",
@@ -7320,14 +7412,14 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.21.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
-			"integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
+			"version": "4.21.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
+			"integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
 			"requires": {
-				"caniuse-lite": "^1.0.30001366",
-				"electron-to-chromium": "^1.4.188",
+				"caniuse-lite": "^1.0.30001370",
+				"electron-to-chromium": "^1.4.202",
 				"node-releases": "^2.0.6",
-				"update-browserslist-db": "^1.0.4"
+				"update-browserslist-db": "^1.0.5"
 			}
 		},
 		"buffer-from": {
@@ -7363,9 +7455,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001370",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001370.tgz",
-			"integrity": "sha512-3PDmaP56wz/qz7G508xzjx8C+MC2qEm4SYhSEzC9IBROo+dGXFWRuaXkWti0A9tuI00g+toiriVqxtWMgl350g=="
+			"version": "1.0.30001373",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz",
+			"integrity": "sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ=="
 		},
 		"chalk": {
 			"version": "4.1.2",
@@ -7378,9 +7470,9 @@
 			}
 		},
 		"chart.js": {
-			"version": "3.8.2",
-			"resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.8.2.tgz",
-			"integrity": "sha512-7rqSlHWMUKFyBDOJvmFGW2lxULtcwaPLegDjX/Nu5j6QybY+GCiQkEY+6cqHw62S5tcwXMD8Y+H5OBGoR7d+ZQ=="
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.9.0.tgz",
+			"integrity": "sha512-SHOC6eCTe3dXe6owLHnO56xTLBbVeMHskkAlgPPVkd6xa0mv3EPhH5azRLg1cucYFsp4UloH/4NjSG0oOIFJtw=="
 		},
 		"chrome-trace-event": {
 			"version": "1.0.3",
@@ -7558,9 +7650,9 @@
 			}
 		},
 		"core-js-pure": {
-			"version": "3.24.0",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.24.0.tgz",
-			"integrity": "sha512-uzMmW8cRh7uYw4JQtzqvGWRyC2T5+4zipQLQdi2FmiRqP83k3d6F3stv2iAlNhOs6cXN401FCD5TL0vvleuHgA==",
+			"version": "3.24.1",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.24.1.tgz",
+			"integrity": "sha512-r1nJk41QLLPyozHUUPmILCEMtMw24NG4oWK6RbsDdjzQgg9ZvrUsPBj1MnG0wXXp1DCDU6j+wUvEmBSrtRbLXg==",
 			"dev": true,
 			"peer": true
 		},
@@ -7658,9 +7750,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.4.200",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.200.tgz",
-			"integrity": "sha512-nPyI7oHc8T64oSqRXrAt99gNMpk0SAgPHw/o+hkNKyb5+bcdnFtZcSO9FUJES5cVkVZvo8u4qiZ1gQILl8UXsA=="
+			"version": "1.4.210",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.210.tgz",
+			"integrity": "sha512-kSiX4tuyZijV7Cz0MWVmGT8K2siqaOA4Z66K5dCttPPRh0HicOcOAEj1KlC8O8J1aOS/1M8rGofOzksLKaHWcQ=="
 		},
 		"emoji-regex": {
 			"version": "9.2.2",
@@ -7783,13 +7875,14 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.20.0.tgz",
-			"integrity": "sha512-d4ixhz5SKCa1D6SCPrivP7yYVi7nyD6A4vs6HIAul9ujBzcEmZVM3/0NN/yu5nKhmO1wjp5xQ46iRfmDGlOviA==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.21.0.tgz",
+			"integrity": "sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==",
 			"dev": true,
 			"requires": {
 				"@eslint/eslintrc": "^1.3.0",
-				"@humanwhocodes/config-array": "^0.9.2",
+				"@humanwhocodes/config-array": "^0.10.4",
+				"@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -7799,14 +7892,17 @@
 				"eslint-scope": "^7.1.1",
 				"eslint-utils": "^3.0.0",
 				"eslint-visitor-keys": "^3.3.0",
-				"espree": "^9.3.2",
+				"espree": "^9.3.3",
 				"esquery": "^1.4.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
+				"find-up": "^5.0.0",
 				"functional-red-black-tree": "^1.0.1",
 				"glob-parent": "^6.0.1",
 				"globals": "^13.15.0",
+				"globby": "^11.1.0",
+				"grapheme-splitter": "^1.0.4",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
@@ -7923,6 +8019,49 @@
 					"requires": {
 						"ms": "^2.1.1"
 					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+					"dev": true
 				}
 			}
 		},
@@ -8166,12 +8305,12 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "9.3.2",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
-			"integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+			"version": "9.3.3",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
+			"integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
 			"dev": true,
 			"requires": {
-				"acorn": "^8.7.1",
+				"acorn": "^8.8.0",
 				"acorn-jsx": "^5.3.2",
 				"eslint-visitor-keys": "^3.3.0"
 			}
@@ -8338,9 +8477,9 @@
 			"integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
 		},
 		"fastest-levenshtein": {
-			"version": "1.0.14",
-			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.14.tgz",
-			"integrity": "sha512-tFfWHjnuUfKE186Tfgr+jtaFc0mZTApEgKDOeyN+FwOqRkO/zK/3h1AiRd8u8CY53owL3CUmGr/oI9p/RdyLTA==",
+			"version": "1.0.16",
+			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+			"integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
 			"dev": true
 		},
 		"fastq": {
@@ -8424,12 +8563,13 @@
 			}
 		},
 		"find-up": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-			"integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 			"dev": true,
 			"requires": {
-				"locate-path": "^2.0.0"
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
 			}
 		},
 		"flat-cache": {
@@ -8594,7 +8734,6 @@
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
 			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
@@ -8608,6 +8747,12 @@
 			"version": "4.2.10",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
 			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+		},
+		"grapheme-splitter": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+			"dev": true
 		},
 		"has": {
 			"version": "1.0.3",
@@ -8794,12 +8939,12 @@
 			}
 		},
 		"is-builtin-module": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.1.0.tgz",
-			"integrity": "sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
+			"integrity": "sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "^3.0.0"
+				"builtin-modules": "^3.3.0"
 			}
 		},
 		"is-callable": {
@@ -9088,13 +9233,12 @@
 			}
 		},
 		"locate-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-			"integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 			"dev": true,
 			"requires": {
-				"p-locate": "^2.0.0",
-				"path-exists": "^3.0.0"
+				"p-locate": "^5.0.0"
 			}
 		},
 		"lodash": {
@@ -9696,21 +9840,21 @@
 			}
 		},
 		"p-limit": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 			"dev": true,
 			"requires": {
-				"p-try": "^1.0.0"
+				"yocto-queue": "^0.1.0"
 			}
 		},
 		"p-locate": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-			"integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 			"dev": true,
 			"requires": {
-				"p-limit": "^1.1.0"
+				"p-limit": "^3.0.2"
 			}
 		},
 		"p-try": {
@@ -9747,9 +9891,9 @@
 			"dev": true
 		},
 		"path-exists": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 			"dev": true
 		},
 		"path-is-absolute": {
@@ -9843,12 +9987,6 @@
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 					"dev": true
 				}
 			}
@@ -10026,12 +10164,6 @@
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 					"dev": true
 				},
 				"type-fest": {
@@ -10351,8 +10483,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"source-map": {
 			"version": "0.6.1",
@@ -10989,6 +11120,12 @@
 			"version": "21.0.1",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
 			"integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+			"dev": true
+		},
+		"yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"dev": true
 		}
 	}


### PR DESCRIPTION
A platfomr can now call init-options.ts to register steps to take when an init param is specified either at the launch of the platform or when the platform is running.

The platform owner can also decide to load javascript modules that contain handlers for actions (the fins link would be fin://localhost:8080/manifest.fin.json?$$action=action-name&$$payload=json-object-that-has-been-stringified-and-then-encoded-using-btoa

An example has been added to the modules folder of customize and it is referenced in the manifest.