### PR TITLE
Added ability for connected apps to specify an app to launch if they …

### DIFF
--- a/how-to/customize-workspace/client/src/launch.ts
+++ b/how-to/customize-workspace/client/src/launch.ts
@@ -254,6 +254,16 @@ export async function launch(appEntry: App) {
 			appEntry.manifestType === manifestTypes.inlineWindow.id
 		) {
 			await launchWindow(appEntry);
+		} else if (appEntry.manifestType === manifestTypes.inlineExternal.id) {
+			console.log(
+				"Application requested is a native app defined as inline-external. Managing request via platform and not Workspace."
+			);
+			try {
+				const options = appEntry.manifest as OpenFin.ExternalProcessRequestType;
+				await fin.System.launchExternalProcess(options);
+			} catch (err) {
+				console.error(`Error trying to launch inline-external with appId: ${appEntry.appId}`, err);
+			}
 		} else if (appEntry.manifestType === manifestTypes.desktopBrowser.id) {
 			await fin.System.openUrlWithBrowser(appEntry.manifest);
 		} else if (appEntry.manifestType === manifestTypes.endpoint.id) {

--- a/how-to/customize-workspace/client/src/manifest-types.ts
+++ b/how-to/customize-workspace/client/src/manifest-types.ts
@@ -25,6 +25,12 @@ export const manifestTypes: { [id: string]: ManifestType } = {
 		description:
 			"This manifest type expects the manifest setting to have the classic window options inline rather than a url to a json file."
 	},
+	inlineExternal: {
+		id: "inline-external",
+		label: "Native App",
+		description:
+			"This manifest type expects the manifest setting to point to an exe or an app asset name using an inline launch external process request."
+	},
 	snapshot: {
 		id: "snapshot",
 		label: "Snapshot",


### PR DESCRIPTION
…are not running

Connected apps now have the option of specify an app entry in the snapshot if they are not running. This is something that would be launched by the platform. The saving app can decide what to pass in order to help rehydrate itself.

Example manifest entry:

"connectionProvider": {
			"connectionId": "workspace-connection",
			"supportedActions": [
				"show-home",
				"show-store",
				"show-dock",
				"hide-home",
				"hide-store",
				"minimize-dock"
			],
			"connections": [
				{
					"identity": { "uuid": "openfin-dotnet6-wpf-test-harness" },
					"validatePayload": false,
					"connectionTypes": [{ "type": "appSource" }, { "type": "snapshotSource" }, { "type": "actions" }]
				},
				{
					"identity": { "uuid": "openfin-dotnet4-winform-test-harness" },
					"validatePayload": false,
					"connectionTypes": [{ "type": "appSource" }, { "type": "snapshotSource" }, { "type": "actions" }]
				}
			]
		},

The supported manifest types would need to include the followng:

"connection",
"inline-external"