### PR TITLE
Update docs and package references in preparation for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The OpenFin Workspace is a full-featured work environment designed to improve th
 
 ## What version does this branch cover?
 
-This branch covers version **9.0.0** of OpenFin Workspace (there are versioned branches for other releases). [Click here to visit the release notes.](https://developer.openfin.co/versions/?product=Runtime#/?product=Workspace&sub-product=Workspace&version=9.0.0)
+This branch covers version **9.0.0** of OpenFin Workspace (there are versioned branches for other releases). [Click here to visit the release notes.](https://developer.openfin.co/versions/?product=Runtime#/?product=Workspace&sub-product=Workspace&version=9.0.9)
 
 ## What you can do with this repository
 
@@ -70,7 +70,7 @@ Depending on your version the following rules will apply:
   "desktopSettings": {
     "openfinSystemApplications": {
       "workspace": {
-        "version": "next",
+        "version": "9.0.9",
         "customConfig": {}
       }
     }
@@ -85,7 +85,7 @@ Depending on your version the following rules will apply:
   "desktopSettings": {
     "systemApps": {
       "workspace": {
-        "version": "next",
+        "version": "9.0.9",
         "customConfig": {}
       }
     }

--- a/how-to/common/package.json
+++ b/how-to/common/package.json
@@ -23,8 +23,8 @@
 	"license": "SEE LICENSE IN LICENSE.MD",
 	"dependencies": {
 		"@openfin/core": "^27.70.8",
-		"@openfin/workspace": "next",
-		"@openfin/workspace-platform": "next"
+		"@openfin/workspace": "9.0.9",
+		"@openfin/workspace-platform": "9.0.9"
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.11",

--- a/how-to/common/public/apps.json
+++ b/how-to/common/public/apps.json
@@ -980,7 +980,7 @@
 		"title": "OpenFin Process Manager",
 		"manifestType": "manifest",
 		"description": "Process Manager: This is OpenFin's tool for helping developers build OpenFin Applications. It lets you see the OpenFin applications that are running, the performance of the applications (memory and cpu) and easy access to the dev tools for the Windows of your application.",
-		"manifest": "https://cdn.openfin.co/process-manager/app.json",
+		"manifest": "https://cdn.openfin.co/release/apps/openfin/processmanager/app.json",
 		"icons": [
 			{
 				"src": "https://cdn.openfin.co/process-manager/img/proc-mgr-icon.png"

--- a/how-to/common/public/dos.json
+++ b/how-to/common/public/dos.json
@@ -2,7 +2,7 @@
 	"desktopSettings": {
 		"systemApps": {
 			"workspace": {
-				"version": "next",
+				"version": "9.0.9",
 				"customConfig": {
 					"hotkeys": {
 						"toggleHomeVisibility": "CommandOrControl+Space"

--- a/how-to/customize-home-templates/package.json
+++ b/how-to/customize-home-templates/package.json
@@ -23,8 +23,8 @@
 	"license": "SEE LICENSE IN LICENSE.MD",
 	"dependencies": {
 		"@openfin/core": "^27.70.8",
-		"@openfin/workspace": "next",
-		"@openfin/workspace-platform": "next",
+		"@openfin/workspace": "9.0.9",
+		"@openfin/workspace-platform": "9.0.9",
 		"chart.js": "^3.7.1",
 		"csstype": "^3.0.11",
 		"luxon": "^2.3.1",

--- a/how-to/customize-workspace/package.json
+++ b/how-to/customize-workspace/package.json
@@ -28,8 +28,8 @@
 		"@openfin/core": "^27.70.8",
 		"@openfin/salesforce": "^2.1.3",
 		"@openfin/salesforce-lwc": "^1.1.1",
-		"@openfin/workspace": "next",
-		"@openfin/workspace-platform": "next",
+		"@openfin/workspace": "9.0.9",
+		"@openfin/workspace-platform": "9.0.9",
 		"csstype": "^3.0.11"
 	},
 	"devDependencies": {

--- a/how-to/customize-workspace/public/manifest.fin.json
+++ b/how-to/customize-workspace/public/manifest.fin.json
@@ -57,7 +57,7 @@
 	"appAssets": [
 		{
 			"alias": "winform-interop-example",
-			"version": "2.0.0",
+			"version": "3.0.0",
 			"src": "http://localhost:8080/common/assets/native-interop-example.zip",
 			"target": "OpenFin.Interop.Win.Sample.exe",
 			"forceDownload": false
@@ -579,7 +579,7 @@
 					"description": "Search for emojis by name",
 					"enabled": false,
 					"autoStart": false,
-					"moduleUrl": "https://samples.openfin.co/workspace-starter/workspace/vnext/customize-home-templates/js/integrations/emoji.bundle.js",
+					"moduleUrl": "https://samples.openfin.co/workspace-starter/workspace/v9.0.0/customize-home-templates/js/integrations/emoji.bundle.js",
 					"data": {}
 				}
 			]

--- a/how-to/customize-workspace/public/second.manifest.fin.json
+++ b/how-to/customize-workspace/public/second.manifest.fin.json
@@ -44,7 +44,7 @@
 	"appAssets": [
 		{
 			"alias": "winform-interop-example",
-			"version": "2.0.0",
+			"version": "3.0.0",
 			"src": "http://localhost:8080/common/assets/native-interop-example.zip",
 			"target": "OpenFin.Interop.Win.Sample.exe",
 			"forceDownload": false
@@ -751,7 +751,7 @@
 					"title": "Emoji Provider",
 					"enabled": true,
 					"autoStart": false,
-					"moduleUrl": "https://samples.openfin.co/workspace-starter/workspace/vnext/customize-home-templates/js/integrations/emoji.bundle.js",
+					"moduleUrl": "https://samples.openfin.co/workspace-starter/workspace/v9.0.0/customize-home-templates/js/integrations/emoji.bundle.js",
 					"data": {}
 				}
 			]

--- a/how-to/integrate-server-authentication/package.json
+++ b/how-to/integrate-server-authentication/package.json
@@ -20,8 +20,8 @@
 	"license": "SEE LICENSE IN LICENSE.MD",
 	"dependencies": {
 		"@openfin/core": "^27.70.8",
-		"@openfin/workspace": "next",
-		"@openfin/workspace-platform": "next",
+		"@openfin/workspace": "9.0.9",
+		"@openfin/workspace-platform": "9.0.9",
 		"cookie-parser": "^1.4.6"
 	},
 	"devDependencies": {

--- a/how-to/integrate-with-excel/package.json
+++ b/how-to/integrate-with-excel/package.json
@@ -21,8 +21,8 @@
 	"dependencies": {
 		"@openfin/core": "^27.70.8",
 		"@openfin/excel": "^1.3.0",
-		"@openfin/workspace": "next",
-		"@openfin/workspace-platform": "next"
+		"@openfin/workspace": "9.0.9",
+		"@openfin/workspace-platform": "9.0.9"
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.13",

--- a/how-to/integrate-with-excel/public/apps.json
+++ b/how-to/integrate-with-excel/public/apps.json
@@ -1,40 +1,48 @@
 [
 	{
-		"appId": "interop-broadcast-view",
-		"name": "interop-broadcast-view",
-		"title": "Interop SetContext View",
-		"description": "This is an example of setting and listening to context using the interop api and seeing a code sample of how to do it.",
-		"manifest": "http://localhost:8080/common/views/interop/context/interop-broadcast-view.json",
-		"manifestType": "view",
-		"icons": [{ "src": "http://localhost:8080/common/images/icon-blue.png" }],
-		"contactEmail": "contact@example.com",
-		"supportEmail": "support@example.com",
-		"publisher": "OpenFin",
-		"intents": [],
-		"images": [
-			{
-				"src": "http://localhost:8080/common/images/previews/interop-view.png"
-			}
-		],
-		"tags": ["view", "interop"]
-	},
-	{
 		"appId": "fdc3-broadcast-view",
 		"name": "fdc3-broadcast-view",
-		"title": "FDC3 Broadcast View",
+		"title": "Context using FDC3",
 		"description": "This is an example view used to demonstrate the broadcasting and listenting of passed context objects using the fdc3 api.",
-		"manifest": "http://localhost:8080/common/views/fdc3/context/fdc3-broadcast-view.json",
+		"manifest": "https://samples.openfin.co/dev-extensions/extensions/v1.0.0/interop/fdc3/context/fdc3-broadcast-view.json",
 		"manifestType": "view",
-		"icons": [{ "src": "http://localhost:8080/common/images/icon-blue.png" }],
+		"icons": [
+			{
+				"src": "http://localhost:8080/common/images/icon-blue.png"
+			}
+		],
 		"contactEmail": "contact@example.com",
 		"supportEmail": "support@example.com",
 		"publisher": "OpenFin",
 		"intents": [],
 		"images": [
 			{
-				"src": "http://localhost:8080/common/images/previews/fdc3-view.png"
+				"src": "https://samples.openfin.co/dev-extensions/extensions/v1.0.0/interop/images/previews/view-context-fdc3.png"
 			}
 		],
-		"tags": ["view", "fdc3"]
+		"tags": ["view", "fdc3", "tools"]
+	},
+	{
+		"appId": "interop-broadcast-view",
+		"name": "interop-broadcast-view",
+		"title": "Context using Interop API",
+		"description": "This is an example of setting and listening to context using the interop api and seeing a code sample of how to do it.",
+		"manifest": "https://samples.openfin.co/dev-extensions/extensions/v1.0.0/interop/interop-api/context/interop-broadcast-view.json",
+		"manifestType": "view",
+		"icons": [
+			{
+				"src": "http://localhost:8080/common/images/icon-blue.png"
+			}
+		],
+		"contactEmail": "contact@example.com",
+		"supportEmail": "support@example.com",
+		"publisher": "OpenFin",
+		"intents": [],
+		"images": [
+			{
+				"src": "https://samples.openfin.co/dev-extensions/extensions/v1.0.0/interop/images/previews/view-context-interop-api.png"
+			}
+		],
+		"tags": ["view", "interop", "tools"]
 	}
 ]

--- a/how-to/integrate-with-rss/package.json
+++ b/how-to/integrate-with-rss/package.json
@@ -20,8 +20,8 @@
 	"license": "SEE LICENSE IN LICENSE.MD",
 	"dependencies": {
 		"@openfin/core": "^27.70.8",
-		"@openfin/workspace": "next",
-		"@openfin/workspace-platform": "next",
+		"@openfin/workspace": "9.0.9",
+		"@openfin/workspace-platform": "9.0.9",
 		"fast-xml-parser": "4.0.9"
 	},
 	"devDependencies": {

--- a/how-to/integrate-with-salesforce/package.json
+++ b/how-to/integrate-with-salesforce/package.json
@@ -25,8 +25,8 @@
 		"@openfin/core": "^27.70.8",
 		"@openfin/salesforce": "^2.1.3",
 		"@openfin/salesforce-lwc": "^1.1.1",
-		"@openfin/workspace": "next",
-		"@openfin/workspace-platform": "next"
+		"@openfin/workspace": "9.0.9",
+		"@openfin/workspace-platform": "9.0.9"
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.13",

--- a/how-to/integrate-with-sso/package.json
+++ b/how-to/integrate-with-sso/package.json
@@ -20,8 +20,8 @@
 	"license": "SEE LICENSE IN LICENSE.MD",
 	"dependencies": {
 		"@openfin/core": "^27.70.8",
-		"@openfin/workspace": "next",
-		"@openfin/workspace-platform": "next",
+		"@openfin/workspace": "9.0.9",
+		"@openfin/workspace-platform": "9.0.9",
 		"auth0-js": "^9.19.0"
 	},
 	"devDependencies": {

--- a/how-to/migrate-from-a-previous-version/README.md
+++ b/how-to/migrate-from-a-previous-version/README.md
@@ -3,6 +3,59 @@
 > **_:information_source: OpenFin Workspace:_** [OpenFin Workspace](https://www.openfin.co/workspace/) is a commercial product and this repo is for evaluation purposes. Use of the OpenFin Container and OpenFin Workspace components is only granted pursuant to a license from OpenFin. Please [**contact us**](https://www.openfin.co/workspace/poc/) if you would like to request a developer evaluation key or to discuss a production license.
 > OpenFin Workspace is currently **only supported on Windows**.
 
+## Migrate from a previous version - From v8.0 to v9.0
+
+The main focus of this release is:
+
+### New and improved Dock
+
+OpenFin has introduced the ability for developers to register a Workspace Platform with the Dock component. This enables end-users to access multiple Workspace Platforms in a single, unified Dock component.
+
+In addition, Dock is fully themable by Workspace Platforms, to deliver a branded experience whilst being part of a shared experience.
+
+Developers of Workspace Platform can also fully customize the buttons in Dock. For example, they can add, remove and reorder buttons in Dock.
+
+### Change of Behaviour - Home doesn't automatically appear on registration
+
+Home no longer appears when a Workspace Platform first registers the Home component. For Home to show automatically, developers of Workspace Platforms must add `Home.show()` right after registering the Home component. This is the pattern followed in the starters so if you have been following the starters you have already been doing this.
+
+### Version Information upon registration
+
+When you register a component you will be returned information that will tell you the version of Workspace you have registered against as well as the version of the npm module that was used for the registration.
+
+```javascript
+{
+    clientAPIVersion: string;
+    workspaceVersion: string;
+}
+```
+
+## What dependencies will I need for v9
+
+You will need the following dependencies
+
+```javascript
+"dependencies": {
+                    "@openfin/workspace": "^9.0.0",
+                    "@openfin/workspace-platform": "^9.0.0"
+                }
+```
+
+## Other Changes?
+
+We have introduced new starters:
+
+* use-theming - this starter is focused on giving you an easy way of trying out different theme palettes. You can change and apply them to the workspace to find the right combination of colors for your platform.
+* register-with-dock-basic - a starter that gives you an easy introduction to Dock and how you can customize it.
+* integrate-with-rss - a few people have asked us about providing a feed for notifications and opening the result in a window. We've used rss as an example and created a starter you can experiment with.
+* common - we have an updated Winform app that demonstrates context sharing and we now point to our brand new Process Manager to help you in debugging your application.
+* customize-workspace - customize workspace continues to be the main example that shows a way of combining all the workspace components and some patterns as suggestions. The following changes have been applied:
+
+  * DockProvider - Dock support has been added and is configurable through the manifest file
+  * An additional example endpoint has been added. This one lets you expose an endpoint that wraps a channel api.
+  * InitOptionsProvider - More module types supported. You can now create a module for handling init option params and we include an example that allows external apps to raise an intent or pass context via querystring parameters that target a platform.
+  * ConnectionProvider - The concept of connections has been added to customize-workspace. How do you support other applications e.g. Native C# apps to provide listing for their child views? How do they get launched when selected and how can the child views be captured in a snapshot (by becoming a snapshot source).
+
 ## Migrate from a previous version - From v7.0 to v8.0
 
 The main focus of this release is:
@@ -32,14 +85,14 @@ Platform Providers can now lock Browser Windows and/or Pages to offer fixed, rep
 
 The visual designs of filters in Workspace Home have been improved, so end-users can quickly and easily zero in on the content that they are searching for and quickly clear out selected filters
 
-## What dependencies will I need for v9
+## What dependencies will I need for v8
 
 You will need the following dependencies
 
 ```javascript
 "dependencies": {
-                    "@openfin/workspace": "^9.0.0",
-                    "@openfin/workspace-platform": "^9.0.0"
+                    "@openfin/workspace": "^8.0.0",
+                    "@openfin/workspace-platform": "^8.0.0"
                 }
 ```
 

--- a/how-to/migrate-from-a-previous-version/README.md
+++ b/how-to/migrate-from-a-previous-version/README.md
@@ -25,8 +25,8 @@ When you register a component you will be returned information that will tell yo
 
 ```javascript
 {
-    clientAPIVersion: string;
-    workspaceVersion: string;
+  clientAPIVersion: string;
+  workspaceVersion: string;
 }
 ```
 
@@ -45,16 +45,16 @@ You will need the following dependencies
 
 We have introduced new starters:
 
-* use-theming - this starter is focused on giving you an easy way of trying out different theme palettes. You can change and apply them to the workspace to find the right combination of colors for your platform.
-* register-with-dock-basic - a starter that gives you an easy introduction to Dock and how you can customize it.
-* integrate-with-rss - a few people have asked us about providing a feed for notifications and opening the result in a window. We've used rss as an example and created a starter you can experiment with.
-* common - we have an updated Winform app that demonstrates context sharing and we now point to our brand new Process Manager to help you in debugging your application.
-* customize-workspace - customize workspace continues to be the main example that shows a way of combining all the workspace components and some patterns as suggestions. The following changes have been applied:
+- use-theming - this starter is focused on giving you an easy way of trying out different theme palettes. You can change and apply them to the workspace to find the right combination of colors for your platform.
+- register-with-dock-basic - a starter that gives you an easy introduction to Dock and how you can customize it.
+- integrate-with-rss - a few people have asked us about providing a feed for notifications and opening the result in a window. We've used rss as an example and created a starter you can experiment with.
+- common - we have an updated Winform app that demonstrates context sharing and we now point to our brand new Process Manager to help you in debugging your application.
+- customize-workspace - customize workspace continues to be the main example that shows a way of combining all the workspace components and some patterns as suggestions. The following changes have been applied:
 
-  * DockProvider - Dock support has been added and is configurable through the manifest file
-  * An additional example endpoint has been added. This one lets you expose an endpoint that wraps a channel api.
-  * InitOptionsProvider - More module types supported. You can now create a module for handling init option params and we include an example that allows external apps to raise an intent or pass context via querystring parameters that target a platform.
-  * ConnectionProvider - The concept of connections has been added to customize-workspace. How do you support other applications e.g. Native C# apps to provide listing for their child views? How do they get launched when selected and how can the child views be captured in a snapshot (by becoming a snapshot source).
+  - DockProvider - Dock support has been added and is configurable through the manifest file
+  - An additional example endpoint has been added. This one lets you expose an endpoint that wraps a channel api.
+  - InitOptionsProvider - More module types supported. You can now create a module for handling init option params and we include an example that allows external apps to raise an intent or pass context via querystring parameters that target a platform.
+  - ConnectionProvider - The concept of connections has been added to customize-workspace. How do you support other applications e.g. Native C# apps to provide listing for their child views? How do they get launched when selected and how can the child views be captured in a snapshot (by becoming a snapshot source).
 
 ## Migrate from a previous version - From v7.0 to v8.0
 

--- a/how-to/migrate-from-a-previous-version/README.md
+++ b/how-to/migrate-from-a-previous-version/README.md
@@ -15,7 +15,7 @@ In addition, Dock is fully themable by Workspace Platforms, to deliver a branded
 
 Developers of Workspace Platform can also fully customize the buttons in Dock. For example, they can add, remove and reorder buttons in Dock.
 
-### Change of Behaviour - Home doesn't automatically appear on registration
+### Change of Behavior - Home doesn't automatically appear on registration
 
 Home no longer appears when a Workspace Platform first registers the Home component. For Home to show automatically, developers of Workspace Platforms must add `Home.show()` right after registering the Home component. This is the pattern followed in the starters so if you have been following the starters you have already been doing this.
 

--- a/how-to/register-with-browser/package.json
+++ b/how-to/register-with-browser/package.json
@@ -20,8 +20,8 @@
 	"license": "SEE LICENSE IN LICENSE.MD",
 	"dependencies": {
 		"@openfin/core": "^27.70.8",
-		"@openfin/workspace": "next",
-		"@openfin/workspace-platform": "next"
+		"@openfin/workspace": "9.0.9",
+		"@openfin/workspace-platform": "9.0.9"
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.13",

--- a/how-to/register-with-dock-basic/package.json
+++ b/how-to/register-with-dock-basic/package.json
@@ -20,8 +20,8 @@
 	"license": "SEE LICENSE IN LICENSE.MD",
 	"dependencies": {
 		"@openfin/core": "^27.70.8",
-		"@openfin/workspace": "next",
-		"@openfin/workspace-platform": "next"
+		"@openfin/workspace": "9.0.9",
+		"@openfin/workspace-platform": "9.0.9"
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.13",

--- a/how-to/register-with-home-basic/package.json
+++ b/how-to/register-with-home-basic/package.json
@@ -20,8 +20,8 @@
 	"license": "SEE LICENSE IN LICENSE.MD",
 	"dependencies": {
 		"@openfin/core": "^27.70.8",
-		"@openfin/workspace": "next",
-		"@openfin/workspace-platform": "next"
+		"@openfin/workspace": "9.0.9",
+		"@openfin/workspace-platform": "9.0.9"
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.13",

--- a/how-to/register-with-home/package.json
+++ b/how-to/register-with-home/package.json
@@ -20,8 +20,8 @@
 	"license": "SEE LICENSE IN LICENSE.MD",
 	"dependencies": {
 		"@openfin/core": "^27.70.8",
-		"@openfin/workspace": "next",
-		"@openfin/workspace-platform": "next"
+		"@openfin/workspace": "9.0.9",
+		"@openfin/workspace-platform": "9.0.9"
 	},
 	"devDependencies": {
 		"express": "^4.18.1",

--- a/how-to/register-with-platform-windows/package.json
+++ b/how-to/register-with-platform-windows/package.json
@@ -20,8 +20,8 @@
 	"license": "SEE LICENSE IN LICENSE.MD",
 	"dependencies": {
 		"@openfin/core": "^27.70.8",
-		"@openfin/workspace": "next",
-		"@openfin/workspace-platform": "next"
+		"@openfin/workspace": "9.0.9",
+		"@openfin/workspace-platform": "9.0.9"
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.11",

--- a/how-to/register-with-store-basic/package.json
+++ b/how-to/register-with-store-basic/package.json
@@ -20,8 +20,8 @@
 	"license": "SEE LICENSE IN LICENSE.MD",
 	"dependencies": {
 		"@openfin/core": "^27.70.8",
-		"@openfin/workspace": "next",
-		"@openfin/workspace-platform": "next"
+		"@openfin/workspace": "9.0.9",
+		"@openfin/workspace-platform": "9.0.9"
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.13",

--- a/how-to/register-with-store/package.json
+++ b/how-to/register-with-store/package.json
@@ -20,8 +20,8 @@
 	"license": "SEE LICENSE IN LICENSE.MD",
 	"dependencies": {
 		"@openfin/core": "^27.70.8",
-		"@openfin/workspace": "next",
-		"@openfin/workspace-platform": "next"
+		"@openfin/workspace": "9.0.9",
+		"@openfin/workspace-platform": "9.0.9"
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.13",

--- a/how-to/support-context-and-intents/package.json
+++ b/how-to/support-context-and-intents/package.json
@@ -20,8 +20,8 @@
 	"license": "SEE LICENSE IN LICENSE.MD",
 	"dependencies": {
 		"@openfin/core": "^27.70.8",
-		"@openfin/workspace": "next",
-		"@openfin/workspace-platform": "next"
+		"@openfin/workspace": "9.0.9",
+		"@openfin/workspace-platform": "9.0.9"
 	},
 	"devDependencies": {
 		"express": "^4.18.1",

--- a/how-to/use-notifications/package.json
+++ b/how-to/use-notifications/package.json
@@ -20,7 +20,7 @@
 	"license": "SEE LICENSE IN LICENSE.MD",
 	"dependencies": {
 		"@openfin/core": "^27.70.8",
-		"@openfin/workspace": "next",
+		"@openfin/workspace": "9.0.9",
 		"csstype": "^3.0.11"
 	},
 	"devDependencies": {

--- a/how-to/use-theming/package.json
+++ b/how-to/use-theming/package.json
@@ -21,7 +21,7 @@
 	"license": "SEE LICENSE IN LICENSE.MD",
 	"dependencies": {
 		"@openfin/core": "^27.70.8",
-		"@openfin/workspace": "next"
+		"@openfin/workspace": "9.0.9"
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.13",

--- a/how-to/workspace-native-window-integration/package.json
+++ b/how-to/workspace-native-window-integration/package.json
@@ -21,8 +21,8 @@
 	"dependencies": {
 		"@openfin/core": "^27.70.8",
 		"@openfin/native-window-integration-client": "0.0.13",
-		"@openfin/workspace": "next",
-		"@openfin/workspace-platform": "next",
+		"@openfin/workspace": "9.0.9",
+		"@openfin/workspace-platform": "9.0.9",
 		"file-loader": "^6.2.0"
 	},
 	"devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,8 +35,8 @@
 			"license": "SEE LICENSE IN LICENSE.MD",
 			"dependencies": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next"
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9"
 			},
 			"devDependencies": {
 				"@types/express": "^4.17.11",
@@ -55,8 +55,8 @@
 			"license": "SEE LICENSE IN LICENSE.MD",
 			"dependencies": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"chart.js": "^3.7.1",
 				"csstype": "^3.0.11",
 				"luxon": "^2.3.1",
@@ -82,8 +82,8 @@
 				"@openfin/core": "^27.70.8",
 				"@openfin/salesforce": "^2.1.3",
 				"@openfin/salesforce-lwc": "^1.1.1",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"csstype": "^3.0.11"
 			},
 			"devDependencies": {
@@ -102,8 +102,8 @@
 			"license": "SEE LICENSE IN LICENSE.MD",
 			"dependencies": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"cookie-parser": "^1.4.6"
 			},
 			"devDependencies": {
@@ -124,8 +124,8 @@
 			"dependencies": {
 				"@openfin/core": "^27.70.8",
 				"@openfin/excel": "^1.3.0",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next"
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9"
 			},
 			"devDependencies": {
 				"@types/express": "^4.17.13",
@@ -143,8 +143,8 @@
 			"license": "SEE LICENSE IN LICENSE.MD",
 			"dependencies": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"fast-xml-parser": "4.0.9"
 			},
 			"devDependencies": {
@@ -169,8 +169,8 @@
 				"@openfin/core": "^27.70.8",
 				"@openfin/salesforce": "^2.1.3",
 				"@openfin/salesforce-lwc": "^1.1.1",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next"
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9"
 			},
 			"devDependencies": {
 				"@types/express": "^4.17.13",
@@ -190,8 +190,8 @@
 			"license": "SEE LICENSE IN LICENSE.MD",
 			"dependencies": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"auth0-js": "^9.19.0"
 			},
 			"devDependencies": {
@@ -211,8 +211,8 @@
 			"license": "SEE LICENSE IN LICENSE.MD",
 			"dependencies": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next"
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9"
 			},
 			"devDependencies": {
 				"@types/express": "^4.17.13",
@@ -231,8 +231,8 @@
 			"license": "SEE LICENSE IN LICENSE.MD",
 			"dependencies": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next"
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9"
 			},
 			"devDependencies": {
 				"@types/express": "^4.17.13",
@@ -251,8 +251,8 @@
 			"license": "SEE LICENSE IN LICENSE.MD",
 			"dependencies": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next"
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9"
 			},
 			"devDependencies": {
 				"@types/express": "^4.17.13",
@@ -270,8 +270,8 @@
 			"license": "SEE LICENSE IN LICENSE.MD",
 			"dependencies": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next"
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9"
 			},
 			"devDependencies": {
 				"@types/express": "^4.17.13",
@@ -289,8 +289,8 @@
 			"license": "SEE LICENSE IN LICENSE.MD",
 			"dependencies": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next"
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9"
 			},
 			"devDependencies": {
 				"@types/express": "^4.17.11",
@@ -309,8 +309,8 @@
 			"license": "SEE LICENSE IN LICENSE.MD",
 			"dependencies": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next"
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9"
 			},
 			"devDependencies": {
 				"@types/express": "^4.17.13",
@@ -329,8 +329,8 @@
 			"license": "SEE LICENSE IN LICENSE.MD",
 			"dependencies": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next"
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9"
 			},
 			"devDependencies": {
 				"@types/express": "^4.17.13",
@@ -348,8 +348,8 @@
 			"license": "SEE LICENSE IN LICENSE.MD",
 			"dependencies": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next"
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9"
 			},
 			"devDependencies": {
 				"@types/express": "^4.17.13",
@@ -367,7 +367,7 @@
 			"license": "SEE LICENSE IN LICENSE.MD",
 			"dependencies": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
+				"@openfin/workspace": "9.0.9",
 				"csstype": "^3.0.11"
 			},
 			"devDependencies": {
@@ -386,7 +386,7 @@
 			"license": "SEE LICENSE IN LICENSE.MD",
 			"dependencies": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next"
+				"@openfin/workspace": "9.0.9"
 			},
 			"devDependencies": {
 				"@types/express": "^4.17.13",
@@ -405,8 +405,8 @@
 			"dependencies": {
 				"@openfin/core": "^27.70.8",
 				"@openfin/native-window-integration-client": "0.0.13",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"file-loader": "^6.2.0"
 			},
 			"devDependencies": {
@@ -699,9 +699,9 @@
 			}
 		},
 		"node_modules/@openfin/core": {
-			"version": "27.71.6",
-			"resolved": "https://registry.npmjs.org/@openfin/core/-/core-27.71.6.tgz",
-			"integrity": "sha512-38PSHbq9eg7IBQywb/WDnFb5dkbSwvuX+pQr+SBek35YCgbXhUnrAHJpOmbnPWVaLiBoEW6wB08jOg+0q60bjQ==",
+			"version": "27.71.7",
+			"resolved": "https://registry.npmjs.org/@openfin/core/-/core-27.71.7.tgz",
+			"integrity": "sha512-L654iRMmhhgchbCf6Ap0TlLVZ/lfzYMQg6hP5SSGhfYDuJv0pMXTy+5O+xj476qrrSSUQwbh+5sD9dQg9DDnOQ==",
 			"dependencies": {
 				"lodash": "^4.17.21"
 			}
@@ -761,25 +761,25 @@
 			"integrity": "sha512-86jIv5CcNT8qdodrzMQjV4tbhao8JlzNId+bENh9t8pk1SWZ6WKbJPsNrPI9vcwO8NbjAKOgqlTZauzM7DSSLA=="
 		},
 		"node_modules/@openfin/salesforce/node_modules/@openfin/core": {
-			"version": "26.70.16",
-			"resolved": "https://registry.npmjs.org/@openfin/core/-/core-26.70.16.tgz",
-			"integrity": "sha512-Y5SHGRu6H05xqHl/dMxp/uMDv/aiOew30gyVQa+fhQ3RyRkayaihbnTlGCX33cz4foK0Q5g27KEYLUgQr7yvWA==",
+			"version": "26.71.7",
+			"resolved": "https://registry.npmjs.org/@openfin/core/-/core-26.71.7.tgz",
+			"integrity": "sha512-TB0Npjrpb+d2vRMWLiS9kiCcLdqGLruzWGXmGIF4NRuuzUi4wGSWi5j7i9prGvPF0kNC6jdnxGMoEqegCVjbZw==",
 			"dependencies": {
 				"lodash": "^4.17.21"
 			}
 		},
 		"node_modules/@openfin/workspace": {
-			"version": "9.0.7",
-			"resolved": "https://registry.npmjs.org/@openfin/workspace/-/workspace-9.0.7.tgz",
-			"integrity": "sha512-vBjwfe9JY+wqjhVkkxLHr4MeZQ+wACs51lhpct+D1OJUVJNXrvkS9WoZArl+nkRpfyt6aBC1E2QylfVhYeLEww==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/@openfin/workspace/-/workspace-9.0.9.tgz",
+			"integrity": "sha512-GZwMPUCxtHyQRCmi0Cy7a2MYjBbNrBqPothOZEE/WS7ysLz8CPSVZ1zIB31XgQekymSlNGv0xExPJJ6XvNP98w==",
 			"dependencies": {
 				"openfin-notifications": "^1.15.0"
 			}
 		},
 		"node_modules/@openfin/workspace-platform": {
-			"version": "9.0.7",
-			"resolved": "https://registry.npmjs.org/@openfin/workspace-platform/-/workspace-platform-9.0.7.tgz",
-			"integrity": "sha512-ZUW/E97eyNcfNvSCynIr4pHXgw1EcEV6RqBbDlF3Dk+ZnoccfZO6ks5BRxzEhxmV8I/J9AAqeSqv3Xa6Ech9rQ=="
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/@openfin/workspace-platform/-/workspace-platform-9.0.9.tgz",
+			"integrity": "sha512-5BXbVRuc9H4J9P1Wc5X1zyg6Pfk6LwxK84hZi2dW0xY7LyJZ6Bw3TmzWdxv4YkonSTB6D15zj/DHN1cWTKsCzw=="
 		},
 		"node_modules/@types/auth0-js": {
 			"version": "9.14.6",
@@ -870,9 +870,9 @@
 			"dev": true
 		},
 		"node_modules/@types/mime": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.0.tgz",
-			"integrity": "sha512-fccbsHKqFDXClBZTDLA43zl0+TbxyIwyzIzwwhvoJvhNjOErCdeX2xJbURimv2EbSVUGav001PaCJg4mZxMl4w==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+			"integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -925,15 +925,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.32.0.tgz",
-			"integrity": "sha512-CHLuz5Uz7bHP2WgVlvoZGhf0BvFakBJKAD/43Ty0emn4wXWv5k01ND0C0fHcl/Im8Td2y/7h44E9pca9qAu2ew==",
+			"version": "5.33.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.33.0.tgz",
+			"integrity": "sha512-jHvZNSW2WZ31OPJ3enhLrEKvAZNyAFWZ6rx9tUwaessTc4sx9KmgMNhVcqVAl1ETnT5rU5fpXTLmY9YvC1DCNg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.32.0",
-				"@typescript-eslint/type-utils": "5.32.0",
-				"@typescript-eslint/utils": "5.32.0",
+				"@typescript-eslint/scope-manager": "5.33.0",
+				"@typescript-eslint/type-utils": "5.33.0",
+				"@typescript-eslint/utils": "5.33.0",
 				"debug": "^4.3.4",
 				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.2.0",
@@ -959,15 +959,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.32.0.tgz",
-			"integrity": "sha512-IxRtsehdGV9GFQ35IGm5oKKR2OGcazUoiNBxhRV160iF9FoyuXxjY+rIqs1gfnd+4eL98OjeGnMpE7RF/NBb3A==",
+			"version": "5.33.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.33.0.tgz",
+			"integrity": "sha512-cgM5cJrWmrDV2KpvlcSkelTBASAs1mgqq+IUGKJvFxWrapHpaRy5EXPQz9YaKF3nZ8KY18ILTiVpUtbIac86/w==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.32.0",
-				"@typescript-eslint/types": "5.32.0",
-				"@typescript-eslint/typescript-estree": "5.32.0",
+				"@typescript-eslint/scope-manager": "5.33.0",
+				"@typescript-eslint/types": "5.33.0",
+				"@typescript-eslint/typescript-estree": "5.33.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -987,14 +987,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.32.0.tgz",
-			"integrity": "sha512-KyAE+tUON0D7tNz92p1uetRqVJiiAkeluvwvZOqBmW9z2XApmk5WSMV9FrzOroAcVxJZB3GfUwVKr98Dr/OjOg==",
+			"version": "5.33.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.33.0.tgz",
+			"integrity": "sha512-/Jta8yMNpXYpRDl8EwF/M8It2A9sFJTubDo0ATZefGXmOqlaBffEw0ZbkbQ7TNDK6q55NPHFshGBPAZvZkE8Pw==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.32.0",
-				"@typescript-eslint/visitor-keys": "5.32.0"
+				"@typescript-eslint/types": "5.33.0",
+				"@typescript-eslint/visitor-keys": "5.33.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1005,13 +1005,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.32.0.tgz",
-			"integrity": "sha512-0gSsIhFDduBz3QcHJIp3qRCvVYbqzHg8D6bHFsDMrm0rURYDj+skBK2zmYebdCp+4nrd9VWd13egvhYFJj/wZg==",
+			"version": "5.33.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.33.0.tgz",
+			"integrity": "sha512-2zB8uEn7hEH2pBeyk3NpzX1p3lF9dKrEbnXq1F7YkpZ6hlyqb2yZujqgRGqXgRBTHWIUG3NGx/WeZk224UKlIA==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/utils": "5.32.0",
+				"@typescript-eslint/utils": "5.33.0",
 				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
 			},
@@ -1032,9 +1032,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.32.0.tgz",
-			"integrity": "sha512-EBUKs68DOcT/EjGfzywp+f8wG9Zw6gj6BjWu7KV/IYllqKJFPlZlLSYw/PTvVyiRw50t6wVbgv4p9uE2h6sZrQ==",
+			"version": "5.33.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.33.0.tgz",
+			"integrity": "sha512-nIMt96JngB4MYFYXpZ/3ZNU4GWPNdBbcB5w2rDOCpXOVUkhtNlG2mmm8uXhubhidRZdwMaMBap7Uk8SZMU/ppw==",
 			"dev": true,
 			"peer": true,
 			"engines": {
@@ -1046,14 +1046,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.32.0.tgz",
-			"integrity": "sha512-ZVAUkvPk3ITGtCLU5J4atCw9RTxK+SRc6hXqLtllC2sGSeMFWN+YwbiJR9CFrSFJ3w4SJfcWtDwNb/DmUIHdhg==",
+			"version": "5.33.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.33.0.tgz",
+			"integrity": "sha512-tqq3MRLlggkJKJUrzM6wltk8NckKyyorCSGMq4eVkyL5sDYzJJcMgZATqmF8fLdsWrW7OjjIZ1m9v81vKcaqwQ==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.32.0",
-				"@typescript-eslint/visitor-keys": "5.32.0",
+				"@typescript-eslint/types": "5.33.0",
+				"@typescript-eslint/visitor-keys": "5.33.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -1074,16 +1074,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.32.0.tgz",
-			"integrity": "sha512-W7lYIAI5Zlc5K082dGR27Fczjb3Q57ECcXefKU/f0ajM5ToM0P+N9NmJWip8GmGu/g6QISNT+K6KYB+iSHjXCQ==",
+			"version": "5.33.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.33.0.tgz",
+			"integrity": "sha512-JxOAnXt9oZjXLIiXb5ZIcZXiwVHCkqZgof0O8KPgz7C7y0HS42gi75PdPlqh1Tf109M0fyUw45Ao6JLo7S5AHw==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.32.0",
-				"@typescript-eslint/types": "5.32.0",
-				"@typescript-eslint/typescript-estree": "5.32.0",
+				"@typescript-eslint/scope-manager": "5.33.0",
+				"@typescript-eslint/types": "5.33.0",
+				"@typescript-eslint/typescript-estree": "5.33.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			},
@@ -1099,13 +1099,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.32.0.tgz",
-			"integrity": "sha512-S54xOHZgfThiZ38/ZGTgB2rqx51CMJ5MCfVT2IplK4Q7hgzGfe0nLzLCcenDnc/cSjP568hdeKfeDcBgqNHD/g==",
+			"version": "5.33.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.0.tgz",
+			"integrity": "sha512-/XsqCzD4t+Y9p5wd9HZiptuGKBlaZO5showwqODii5C0nZawxWLF+Q6k5wYHBrQv96h6GYKyqqMHCSTqta8Kiw==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.32.0",
+				"@typescript-eslint/types": "5.33.0",
 				"eslint-visitor-keys": "^3.3.0"
 			},
 			"engines": {
@@ -1766,9 +1766,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001373",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz",
-			"integrity": "sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ==",
+			"version": "1.0.30001374",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001374.tgz",
+			"integrity": "sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -2163,9 +2163,9 @@
 			"dev": true
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.210",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.210.tgz",
-			"integrity": "sha512-kSiX4tuyZijV7Cz0MWVmGT8K2siqaOA4Z66K5dCttPPRh0HicOcOAEj1KlC8O8J1aOS/1M8rGofOzksLKaHWcQ=="
+			"version": "1.4.213",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.213.tgz",
+			"integrity": "sha512-+3DbGHGOCHTVB/Ms63bGqbyC1b8y7Fk86+7ltssB8NQrZtSCvZG6eooSl9U2Q0yw++fL2DpHKOdTU0NVEkFObg=="
 		},
 		"node_modules/emoji-regex": {
 			"version": "9.2.2",
@@ -3794,9 +3794,9 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+			"integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
 			"dev": true,
 			"dependencies": {
 				"has": "^1.0.3"
@@ -4079,14 +4079,14 @@
 			}
 		},
 		"node_modules/jsx-ast-utils": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.2.tgz",
-			"integrity": "sha512-4ZCADZHRkno244xlNnn4AOG6sRQ7iBZ5BbgZ4vW4y5IZw7cVUD1PPeblm1xx/nfmMxPdt/LHsXZW8z/j58+l9Q==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
+			"integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"array-includes": "^3.1.5",
-				"object.assign": "^4.1.2"
+				"object.assign": "^4.1.3"
 			},
 			"engines": {
 				"node": ">=4.0"
@@ -4451,14 +4451,14 @@
 			}
 		},
 		"node_modules/object.assign": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-			"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
+			"integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3",
-				"has-symbols": "^1.0.1",
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"has-symbols": "^1.0.3",
 				"object-keys": "^1.1.1"
 			},
 			"engines": {
@@ -4553,9 +4553,9 @@
 			}
 		},
 		"node_modules/openfin-adapter": {
-			"version": "26.70.16",
-			"resolved": "https://registry.npmjs.org/openfin-adapter/-/openfin-adapter-26.70.16.tgz",
-			"integrity": "sha512-3broSz+y8ydD3V6P8hxNLZ9/hao1zS2yz91tuHDC6sVu5yAn4sioiTVRtNV3Gz+FmFjCt8xQAJh7FkGx3uOeQw==",
+			"version": "26.71.7",
+			"resolved": "https://registry.npmjs.org/openfin-adapter/-/openfin-adapter-26.71.7.tgz",
+			"integrity": "sha512-LlvXiDEMHasqU4aQIgPOTQ7hVOO3BWTnZArmquJlya+CaUrnj2EpIWz875h7UqHl06f9wFhRsMUR4ZAITxtIdA==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "^10.17.19",
@@ -6488,9 +6488,9 @@
 			}
 		},
 		"node_modules/yargs-parser": {
-			"version": "21.1.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.0.tgz",
-			"integrity": "sha512-xzm2t63xTV/f7+bGMSRzLhUNk1ajv/tDoaD5OeGyC3cFo2fl7My9Z4hS3q2VdQ7JaLvTxErO8Jp5pRIFGMD/zg==",
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
@@ -6731,9 +6731,9 @@
 			}
 		},
 		"@openfin/core": {
-			"version": "27.71.6",
-			"resolved": "https://registry.npmjs.org/@openfin/core/-/core-27.71.6.tgz",
-			"integrity": "sha512-38PSHbq9eg7IBQywb/WDnFb5dkbSwvuX+pQr+SBek35YCgbXhUnrAHJpOmbnPWVaLiBoEW6wB08jOg+0q60bjQ==",
+			"version": "27.71.7",
+			"resolved": "https://registry.npmjs.org/@openfin/core/-/core-27.71.7.tgz",
+			"integrity": "sha512-L654iRMmhhgchbCf6Ap0TlLVZ/lfzYMQg6hP5SSGhfYDuJv0pMXTy+5O+xj476qrrSSUQwbh+5sD9dQg9DDnOQ==",
 			"requires": {
 				"lodash": "^4.17.21"
 			}
@@ -6792,9 +6792,9 @@
 			},
 			"dependencies": {
 				"@openfin/core": {
-					"version": "26.70.16",
-					"resolved": "https://registry.npmjs.org/@openfin/core/-/core-26.70.16.tgz",
-					"integrity": "sha512-Y5SHGRu6H05xqHl/dMxp/uMDv/aiOew30gyVQa+fhQ3RyRkayaihbnTlGCX33cz4foK0Q5g27KEYLUgQr7yvWA==",
+					"version": "26.71.7",
+					"resolved": "https://registry.npmjs.org/@openfin/core/-/core-26.71.7.tgz",
+					"integrity": "sha512-TB0Npjrpb+d2vRMWLiS9kiCcLdqGLruzWGXmGIF4NRuuzUi4wGSWi5j7i9prGvPF0kNC6jdnxGMoEqegCVjbZw==",
 					"requires": {
 						"lodash": "^4.17.21"
 					}
@@ -6807,17 +6807,17 @@
 			"integrity": "sha512-86jIv5CcNT8qdodrzMQjV4tbhao8JlzNId+bENh9t8pk1SWZ6WKbJPsNrPI9vcwO8NbjAKOgqlTZauzM7DSSLA=="
 		},
 		"@openfin/workspace": {
-			"version": "9.0.7",
-			"resolved": "https://registry.npmjs.org/@openfin/workspace/-/workspace-9.0.7.tgz",
-			"integrity": "sha512-vBjwfe9JY+wqjhVkkxLHr4MeZQ+wACs51lhpct+D1OJUVJNXrvkS9WoZArl+nkRpfyt6aBC1E2QylfVhYeLEww==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/@openfin/workspace/-/workspace-9.0.9.tgz",
+			"integrity": "sha512-GZwMPUCxtHyQRCmi0Cy7a2MYjBbNrBqPothOZEE/WS7ysLz8CPSVZ1zIB31XgQekymSlNGv0xExPJJ6XvNP98w==",
 			"requires": {
 				"openfin-notifications": "^1.15.0"
 			}
 		},
 		"@openfin/workspace-platform": {
-			"version": "9.0.7",
-			"resolved": "https://registry.npmjs.org/@openfin/workspace-platform/-/workspace-platform-9.0.7.tgz",
-			"integrity": "sha512-ZUW/E97eyNcfNvSCynIr4pHXgw1EcEV6RqBbDlF3Dk+ZnoccfZO6ks5BRxzEhxmV8I/J9AAqeSqv3Xa6Ech9rQ=="
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/@openfin/workspace-platform/-/workspace-platform-9.0.9.tgz",
+			"integrity": "sha512-5BXbVRuc9H4J9P1Wc5X1zyg6Pfk6LwxK84hZi2dW0xY7LyJZ6Bw3TmzWdxv4YkonSTB6D15zj/DHN1cWTKsCzw=="
 		},
 		"@types/auth0-js": {
 			"version": "9.14.6",
@@ -6908,9 +6908,9 @@
 			"dev": true
 		},
 		"@types/mime": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.0.tgz",
-			"integrity": "sha512-fccbsHKqFDXClBZTDLA43zl0+TbxyIwyzIzwwhvoJvhNjOErCdeX2xJbURimv2EbSVUGav001PaCJg4mZxMl4w==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+			"integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
 			"dev": true
 		},
 		"@types/node": {
@@ -6963,15 +6963,15 @@
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.32.0.tgz",
-			"integrity": "sha512-CHLuz5Uz7bHP2WgVlvoZGhf0BvFakBJKAD/43Ty0emn4wXWv5k01ND0C0fHcl/Im8Td2y/7h44E9pca9qAu2ew==",
+			"version": "5.33.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.33.0.tgz",
+			"integrity": "sha512-jHvZNSW2WZ31OPJ3enhLrEKvAZNyAFWZ6rx9tUwaessTc4sx9KmgMNhVcqVAl1ETnT5rU5fpXTLmY9YvC1DCNg==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.32.0",
-				"@typescript-eslint/type-utils": "5.32.0",
-				"@typescript-eslint/utils": "5.32.0",
+				"@typescript-eslint/scope-manager": "5.33.0",
+				"@typescript-eslint/type-utils": "5.33.0",
+				"@typescript-eslint/utils": "5.33.0",
 				"debug": "^4.3.4",
 				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.2.0",
@@ -6981,57 +6981,57 @@
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.32.0.tgz",
-			"integrity": "sha512-IxRtsehdGV9GFQ35IGm5oKKR2OGcazUoiNBxhRV160iF9FoyuXxjY+rIqs1gfnd+4eL98OjeGnMpE7RF/NBb3A==",
+			"version": "5.33.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.33.0.tgz",
+			"integrity": "sha512-cgM5cJrWmrDV2KpvlcSkelTBASAs1mgqq+IUGKJvFxWrapHpaRy5EXPQz9YaKF3nZ8KY18ILTiVpUtbIac86/w==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.32.0",
-				"@typescript-eslint/types": "5.32.0",
-				"@typescript-eslint/typescript-estree": "5.32.0",
+				"@typescript-eslint/scope-manager": "5.33.0",
+				"@typescript-eslint/types": "5.33.0",
+				"@typescript-eslint/typescript-estree": "5.33.0",
 				"debug": "^4.3.4"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.32.0.tgz",
-			"integrity": "sha512-KyAE+tUON0D7tNz92p1uetRqVJiiAkeluvwvZOqBmW9z2XApmk5WSMV9FrzOroAcVxJZB3GfUwVKr98Dr/OjOg==",
+			"version": "5.33.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.33.0.tgz",
+			"integrity": "sha512-/Jta8yMNpXYpRDl8EwF/M8It2A9sFJTubDo0ATZefGXmOqlaBffEw0ZbkbQ7TNDK6q55NPHFshGBPAZvZkE8Pw==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@typescript-eslint/types": "5.32.0",
-				"@typescript-eslint/visitor-keys": "5.32.0"
+				"@typescript-eslint/types": "5.33.0",
+				"@typescript-eslint/visitor-keys": "5.33.0"
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.32.0.tgz",
-			"integrity": "sha512-0gSsIhFDduBz3QcHJIp3qRCvVYbqzHg8D6bHFsDMrm0rURYDj+skBK2zmYebdCp+4nrd9VWd13egvhYFJj/wZg==",
+			"version": "5.33.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.33.0.tgz",
+			"integrity": "sha512-2zB8uEn7hEH2pBeyk3NpzX1p3lF9dKrEbnXq1F7YkpZ6hlyqb2yZujqgRGqXgRBTHWIUG3NGx/WeZk224UKlIA==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@typescript-eslint/utils": "5.32.0",
+				"@typescript-eslint/utils": "5.33.0",
 				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.32.0.tgz",
-			"integrity": "sha512-EBUKs68DOcT/EjGfzywp+f8wG9Zw6gj6BjWu7KV/IYllqKJFPlZlLSYw/PTvVyiRw50t6wVbgv4p9uE2h6sZrQ==",
+			"version": "5.33.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.33.0.tgz",
+			"integrity": "sha512-nIMt96JngB4MYFYXpZ/3ZNU4GWPNdBbcB5w2rDOCpXOVUkhtNlG2mmm8uXhubhidRZdwMaMBap7Uk8SZMU/ppw==",
 			"dev": true,
 			"peer": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.32.0.tgz",
-			"integrity": "sha512-ZVAUkvPk3ITGtCLU5J4atCw9RTxK+SRc6hXqLtllC2sGSeMFWN+YwbiJR9CFrSFJ3w4SJfcWtDwNb/DmUIHdhg==",
+			"version": "5.33.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.33.0.tgz",
+			"integrity": "sha512-tqq3MRLlggkJKJUrzM6wltk8NckKyyorCSGMq4eVkyL5sDYzJJcMgZATqmF8fLdsWrW7OjjIZ1m9v81vKcaqwQ==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@typescript-eslint/types": "5.32.0",
-				"@typescript-eslint/visitor-keys": "5.32.0",
+				"@typescript-eslint/types": "5.33.0",
+				"@typescript-eslint/visitor-keys": "5.33.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -7040,28 +7040,28 @@
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.32.0.tgz",
-			"integrity": "sha512-W7lYIAI5Zlc5K082dGR27Fczjb3Q57ECcXefKU/f0ajM5ToM0P+N9NmJWip8GmGu/g6QISNT+K6KYB+iSHjXCQ==",
+			"version": "5.33.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.33.0.tgz",
+			"integrity": "sha512-JxOAnXt9oZjXLIiXb5ZIcZXiwVHCkqZgof0O8KPgz7C7y0HS42gi75PdPlqh1Tf109M0fyUw45Ao6JLo7S5AHw==",
 			"dev": true,
 			"peer": true,
 			"requires": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.32.0",
-				"@typescript-eslint/types": "5.32.0",
-				"@typescript-eslint/typescript-estree": "5.32.0",
+				"@typescript-eslint/scope-manager": "5.33.0",
+				"@typescript-eslint/types": "5.33.0",
+				"@typescript-eslint/typescript-estree": "5.33.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.32.0.tgz",
-			"integrity": "sha512-S54xOHZgfThiZ38/ZGTgB2rqx51CMJ5MCfVT2IplK4Q7hgzGfe0nLzLCcenDnc/cSjP568hdeKfeDcBgqNHD/g==",
+			"version": "5.33.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.0.tgz",
+			"integrity": "sha512-/XsqCzD4t+Y9p5wd9HZiptuGKBlaZO5showwqODii5C0nZawxWLF+Q6k5wYHBrQv96h6GYKyqqMHCSTqta8Kiw==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@typescript-eslint/types": "5.32.0",
+				"@typescript-eslint/types": "5.33.0",
 				"eslint-visitor-keys": "^3.3.0"
 			}
 		},
@@ -7577,9 +7577,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001373",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz",
-			"integrity": "sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ=="
+			"version": "1.0.30001374",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001374.tgz",
+			"integrity": "sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw=="
 		},
 		"chalk": {
 			"version": "4.1.2",
@@ -7872,9 +7872,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.4.210",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.210.tgz",
-			"integrity": "sha512-kSiX4tuyZijV7Cz0MWVmGT8K2siqaOA4Z66K5dCttPPRh0HicOcOAEj1KlC8O8J1aOS/1M8rGofOzksLKaHWcQ=="
+			"version": "1.4.213",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.213.tgz",
+			"integrity": "sha512-+3DbGHGOCHTVB/Ms63bGqbyC1b8y7Fk86+7ltssB8NQrZtSCvZG6eooSl9U2Q0yw++fL2DpHKOdTU0NVEkFObg=="
 		},
 		"emoji-regex": {
 			"version": "9.2.2",
@@ -9084,9 +9084,9 @@
 			"dev": true
 		},
 		"is-core-module": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+			"integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -9291,14 +9291,14 @@
 			}
 		},
 		"jsx-ast-utils": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.2.tgz",
-			"integrity": "sha512-4ZCADZHRkno244xlNnn4AOG6sRQ7iBZ5BbgZ4vW4y5IZw7cVUD1PPeblm1xx/nfmMxPdt/LHsXZW8z/j58+l9Q==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
+			"integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
 			"dev": true,
 			"peer": true,
 			"requires": {
 				"array-includes": "^3.1.5",
-				"object.assign": "^4.1.2"
+				"object.assign": "^4.1.3"
 			}
 		},
 		"kind-of": {
@@ -9572,14 +9572,14 @@
 			"dev": true
 		},
 		"object.assign": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-			"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
+			"integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3",
-				"has-symbols": "^1.0.1",
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"has-symbols": "^1.0.3",
 				"object-keys": "^1.1.1"
 			}
 		},
@@ -9647,9 +9647,9 @@
 			}
 		},
 		"openfin-adapter": {
-			"version": "26.70.16",
-			"resolved": "https://registry.npmjs.org/openfin-adapter/-/openfin-adapter-26.70.16.tgz",
-			"integrity": "sha512-3broSz+y8ydD3V6P8hxNLZ9/hao1zS2yz91tuHDC6sVu5yAn4sioiTVRtNV3Gz+FmFjCt8xQAJh7FkGx3uOeQw==",
+			"version": "26.71.7",
+			"resolved": "https://registry.npmjs.org/openfin-adapter/-/openfin-adapter-26.71.7.tgz",
+			"integrity": "sha512-LlvXiDEMHasqU4aQIgPOTQ7hVOO3BWTnZArmquJlya+CaUrnj2EpIWz875h7UqHl06f9wFhRsMUR4ZAITxtIdA==",
 			"dev": true,
 			"requires": {
 				"@types/node": "^10.17.19",
@@ -9674,8 +9674,8 @@
 			"version": "file:how-to/common",
 			"requires": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"@types/express": "^4.17.11",
 				"@types/node": "^17.0.41",
 				"express": "^4.17.1",
@@ -9690,8 +9690,8 @@
 			"version": "file:how-to/customize-home-templates",
 			"requires": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"@types/express": "^4.17.13",
 				"@types/luxon": "^2.3.2",
 				"@types/node": "^17.0.41",
@@ -9713,8 +9713,8 @@
 				"@openfin/core": "^27.70.8",
 				"@openfin/salesforce": "^2.1.3",
 				"@openfin/salesforce-lwc": "^1.1.1",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"@types/express": "^4.17.13",
 				"@types/node": "^17.0.41",
 				"csstype": "^3.0.11",
@@ -9729,8 +9729,8 @@
 			"version": "file:how-to/integrate-server-authentication",
 			"requires": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"@types/auth0-js": "^9.14.6",
 				"@types/express": "^4.17.13",
 				"@types/node": "^17.0.41",
@@ -9747,8 +9747,8 @@
 			"requires": {
 				"@openfin/core": "^27.70.8",
 				"@openfin/excel": "^1.3.0",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"@types/express": "^4.17.13",
 				"@types/node": "^17.0.41",
 				"express": "^4.18.1",
@@ -9762,8 +9762,8 @@
 			"version": "file:how-to/integrate-with-rss",
 			"requires": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"@types/express": "^4.17.13",
 				"@types/node": "^17.0.41",
 				"@types/node-fetch": "^2.6.2",
@@ -9784,8 +9784,8 @@
 				"@openfin/core": "^27.70.8",
 				"@openfin/salesforce": "^2.1.3",
 				"@openfin/salesforce-lwc": "^1.1.1",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"@types/express": "^4.17.13",
 				"@types/node": "^17.0.41",
 				"copy-webpack-plugin": "^11.0.0",
@@ -9801,8 +9801,8 @@
 			"version": "file:how-to/integrate-with-sso",
 			"requires": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"@types/auth0-js": "^9.14.6",
 				"@types/express": "^4.17.13",
 				"@types/node": "^17.0.41",
@@ -9818,8 +9818,8 @@
 			"version": "file:how-to/register-with-browser",
 			"requires": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"@types/express": "^4.17.13",
 				"@types/node": "^17.0.41",
 				"express": "^4.18.1",
@@ -9834,8 +9834,8 @@
 			"version": "file:how-to/register-with-dock-basic",
 			"requires": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"@types/express": "^4.17.13",
 				"@types/node": "^17.0.41",
 				"express": "^4.18.1",
@@ -9850,8 +9850,8 @@
 			"version": "file:how-to/register-with-home",
 			"requires": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"@types/express": "^4.17.13",
 				"@types/node": "^17.0.41",
 				"express": "^4.18.1",
@@ -9865,8 +9865,8 @@
 			"version": "file:how-to/register-with-home-basic",
 			"requires": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"@types/express": "^4.17.13",
 				"@types/node": "^17.0.41",
 				"express": "^4.18.1",
@@ -9880,8 +9880,8 @@
 			"version": "file:how-to/register-with-platform-windows",
 			"requires": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"@types/express": "^4.17.11",
 				"@types/node": "^17.0.41",
 				"express": "^4.17.1",
@@ -9896,8 +9896,8 @@
 			"version": "file:how-to/register-with-store",
 			"requires": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"@types/express": "^4.17.13",
 				"@types/node": "^17.0.41",
 				"express": "^4.18.1",
@@ -9912,8 +9912,8 @@
 			"version": "file:how-to/register-with-store-basic",
 			"requires": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"@types/express": "^4.17.13",
 				"@types/node": "^17.0.41",
 				"express": "^4.18.1",
@@ -9927,8 +9927,8 @@
 			"version": "file:how-to/support-context-and-intents",
 			"requires": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"@types/express": "^4.17.13",
 				"@types/node": "^17.0.41",
 				"express": "^4.18.1",
@@ -9942,7 +9942,7 @@
 			"version": "file:how-to/use-notifications",
 			"requires": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
+				"@openfin/workspace": "9.0.9",
 				"@types/express": "^4.17.13",
 				"@types/node": "^17.0.41",
 				"csstype": "^3.0.11",
@@ -9957,7 +9957,7 @@
 			"version": "file:how-to/use-theming",
 			"requires": {
 				"@openfin/core": "^27.70.8",
-				"@openfin/workspace": "next",
+				"@openfin/workspace": "9.0.9",
 				"@types/express": "^4.17.13",
 				"@types/node": "^17.0.41",
 				"express": "^4.18.1",
@@ -9972,8 +9972,8 @@
 			"requires": {
 				"@openfin/core": "^27.70.8",
 				"@openfin/native-window-integration-client": "0.0.13",
-				"@openfin/workspace": "next",
-				"@openfin/workspace-platform": "next",
+				"@openfin/workspace": "9.0.9",
+				"@openfin/workspace-platform": "9.0.9",
 				"@types/express": "^4.17.13",
 				"@types/node": "^17.0.41",
 				"express": "^4.18.1",
@@ -11293,9 +11293,9 @@
 			}
 		},
 		"yargs-parser": {
-			"version": "21.1.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.0.tgz",
-			"integrity": "sha512-xzm2t63xTV/f7+bGMSRzLhUNk1ajv/tDoaD5OeGyC3cFo2fl7My9Z4hS3q2VdQ7JaLvTxErO8Jp5pRIFGMD/zg==",
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
 			"dev": true
 		},
 		"yocto-queue": {


### PR DESCRIPTION
Updated the version number to start moving away from next. The main package.json still has a custom how-to path and that will stay until the official release. Updated the migration guide, updated process manager to use the new version. Updated preview images and updated Migration Guide to highlight some of the changes. Also pulled in Adam's update to the excel demo so it doesn't get lost when vnext becomes main.