### PR TITLE
Added wider intent target support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-	"cSpell.words": ["actioned", "templating"]
+	"cSpell.words": ["actioned", "templating"],
+	"files.eol": "\n"
 }

--- a/how-to/common/client/src/windows/intent-window/intent-snapshot-launcher.ts
+++ b/how-to/common/client/src/windows/intent-window/intent-snapshot-launcher.ts
@@ -1,0 +1,103 @@
+interface LauncherSettings {
+	intentName?: string;
+	snapshotUrl?: string;
+	idToken?: string;
+	idName?: string;
+	contextGroupName?: string;
+	contextGroupToken?: string;
+}
+let lastContextGroupIndex: number = -1;
+
+async function getLauncherSettings(): Promise<LauncherSettings> {
+	const options = await fin.me.getOptions();
+	let settings: LauncherSettings = {};
+	if (options?.customData?.settings !== undefined) {
+		settings = Object.assign(settings, options.customData.settings);
+		if (settings.snapshotUrl === undefined) {
+			console.error("Unable to setup intent handler as we need a snapshotUrl setting passed to fetch.");
+			return null;
+		}
+		if (settings.intentName === undefined) {
+			console.error("Unable to setup intent handler as we need a intentName setting passed.");
+			return null;
+		}
+	}
+	return settings;
+}
+
+async function getContextGroupName(contextGroupName: string, contextGroupToken: string): Promise<string> {
+	let targetContextGroupName = contextGroupName;
+	if (targetContextGroupName !== undefined) {
+		const availableContextGroups = await fin.me.interop.getContextGroups();
+		if (targetContextGroupName === "*") {
+			console.log("The specified context group is all (*) indicating the target group should be rotated.");
+			lastContextGroupIndex++;
+			if (lastContextGroupIndex > availableContextGroups.length) {
+				lastContextGroupIndex = 0;
+			}
+			targetContextGroupName = availableContextGroups[lastContextGroupIndex].id;
+		}
+		const targetContextGroup = availableContextGroups.find((entry) => entry.id === targetContextGroupName);
+		if (targetContextGroup === undefined) {
+			if (contextGroupToken !== undefined) {
+				console.warn(
+					"Passed contextGroupName is invalid and cannot be used for contextGroupToken replacement. Setting context group to first in available list:",
+					availableContextGroups[0].id
+				);
+				targetContextGroupName = availableContextGroups[0].id;
+			} else {
+				console.warn(
+					"The passed context group name is not valid and isn't used in the snapshot so will not be used or defaulted."
+				);
+				targetContextGroupName = undefined;
+			}
+		}
+	}
+	return targetContextGroupName;
+}
+
+async function launcherInit() {
+	const settings = await getLauncherSettings();
+
+	if (settings !== null) {
+		const snapshotUrl: string = settings.snapshotUrl;
+		const idName: string = settings.idName;
+		const contextGroupName: string = settings.contextGroupName;
+		const contextGroupToken: string = settings.contextGroupToken;
+		const idToken: string = settings.idToken;
+		const intentName: string = settings.intentName;
+
+		await fin.me.interop.registerIntentHandler(async (intent) => {
+			const response = await fetch(snapshotUrl, {
+				headers: {
+					Accept: "application/json"
+				}
+			});
+			if (response.status === 200) {
+				console.log("Received snapshot response");
+				let text = await response.text();
+				if (
+					idName !== undefined &&
+					intent?.context?.id !== undefined &&
+					intent.context.id[idName] !== undefined
+				) {
+					text = text.replaceAll(idToken, intent.context.id[idName]);
+				}
+
+				const targetContextGroupName: string = await getContextGroupName(contextGroupName, contextGroupToken);
+				if (targetContextGroupName !== undefined && contextGroupToken !== undefined) {
+					text = text.replaceAll(contextGroupToken, targetContextGroupName);
+				}
+				const snapshot: OpenFin.Snapshot = JSON.parse(text);
+				const platform = fin.Platform.getCurrentSync();
+				if (targetContextGroupName !== undefined) {
+					await fin.me.interop.joinContextGroup(targetContextGroupName);
+					await fin.me.interop.setContext(intent.context);
+				}
+				await platform.applySnapshot(snapshot);
+			}
+		}, intentName);
+	}
+}
+
+window.addEventListener("DOMContentLoaded", launcherInit);

--- a/how-to/common/client/webpack.config.js
+++ b/how-to/common/client/webpack.config.js
@@ -81,5 +81,32 @@ module.exports = [
 		experiments: {
 			outputModule: true
 		}
+	},
+	{
+		entry: './client/src/windows/intent-window/intent-snapshot-launcher.ts',
+		devtool: 'inline-source-map',
+		module: {
+			rules: [
+				{
+					test: /\.tsx?$/,
+					use: 'ts-loader',
+					exclude: /node_modules/
+				}
+			]
+		},
+		resolve: {
+			extensions: ['.tsx', '.ts', '.js']
+		},
+		externals: { fin: 'fin' },
+		output: {
+			filename: 'common.windows.intent-snapshot-launcher.bundle.js',
+			library: {
+				type: 'module'
+			},
+			path: path.resolve(__dirname, '..', 'public', 'js')
+		},
+		experiments: {
+			outputModule: true
+		}
 	}
 ];

--- a/how-to/common/public/apps.json
+++ b/how-to/common/public/apps.json
@@ -181,6 +181,48 @@
 		"tags": ["page", "openfin", "client", "interop", "fdc3", "contact"]
 	},
 	{
+		"appId": "view-contact-dashboard-launcher",
+		"name": "view-contact-dashboard-launcher",
+		"title": "View Contact Dashboard",
+		"description": "A hidden window that acts as an intent target and launches and snapshot and optionally publishes a context object to a specific context group",
+		"manifest": {
+			"name": "view-contact-dashboard-launcher",
+			"url": "http://localhost:8080/common/windows/intent-window/intent-snapshot-launcher.html",
+			"autoShow": false,
+			"includeInSnapshots": false,
+			"customData": {
+				"settings": {
+					"snapshotUrl": "http://localhost:8080/common/snapshots/template-snapshot-contact-dashboard.json",
+					"contextGroupName": "*",
+					"contextGroupToken": "{CONTEXT_GROUP}",
+					"intentName": "ViewContact",
+					"idToken": "{ID}",
+					"idName": "email"
+				}
+			}
+		},
+		"manifestType": "inline-window",
+		"icons": [
+			{
+				"src": "http://localhost:8080/common/images/icon-blue.png"
+			}
+		],
+		"contactEmail": "contact@example.com",
+		"supportEmail": "support@example.com",
+		"publisher": "OpenFin",
+		"intents": [
+			{
+				"name": "ViewContact",
+				"displayName": "View Contact",
+				"contexts": ["fdc3.contact"],
+				"customConfig": {}
+			}
+		],
+		"private": true,
+		"images": [],
+		"tags": ["window", "fdc3", "interop", "contact"]
+	},
+	{
 		"appId": "fdc3-workbench",
 		"name": "fdc3-workbench",
 		"title": "FDC3 Workbench",

--- a/how-to/common/public/snapshots/template-snapshot-contact-dashboard.json
+++ b/how-to/common/public/snapshots/template-snapshot-contact-dashboard.json
@@ -1,0 +1,184 @@
+{
+	"windows": [
+		{
+			"title": "Contact Dashboard",
+			"defaultHeight": 930,
+			"defaultLeft": 346,
+			"defaultTop": 238,
+			"defaultWidth": 1501,
+			"height": 931,
+			"width": 1503,
+			"workspacePlatform": {
+				"pages": [
+					{
+						"title": "Contact Dashboard",
+						"layout": {
+							"settings": {
+								"hasHeaders": true,
+								"constrainDragToContainer": true,
+								"reorderEnabled": true,
+								"selectionEnabled": false,
+								"popoutWholeStack": false,
+								"blockedPopoutsThrowError": true,
+								"closePopoutsOnUnload": true,
+								"showPopoutIcon": false,
+								"showMaximiseIcon": true,
+								"showCloseIcon": false,
+								"responsiveMode": "onload",
+								"tabOverlapAllowance": 0,
+								"reorderOnTabMenuClick": true,
+								"tabControlOffset": 10,
+								"constrainDragToHeaders": false,
+								"preventDragOut": true,
+								"preventDragIn": true
+							},
+							"content": [
+								{
+									"type": "row",
+									"reorderEnabled": true,
+									"title": "",
+									"content": [
+										{
+											"type": "row",
+											"reorderEnabled": true,
+											"title": "",
+											"height": 100,
+											"width": 100,
+											"content": [
+												{
+													"type": "column",
+													"reorderEnabled": true,
+													"title": "",
+													"width": 50,
+													"content": [
+														{
+															"type": "stack",
+															"width": 50,
+															"height": 54.035874439461885,
+															"reorderEnabled": true,
+															"title": "",
+															"activeItemIndex": 0,
+															"content": [
+																{
+																	"type": "component",
+																	"isClosable": false,
+																	"componentName": "view",
+																	"componentState": {
+																		"url": "http://localhost:8080/common/views/contact/participant-summary/index.html",
+																		"componentName": "view",
+																		"fdc3InteropApi": "1.2",
+																		"interop": { "currentContextGroup": "{CONTEXT_GROUP}" },
+																		"preloadScripts": [
+																			{
+																				"url": "http://localhost:8080/common/style/style-changed-preload.js"
+																			}
+																		]
+																	}
+																},
+																{
+																	"type": "component",
+																	"isClosable": false,
+																	"componentName": "view",
+																	"componentState": {
+																		"url": "http://localhost:8080/common/views/contact/investments-and-models/index.html",
+																		"componentName": "view",
+																		"fdc3InteropApi": "1.2",
+																		"interop": { "currentContextGroup": "{CONTEXT_GROUP}" },
+																		"preloadScripts": [
+																			{
+																				"url": "http://localhost:8080/common/style/style-changed-preload.js"
+																			}
+																		]
+																	}
+																}
+															]
+														},
+														{
+															"type": "stack",
+															"header": {},
+															"reorderEnabled": true,
+															"title": "",
+															"activeItemIndex": 0,
+															"height": 45.964125560538115,
+															"content": [
+																{
+																	"type": "component",
+																	"isClosable": false,
+																	"componentName": "view",
+																	"componentState": {
+																		"url": "http://localhost:8080/common/views/contact/participant-history/index.html",
+																		"componentName": "view",
+																		"fdc3InteropApi": "1.2",
+																		"interop": { "currentContextGroup": "{CONTEXT_GROUP}" },
+																		"preloadScripts": [
+																			{
+																				"url": "http://localhost:8080/common/style/style-changed-preload.js"
+																			}
+																		]
+																	}
+																},
+																{
+																	"type": "component",
+																	"isClosable": false,
+																	"componentName": "view",
+																	"componentState": {
+																		"url": "http://localhost:8080/common/views/contact/participant-selection/index.html",
+																		"componentName": "view",
+																		"fdc3InteropApi": "1.2",
+																		"interop": { "currentContextGroup": "{CONTEXT_GROUP}" },
+																		"preloadScripts": [
+																			{
+																				"url": "http://localhost:8080/common/style/style-changed-preload.js",
+																				"state": "succeeded"
+																			}
+																		]
+																	}
+																}
+															]
+														}
+													]
+												},
+												{
+													"type": "stack",
+													"header": {},
+													"reorderEnabled": true,
+													"title": "",
+													"activeItemIndex": 0,
+													"width": 50,
+													"content": [
+														{
+															"type": "component",
+															"isClosable": false,
+															"componentName": "view",
+															"componentState": {
+																"url": "http://localhost:8080/common/views/platform/new-tab/new-tab.html?q={ID}",
+																"componentName": "view"
+															}
+														}
+													]
+												}
+											]
+										}
+									]
+								}
+							],
+							"reorderEnabled": true,
+							"title": "",
+							"openPopouts": [],
+							"maximisedItemId": null
+						},
+						"isReadOnly": false,
+						"hasUnsavedChanges": false,
+						"isActive": true
+					}
+				],
+				"title": "Contact Dashboard",
+				"newTabUrl": null,
+				"newPageUrl": null,
+				"toolbarOptions": {}
+			},
+			"ignoreSavedWindowState": true,
+			"preloadScripts": []
+		}
+	]
+}

--- a/how-to/common/public/views/platform/new-tab/new-tab.js
+++ b/how-to/common/public/views/platform/new-tab/new-tab.js
@@ -29,6 +29,12 @@ async function init() {
 		}
 	});
 	action.addEventListener('click', actionQuery);
+	if (location.search !== undefined) {
+		const queryParams = new URLSearchParams(location.search);
+		if (queryParams.has('q')) {
+			query.value = queryParams.get('q');
+		}
+	}
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/how-to/common/public/windows/intent-window/intent-snapshot-launcher.html
+++ b/how-to/common/public/windows/intent-window/intent-snapshot-launcher.html
@@ -1,0 +1,11 @@
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" href="/favicon.ico" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
+		<title>Intent Snapshot Launcher</title>
+		<script type="module" src="../../js/common.windows.intent-snapshot-launcher.bundle.js" defer></script>
+	</head>
+
+	<body></body>
+</html>

--- a/how-to/customize-workspace/CHANGELOG.md
+++ b/how-to/customize-workspace/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Removed `enablePageIntegration` from `homeProvider`, enable/disable the Pages integration instead
 - Added Automation Testing examples
 - Added option of modules receiving a getInteropClient function if they are allowed. Added pattern that a module should listen for the after bootstrap lifecycle event before trying to get an interop client. Added an example to the dev module in modules/composite/developer. There is an analytics implementation that publishes events to an interop/fdc3 channel. This is for dev purposes so you can easily listen to a stream of the events and build a UI (it complements the console analytics module we have). It is only enabled in manifest.fin.json.
+- Added intent support for manifest type: inline-window and window. These can now be intent targets. Specifying the name of the window means only a single window will be launched as the intent target.
 
 ## v9.2
 


### PR DESCRIPTION
Added support for window and inline-window manifest type to the broker as a supported intent target. Added example of why you might want to use this and the private app setting (so apps do not show in home and store but can be intent targets). New contact dashboard example added to common by adding an intent snapshot launcher window which can take custom settings to support the launching and modifying of a snapshot. This shows targeting specific context groups and dynamic replacement of tokens in a snapshot (provided an example of something that might not support intents but can have the context passed to a querystring (it could have been custom data).