### PR TITLE
Added an app endpoint mapping pattern

### DIFF
--- a/how-to/customize-workspace/client/src/framework/apps.ts
+++ b/how-to/customize-workspace/client/src/framework/apps.ts
@@ -3,14 +3,14 @@ import { getConnectedApps } from "./connections";
 import { createLogger } from "./logger-provider";
 import { manifestTypes } from "./manifest-types";
 import type { EndpointProvider } from "./shapes/endpoint-shapes";
-import type { AppProviderOptions } from "./shapes/framework-shapes";
+import type { AppEndpointOptions, AppProviderOptions } from "./shapes/framework-shapes";
 
 const logger = createLogger("Apps");
 
 let cachedApps: App[];
 let endpoints: EndpointProvider;
 let cacheDuration = 0;
-let endpointIds: string[] = [];
+let endpointIds: AppEndpointOptions[] = [];
 let isInitialized = false;
 let defaultCredentials: "omit" | "same-origin" | "include";
 let appAssetTag: string = "appasset";
@@ -90,7 +90,7 @@ async function validateEntries(apps: App[]) {
 }
 
 async function getEntries(
-	source: string[],
+	source: string[] | AppEndpointOptions[],
 	credentials?: "omit" | "same-origin" | "include",
 	cache?: number
 ): Promise<App[]> {
@@ -100,19 +100,58 @@ async function getEntries(
 	}
 	const apps: App[] = [];
 
-	for (let i = 0; i < endpointIds.length; i++) {
-		const endpointId = endpointIds[i];
+	for (let i = 0; i < source.length; i++) {
+		const endpoint = source[i];
 		try {
-			if (endpoints.hasEndpoint(endpointId)) {
-				const results = await endpoints.requestResponse<never, App[]>(endpointId);
+			if (typeof endpoint === "string") {
+				if (endpoints.hasEndpoint(endpoint)) {
+					logger.info(`Fetching apps from source: ${endpoint}`);
+					const results = await endpoints.requestResponse<never, App[]>(endpoint);
+					logger.info(`${results.length} app(s) received.`);
+					apps.push(...results);
+				} else if (endpoint.startsWith("http")) {
+					logger.info(`Fetching apps from url: ${endpoint}`);
+					const resp = await fetch(endpoint, options);
+					const jsonResults: App[] = await resp.json();
+					logger.info(`${jsonResults.length} app(s) received.`);
+					apps.push(...jsonResults);
+				} else {
+					logger.warn(
+						`Endpoint provided ${endpoint} that is not an available endpoint or a url. Unable to fetch apps.`
+					);
+				}
+			} else if (endpoint?.inputId !== undefined && endpoint?.outputId !== undefined) {
+				if (endpoints.hasEndpoint(endpoint.inputId) && endpoints.hasEndpoint(endpoint.outputId)) {
+					logger.info(
+						`Mapping from App Source: ${endpoint.inputId} to Platform App using: ${endpoint.outputId}`
+					);
+					const inputResults = await endpoints.requestResponse<never, unknown[]>(endpoint.inputId);
+					logger.info(`Received ${inputResults.length} result(s) from ${endpoint.inputId}.`);
+					const outputResults = await endpoints.requestResponse<unknown, App[]>(
+						endpoint.outputId,
+						inputResults
+					);
+					logger.info(`Mapped ${outputResults.length} app(s) using ${endpoint.outputId}`);
+					apps.push(...outputResults);
+				} else {
+					logger.warn(
+						`Unable to mapping from App Source: ${endpoint.inputId} to Platform App using: ${endpoint.outputId} as one or both of the endpoints are not defined.`
+					);
+				}
+			} else if (endpoint?.inputId !== undefined && endpoints.hasEndpoint(endpoint?.inputId)) {
+				logger.info(`Fetching apps from source: ${endpoint.inputId}`);
+				const results = await endpoints.requestResponse<never, App[]>(endpoint.inputId);
+				logger.info(`${results.length} app(s) received.`);
 				apps.push(...results);
 			} else {
-				const resp = await fetch(endpointId, options);
-				const jsonResults: App[] = await resp.json();
-				apps.push(...jsonResults);
+				logger.warn(
+					`Endpoint provided ${JSON.stringify(
+						endpoint
+					)} cannot be resolved. Please ensure that ids are provided and available.`
+				);
 			}
 		} catch (error) {
-			logger.error(`Error fetching apps from endpoint ${endpointId}`, error);
+			logger.error(`Error fetching apps from endpoint ${JSON.stringify(endpoint)}`, error);
 		}
 	}
 

--- a/how-to/customize-workspace/client/src/framework/shapes/framework-shapes.ts
+++ b/how-to/customize-workspace/client/src/framework/shapes/framework-shapes.ts
@@ -138,10 +138,16 @@ interface DockProviderOptions {
 interface ThemeProviderOptions {
 	themes: CustomThemes;
 }
+export type AppEndpointOptions =
+	| string
+	| {
+			inputId: string;
+			outputId?: string;
+	  };
 
 export interface AppProviderOptions {
 	appsSourceUrl?: string | string[];
-	endpointIds?: string[];
+	endpointIds?: AppEndpointOptions[];
 	includeCredentialOnSourceRequest?: "omit" | "same-origin" | "include";
 	cacheDurationInMinutes?: number;
 	cacheDurationInSeconds?: number;

--- a/how-to/customize-workspace/client/src/modules/endpoints/fdc3-app/endpoint.ts
+++ b/how-to/customize-workspace/client/src/modules/endpoints/fdc3-app/endpoint.ts
@@ -28,7 +28,7 @@ export async function requestResponse(
 		);
 		return results;
 	}
-	const fdc3Version = endpointDefinition?.options?.fdc3Version || "1.2";
+	const fdc3Version = endpointDefinition?.options?.fdc3Version ?? "1.2";
 	let applications;
 
 	if (Array.isArray(request)) {

--- a/how-to/customize-workspace/client/src/modules/endpoints/fdc3-app/endpoint.ts
+++ b/how-to/customize-workspace/client/src/modules/endpoints/fdc3-app/endpoint.ts
@@ -1,0 +1,83 @@
+import type { App } from "@openfin/workspace";
+import type { EndpointDefinition } from "customize-workspace/shapes/endpoint-shapes";
+import type { Logger, LoggerCreator } from "customize-workspace/shapes/logger-shapes";
+import type { ModuleDefinition } from "customize-workspace/shapes/module-shapes";
+import * as fdc3OnePointTwoHelper from "./fdc3-1-2-helper";
+import type { AppDefinition as AppDefinitionOnePointTwo } from "./fdc3-1-2-shapes";
+import * as fdc3TwoPointZeroHelper from "./fdc3-2-0-helper";
+import type { AppDefinition as AppDefinitionTwoPointZero } from "./fdc3-2-0-shapes";
+
+let logger: Logger;
+
+export async function initialize(definition: ModuleDefinition, createLogger: LoggerCreator, helpers?: never) {
+	logger = createLogger("FDC3 App Mapper");
+	logger.info("Was passed the following options", definition.data);
+}
+
+export async function requestResponse(
+	endpointDefinition: EndpointDefinition<{
+		fdc3Version: string;
+	}>,
+	request?: unknown[] | { applications: unknown[] }
+): Promise<App[]> {
+	const results: App[] = [];
+
+	if (endpointDefinition.type !== "module") {
+		logger.warn(
+			`We only expect endpoints of type module. Unable to action request/response for: ${endpointDefinition.id}`
+		);
+		return results;
+	}
+	const fdc3Version = endpointDefinition?.options?.fdc3Version || "1.2";
+	let applications;
+
+	if (Array.isArray(request)) {
+		applications = request;
+	} else {
+		applications = request.applications;
+	}
+	if (fdc3Version === "1.2") {
+		for (let i = 0; i < applications.length; i++) {
+			const passedApp: AppDefinitionOnePointTwo = applications[i] as AppDefinitionOnePointTwo;
+			const platformApp: App = {
+				appId: passedApp.appId,
+				title: passedApp.title || passedApp.name,
+				manifestType: passedApp.manifestType,
+				manifest: fdc3OnePointTwoHelper.getManifest(passedApp) as string,
+				description: passedApp.description,
+				intents: passedApp.intents,
+				tags: [passedApp.manifestType],
+				version: passedApp.version,
+				publisher: passedApp.publisher,
+				contactEmail: passedApp.contactEmail,
+				supportEmail: passedApp.supportEmail,
+				icons: fdc3OnePointTwoHelper.getIcons(passedApp.icons),
+				images: fdc3OnePointTwoHelper.getImages(passedApp.images)
+			};
+			results.push(platformApp);
+		}
+	} else if (fdc3Version === "2.0") {
+		for (let i = 0; i < applications.length; i++) {
+			const passedApp: AppDefinitionTwoPointZero = applications[i] as AppDefinitionTwoPointZero;
+			const platformApp: App = {
+				appId: passedApp.appId,
+				title: passedApp.title || passedApp.name,
+				manifestType: fdc3TwoPointZeroHelper.getManifestType(passedApp),
+				manifest: fdc3TwoPointZeroHelper.getManifest(passedApp) as string,
+				description: passedApp.description,
+				intents: fdc3TwoPointZeroHelper.getIntents(passedApp),
+				tags: passedApp.categories,
+				version: passedApp.version,
+				publisher: passedApp.publisher,
+				contactEmail: passedApp.contactEmail,
+				supportEmail: passedApp.supportEmail,
+				icons: passedApp.icons,
+				images: passedApp.screenshots
+			};
+			results.push(platformApp);
+		}
+	} else {
+		logger.warn(`Unsupported FDC3 version passed: ${fdc3Version}. Unable to map apps.`);
+	}
+	return results;
+}

--- a/how-to/customize-workspace/client/src/modules/endpoints/fdc3-app/fdc3-1-2-helper.ts
+++ b/how-to/customize-workspace/client/src/modules/endpoints/fdc3-app/fdc3-1-2-helper.ts
@@ -3,7 +3,7 @@ import type { AppDefinition, AppIcon, AppImage } from "./fdc3-1-2-shapes";
 
 export function getIcons(icons: AppIcon[]): Image[] {
 	const appIcons: Image[] = [];
-	if (icons === undefined) {
+	if (!Array.isArray(icons)) {
 		return appIcons;
 	}
 	for (const appIcon of icons) {
@@ -14,7 +14,7 @@ export function getIcons(icons: AppIcon[]): Image[] {
 
 export function getImages(images: AppImage[]): Image[] {
 	const appImages: Image[] = [];
-	if (images === undefined) {
+	if (!Array.isArray(images)) {
 		return appImages;
 	}
 	for (const appImage of images) {

--- a/how-to/customize-workspace/client/src/modules/endpoints/fdc3-app/fdc3-1-2-helper.ts
+++ b/how-to/customize-workspace/client/src/modules/endpoints/fdc3-app/fdc3-1-2-helper.ts
@@ -1,0 +1,32 @@
+import type { Image } from "@openfin/workspace";
+import type { AppDefinition, AppIcon, AppImage } from "./fdc3-1-2-shapes";
+
+export function getIcons(icons: AppIcon[]): Image[] {
+	const appIcons: Image[] = [];
+	if (icons === undefined) {
+		return appIcons;
+	}
+	for (const appIcon of icons) {
+		appIcons.push({ src: appIcon.icon });
+	}
+	return appIcons;
+}
+
+export function getImages(images: AppImage[]): Image[] {
+	const appImages: Image[] = [];
+	if (images === undefined) {
+		return appImages;
+	}
+	for (const appImage of images) {
+		appImages.push({ src: appImage.url });
+	}
+	return appImages;
+}
+
+export function getManifest(app: AppDefinition): unknown {
+	if (typeof app.manifest === "string" && app.manifest.startsWith("{")) {
+		return JSON.parse(app.manifest);
+	}
+
+	return app.manifest;
+}

--- a/how-to/customize-workspace/client/src/modules/endpoints/fdc3-app/fdc3-1-2-shapes.ts
+++ b/how-to/customize-workspace/client/src/modules/endpoints/fdc3-app/fdc3-1-2-shapes.ts
@@ -1,0 +1,32 @@
+export interface AppImage {
+	url: string;
+}
+
+export interface AppIcon {
+	icon: string;
+}
+
+export interface AppIntents {
+	name: string;
+	displayName: string;
+	contexts: string[];
+	customConfig: { [key: string]: unknown };
+}
+
+export interface AppDefinition {
+	appId: string;
+	name: string;
+	manifest: string;
+	manifestType: string;
+	version?: string;
+	title?: string;
+	tooltip?: string;
+	description?: string;
+	images: AppImage[];
+	contactEmail: string;
+	supportEmail: string;
+	publisher: string;
+	icons: AppIcon[];
+	customConfig: { [key: string]: unknown };
+	intents?: AppIntents[];
+}

--- a/how-to/customize-workspace/client/src/modules/endpoints/fdc3-app/fdc3-2-0-helper.ts
+++ b/how-to/customize-workspace/client/src/modules/endpoints/fdc3-app/fdc3-2-0-helper.ts
@@ -1,0 +1,92 @@
+import type { AppIntent } from "@openfin/workspace";
+import type {
+	AppDefinition,
+	WebAppDetails,
+	NativeAppDetails,
+	OnlineNativeAppDetails
+} from "./fdc3-2-0-shapes";
+
+export function getManifestType(app: AppDefinition): string {
+	let manifestType: string;
+
+	switch (app.type) {
+		case "web": {
+			manifestType = "inline-view";
+			break;
+		}
+		case "native": {
+			manifestType = "inline-external";
+			break;
+		}
+		case "onlineNative": {
+			manifestType = "desktop-browser";
+			break;
+		}
+		case "other": {
+			manifestType = app.hostManifests?.OpenFin?.type;
+			break;
+		}
+		default: {
+			manifestType = app.type;
+		}
+	}
+	return manifestType;
+}
+
+export function getManifest(app: AppDefinition): unknown {
+	let manifest: string | unknown;
+
+	switch (app.type) {
+		case "web": {
+			if (app?.details !== undefined) {
+				// return fdc3InteropApi 1.2 as the platform currently supports that.
+				manifest = {
+					url: (app?.details as WebAppDetails).url,
+					fdc3InteropApi: "1.2"
+				};
+			}
+			break;
+		}
+		case "native": {
+			if (app?.details !== undefined) {
+				// our native api supports path and arguments.
+				manifest = app.details as NativeAppDetails;
+			}
+			break;
+		}
+		case "onlineNative": {
+			if (app?.details !== undefined) {
+				manifest = (app?.details as OnlineNativeAppDetails).url;
+			}
+			break;
+		}
+		case "other": {
+			manifest = app.hostManifests?.OpenFin?.details;
+			break;
+		}
+		default: {
+			manifest = app.details;
+		}
+	}
+	return manifest;
+}
+
+export function getIntents(app: AppDefinition): AppIntent[] {
+	const intents: AppIntent[] = [];
+
+	if (app?.interop?.intents?.listensFor === undefined) {
+		return intents;
+	}
+
+	const intentIds = Object.keys(app.interop.intents.listensFor);
+	for (let i = 0; i < intentIds.length; i++) {
+		const intentName = intentIds[i];
+		intents.push({
+			name: intentName,
+			displayName: app.interop.intents.listensFor[intentName].displayName,
+			contexts: app.interop.intents.listensFor[intentName].contexts
+		});
+	}
+
+	return intents;
+}

--- a/how-to/customize-workspace/client/src/modules/endpoints/fdc3-app/fdc3-2-0-shapes.ts
+++ b/how-to/customize-workspace/client/src/modules/endpoints/fdc3-app/fdc3-2-0-shapes.ts
@@ -1,0 +1,67 @@
+interface Image {
+	src: string;
+	size?: string;
+	type?: string;
+}
+export type Icon = Image;
+
+export interface Screenshot extends Image {
+	label?: string;
+}
+
+export interface WebAppDetails {
+	url: string;
+}
+
+export interface NativeAppDetails {
+	path: string;
+	arguments?: string;
+}
+
+export interface OnlineNativeAppDetails {
+	url: string;
+}
+
+export interface AppIntents {
+	displayName?: string;
+	contexts: string[];
+	resultType?: string;
+	customConfig?: { [key: string]: unknown };
+}
+
+export interface AppDefinition {
+	appId: string;
+	name: string;
+	title?: string;
+	description?: string;
+	categories?: string[];
+	version?: string;
+	tooltip?: string;
+	lang?: string;
+	icons: Icon[];
+	screenshots?: Screenshot[];
+	contactEmail?: string;
+	supportEmail?: string;
+	moreInfo?: string;
+	publisher?: string;
+	type: string;
+	details: unknown;
+	customConfig?: { [key: string]: unknown };
+	hostManifests?: { OpenFin: { type: string; details: unknown } };
+	interop?: {
+		intents?: {
+			listensFor?: {
+				[key: string]: AppIntents;
+			};
+			raises?: {
+				[key: string]: string;
+			};
+		};
+		userChannels?: {
+			broadcasts?: string[];
+			listensFor?: string[];
+		};
+		appChannels?: { name: string; description?: string; broadcasts?: string[]; listensFor?: string[] }[];
+	};
+	localizedVersions?: { [key: string]: { [key: string]: string } };
+}

--- a/how-to/customize-workspace/client/src/modules/endpoints/fdc3-app/index.ts
+++ b/how-to/customize-workspace/client/src/modules/endpoints/fdc3-app/index.ts
@@ -1,0 +1,6 @@
+import type { ModuleImplementation, ModuleTypes } from "customize-workspace/shapes/module-shapes";
+import * as endpointImplementation from "./endpoint";
+
+export const entryPoints: { [type in ModuleTypes]?: ModuleImplementation } = {
+	endpoint: endpointImplementation
+};

--- a/how-to/customize-workspace/client/webpack.config.js
+++ b/how-to/customize-workspace/client/webpack.config.js
@@ -130,6 +130,33 @@ module.exports = [
 		}
 	},
 	{
+		entry: './client/src/modules/endpoints/fdc3-app/index.ts',
+		devtool: 'inline-source-map',
+		module: {
+			rules: [
+				{
+					test: /\.tsx?$/,
+					use: 'ts-loader',
+					exclude: /node_modules/
+				}
+			]
+		},
+		resolve: {
+			extensions: ['.tsx', '.ts', '.js']
+		},
+		externals: { fin: 'fin' },
+		output: {
+			filename: 'fdc3-app.bundle.js',
+			library: {
+				type: 'module'
+			},
+			path: path.resolve(__dirname, '..', 'public', 'js', 'modules', 'endpoints')
+		},
+		experiments: {
+			outputModule: true
+		}
+	},
+	{
 		entry: './client/src/modules/init-options/interop/index.ts',
 		devtool: 'inline-source-map',
 		module: {

--- a/how-to/customize-workspace/docs/how-to-define-apps.md
+++ b/how-to/customize-workspace/docs/how-to-define-apps.md
@@ -186,7 +186,7 @@ You would define two endpoints. One endpoint takes the source apps and the secon
             "type": "fetch",
             "options": {
                 "method": "GET",
-                "url": "http://localhost:8080/fdc3-apps.json"
+                "url": "https://yourserver.com/fdc3/1.2/apps"
             }
         },
         {

--- a/how-to/customize-workspace/docs/how-to-define-apps.md
+++ b/how-to/customize-workspace/docs/how-to-define-apps.md
@@ -182,21 +182,21 @@ You would define two endpoints. One endpoint takes the source apps and the secon
     ],
     "endpoints": [
         {
-     "id": "fdc3-in",
-     "type": "fetch",
-     "options": {
-      "method": "GET",
-      "url": "http://localhost:8080/fdc3-apps.json"
-     }
-    },
-    {
-     "id": "fdc3-out",
-     "type": "module",
-     "typeId": "fdc3-app",
-     "options": {
-      "fdc3Version": "1.2"
-     }
-  },
+            "id": "fdc3-in",
+            "type": "fetch",
+            "options": {
+                "method": "GET",
+                "url": "http://localhost:8080/fdc3-apps.json"
+            }
+        },
+        {
+            "id": "fdc3-out",
+            "type": "module",
+            "typeId": "fdc3-app",
+            "options": {
+                "fdc3Version": "1.2"
+            }
+        }
     ]
 },
 ```

--- a/how-to/customize-workspace/docs/how-to-define-endpoints.md
+++ b/how-to/customize-workspace/docs/how-to-define-endpoints.md
@@ -79,7 +79,8 @@ To learn more about how to modules see [How To Add A Module](./how-to-add-a-modu
 We include two examples of endpoint modules in the modules folder:
 
 - local-storage - shows how you can have an endpoint that can save and fetch from local storage
-- channel - lets you provide endpoint settings that specify a channel api you wish to connect to and whether you wish to pass a payload and return (action) or perform a requestResponse and get something back from the channel.
+- channel - lets you provide endpoint settings that specify a channel api you wish to connect to and whether you wish to pass a payload and return (action) or perform a requestResponse and get something back from the channel
+- fdc3-app - can be used to transform an array of fdc3 1.2 or 2.0 apps into platform apps. Generally used when importing apps from one or more app directories (see [how to define apps](./how-to-define-apps.md))
 
 Endpoints can be defined as:
 
@@ -96,5 +97,6 @@ Endpoints can be defined as:
 - [endpoint-shapes.ts](../client/src/framework/shapes/endpoint-shapes.ts)
 - local-storage [endpoint](../client/src/modules/endpoints/local-storage/endpoint.ts)
 - channel [endpoint](../client/src/modules/endpoints/channel/endpoint.ts)
+- fdc3-app [endpoint](../client/src/modules/endpoints/fdc3-app/endpoint.ts)
 
 [<- Back to Table Of Contents](../README.md)

--- a/how-to/customize-workspace/public/manifest.fin.json
+++ b/how-to/customize-workspace/public/manifest.fin.json
@@ -98,7 +98,8 @@
 				"inline-view",
 				"window",
 				"inline-window",
-				"desktop-browser"
+				"desktop-browser",
+				"inline-external"
 			]
 		},
 		"endpointProvider": {

--- a/how-to/customize-workspace/public/settings.json
+++ b/how-to/customize-workspace/public/settings.json
@@ -45,7 +45,8 @@
 			"inline-view",
 			"window",
 			"inline-window",
-			"desktop-browser"
+			"desktop-browser",
+			"inline-external"
 		]
 	},
 	"endpointProvider": {


### PR DESCRIPTION
Added the ability to specify that you wish to map apps from one format to the platform's format. Added an endpoint module that looks at the shape of fdc3 1.2 and 2.0 apps and takes the required information and maps it onto our platform app shape.

Also added ability to support inline-external for cases where the fdc3 2.0 type native was specified.