### PR TITLE
Make sure we don't include any empty filters

### DIFF
--- a/how-to/customize-workspace/client/src/framework/workspace/home.ts
+++ b/how-to/customize-workspace/client/src/framework/workspace/home.ts
@@ -370,7 +370,7 @@ async function getResults(
 		return {
 			results: finalResults,
 			context: {
-				filters: getSearchFilters(tags)
+				filters: getSearchFilters(tags.filter(Boolean))
 			}
 		};
 	}


### PR DESCRIPTION
Remove any empty filters before returning them, otherwise home ui might blow up