### PR TITLE
Add missing preload scripts for content without manifests

### DIFF
--- a/how-to/common/public/views/platform/new-tab/new-tab.html
+++ b/how-to/common/public/views/platform/new-tab/new-tab.html
@@ -4,6 +4,7 @@
 		<link rel="icon" href="/favicon.ico" />
 		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>New Tab</title>
+		<script src="../../../style/style-changed-preload.js"></script>
 		<link rel="stylesheet" href="../../../style/app.css" />
 		<script defer="defer" src="./new-tab.js"></script>
 		<style>

--- a/how-to/common/public/windows/hidden-window/hidden.html
+++ b/how-to/common/public/windows/hidden-window/hidden.html
@@ -5,6 +5,7 @@
 		<meta name="description" content="" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Headless window example</title>
+		<script src="../../style/style-changed-preload.js"></script>
 		<link rel="stylesheet" href="../../style/app.css" />
 		<script type="module" src="../../js/common.windows.hidden.bundle.js" defer></script>
 	</head>


### PR DESCRIPTION
The new tab and hidden window examples have no manifest so needed to include the style preload scripts manually