### PR TITLE
Update validation of passed intent target app

### DIFF
--- a/how-to/customize-workspace/CHANGELOG.md
+++ b/how-to/customize-workspace/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Added Automation Testing examples
 - Added option of modules receiving a getInteropClient function if they are allowed. Added pattern that a module should listen for the after bootstrap lifecycle event before trying to get an interop client. Added an example to the dev module in modules/composite/developer. There is an analytics implementation that publishes events to an interop/fdc3 channel. This is for dev purposes so you can easily listen to a stream of the events and build a UI (it complements the console analytics module we have). It is only enabled in manifest.fin.json.
 - Added intent support for manifest type: inline-window and window. These can now be intent targets. Specifying the name of the window means only a single window will be launched as the intent target.
+- Only lookup and use intent target if it isn't undefined, null or an empty string
 
 ## v9.2
 

--- a/how-to/customize-workspace/client/src/framework/platform/interopbroker.ts
+++ b/how-to/customize-workspace/client/src/framework/platform/interopbroker.ts
@@ -241,7 +241,11 @@ export function interopOverride(
 			let targetAppIntent;
 			let targetAppIntentCount = 0;
 
-			if (contextForIntent.metadata?.target !== undefined) {
+			if (
+				contextForIntent.metadata?.target !== undefined &&
+				contextForIntent.metadata?.target !== null &&
+				contextForIntent.metadata?.target.trim().length > 0
+			) {
 				targetApp = await getApp(contextForIntent.metadata?.target);
 			}
 
@@ -351,7 +355,11 @@ export function interopOverride(
 			let targetAppSpecified: boolean = false;
 			let targetAppId: string;
 
-			if (intent.metadata?.target !== undefined) {
+			if (
+				intent.metadata?.target !== undefined &&
+				intent.metadata?.target !== null &&
+				intent.metadata?.target.trim().length > 0
+			) {
 				targetAppSpecified = true;
 				targetAppId = intent.metadata?.target as string;
 				targetApp = await getApp(targetAppId);

--- a/how-to/customize-workspace/client/src/framework/platform/platform-version.ts
+++ b/how-to/customize-workspace/client/src/framework/platform/platform-version.ts
@@ -1,2 +1,2 @@
 // Generated from package.json version at build time. Do not modify directly.
-export const PLATFORM_VERSION = "10.3.0";
+export const PLATFORM_VERSION = "10.3.1";

--- a/how-to/customize-workspace/package.json
+++ b/how-to/customize-workspace/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "openfin-workspace--customize-workspace",
-	"version": "10.3.0",
+	"version": "10.3.1",
 	"description": "This npm package contains an opinionated implementation of a workspace platform. It shows you the type of patterns available to a workspace platform developer.",
 	"main": "dist/js/provider.bundle.js",
 	"types": "client/types/provider.d.ts",


### PR DESCRIPTION
If someone passes an intent target we should ensure they specified an app name/id before trying to fetch it. E.g. .NET code may pass null instead of undefined when a value is not set.