### PR TITLE
csstype was missing from common

### DIFF
--- a/how-to/common/package.json
+++ b/how-to/common/package.json
@@ -25,7 +25,8 @@
 	"dependencies": {
 		"@openfin/core": "^27.70.8",
 		"@openfin/workspace": "9.0.14",
-		"@openfin/workspace-platform": "9.0.14"
+		"@openfin/workspace-platform": "9.0.14",
+		"csstype": "^3.0.11"
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.11",


### PR DESCRIPTION
It is a dependency of common and should be listed for cases where npm run setup does not work and npm installs need to be run on common directly (the npm version doesn't support workspaces).