### PR TITLE
Make sure search always returns an object

### DIFF
--- a/how-to/customize-workspace/client/src/framework/workspace/home.ts
+++ b/how-to/customize-workspace/client/src/framework/workspace/home.ts
@@ -495,14 +495,16 @@ export async function register(): Promise<RegistrationMetaInfo> {
 					}
 				}
 			}
-			searchResults.context.filters = finalFilters.length > 0 ? finalFilters : undefined;
-
-			if (searchResults.results.length > 0 || finalFilters.length > 0) {
-				return searchResults;
+			if (finalFilters.length > 0) {
+				searchResults.context.filters = finalFilters;
 			}
+
+			return searchResults;
 		} catch (err) {
 			logger.error("Exception while getting search list results", err);
 		}
+
+		return { results: [] };
 	};
 
 	const onSelection = async (result: HomeDispatchedSearchResult) => {


### PR DESCRIPTION
Make sure search query always returns an object, even if it has no results. The calling code destructures it and returning undefined triggers an exception.