### PR TITLE
Added example of doing a platform override and adding a custom menu entry

### DIFF
--- a/how-to/register-with-browser/client/src/browser.ts
+++ b/how-to/register-with-browser/client/src/browser.ts
@@ -51,3 +51,12 @@ export function createViewIdentity(uuid: string, name: string): OpenFin.Identity
 	};
 	return viewIdentity;
 }
+
+export async function addPageToWindow(pageId: string, windowIdentity: OpenFin.Identity) {
+	const page = await platform.Storage.getPage(pageId);
+	if (page !== undefined && page !== null) {
+		const targetWindow = platform.Browser.wrapSync(windowIdentity);
+		await targetWindow.addPage(page);
+		await targetWindow.setActivePage(pageId);
+	}
+}

--- a/how-to/register-with-browser/client/src/launchbar.ts
+++ b/how-to/register-with-browser/client/src/launchbar.ts
@@ -165,8 +165,6 @@ export async function createWindowWithLockedPage(): Promise<BrowserWindowModule>
 }
 
 document.addEventListener("DOMContentLoaded", async () => {
-	await (fin.me as OpenFin.Window).showDeveloperTools();
-
 	// CREATE BROWSER WINDOW WITH VIEW
 	const createBrowserWinBtn = document.querySelector("#launch-browser-window");
 	createBrowserWinBtn.addEventListener("click", createBrowserWindow);
@@ -194,6 +192,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 	// GET ALL BROWSER PAGES
 	const getBrowserPagesBtn = document.querySelector("#get-browser-pages");
 	getBrowserPagesBtn.addEventListener("click", async () => {
+		await (fin.me as OpenFin.Window).showDeveloperTools();
 		const lastFocusedWindow = await platform.Browser.getLastFocusedWindow();
 		if (lastFocusedWindow) {
 			const pages = await platform.Browser.getAllAttachedPages();

--- a/how-to/register-with-browser/client/src/platform-override.ts
+++ b/how-to/register-with-browser/client/src/platform-override.ts
@@ -114,7 +114,14 @@ export const overrideCallback: WorkspacePlatformOverrideCallback = async (Worksp
 					});
 				}
 				menuEntry.submenu.push(...pagesMenu);
-				template.push(menuEntry);
+
+				const savePageAsIndex = template.findIndex(
+					(existingMenuEntry) =>
+						existingMenuEntry?.data?.type !== undefined &&
+						existingMenuEntry.data.type === GlobalContextMenuOptionType.SavePageAs
+				);
+
+				template.splice(savePageAsIndex + 1, 0, menuEntry);
 			}
 
 			return super.openGlobalContextMenu(

--- a/how-to/register-with-browser/client/src/platform-override.ts
+++ b/how-to/register-with-browser/client/src/platform-override.ts
@@ -1,5 +1,4 @@
 import {
-	AnalyticsEvent,
 	CreateSavedPageRequest,
 	CreateSavedWorkspaceRequest,
 	getCurrentSync,
@@ -17,14 +16,6 @@ import {
 
 export const overrideCallback: WorkspacePlatformOverrideCallback = async (WorkspacePlatformProvider) => {
 	class Override extends WorkspacePlatformProvider {
-		public async getSnapshot(...args: [undefined, OpenFin.ClientIdentity]) {
-			return super.getSnapshot(...args);
-		}
-
-		public async applySnapshot(...args: [OpenFin.ApplySnapshotPayload, OpenFin.ClientIdentity]) {
-			return super.applySnapshot(...args);
-		}
-
 		public async getSavedWorkspaces(query?: string): Promise<Workspace[]> {
 			// you can add your own custom implementation here if you are storing your workspaces
 			// in non-default location (e.g. on the server instead of locally)
@@ -157,10 +148,6 @@ export const overrideCallback: WorkspacePlatformOverrideCallback = async (Worksp
 				},
 				callerIdentity
 			);
-		}
-
-		public async handleAnalytics(events: AnalyticsEvent[]) {
-			// you can pass generated workspace analytic events to your own server from here
 		}
 	}
 	return new Override();

--- a/how-to/register-with-browser/client/src/platform-override.ts
+++ b/how-to/register-with-browser/client/src/platform-override.ts
@@ -1,0 +1,160 @@
+import {
+	AnalyticsEvent,
+	CreateSavedPageRequest,
+	CreateSavedWorkspaceRequest,
+	getCurrentSync,
+	GlobalContextMenuItemTemplate,
+	GlobalContextMenuOptionType,
+	OpenGlobalContextMenuPayload,
+	OpenPageTabContextMenuPayload,
+	OpenViewTabContextMenuPayload,
+	Page,
+	UpdateSavedPageRequest,
+	UpdateSavedWorkspaceRequest,
+	Workspace,
+	WorkspacePlatformOverrideCallback
+} from "@openfin/workspace-platform";
+
+export const overrideCallback: WorkspacePlatformOverrideCallback = async (WorkspacePlatformProvider) => {
+	class Override extends WorkspacePlatformProvider {
+		public async getSnapshot(...args: [undefined, OpenFin.ClientIdentity]) {
+			return super.getSnapshot(...args);
+		}
+
+		public async applySnapshot(...args: [OpenFin.ApplySnapshotPayload, OpenFin.ClientIdentity]) {
+			return super.applySnapshot(...args);
+		}
+
+		public async getSavedWorkspaces(query?: string): Promise<Workspace[]> {
+			// you can add your own custom implementation here if you are storing your workspaces
+			// in non-default location (e.g. on the server instead of locally)
+			return super.getSavedWorkspaces(query);
+		}
+
+		public async getSavedWorkspace(id: string): Promise<Workspace> {
+			// you can add your own custom implementation here if you are storing your workspaces
+			// in non-default location (e.g. on the server instead of locally)
+			return super.getSavedWorkspace(id);
+		}
+
+		public async createSavedWorkspace(req: CreateSavedWorkspaceRequest): Promise<void> {
+			// you can add your own custom implementation here if you are storing your workspaces
+			// in non-default location (e.g. on the server instead of locally)
+			return super.createSavedWorkspace(req);
+		}
+
+		public async updateSavedWorkspace(req: UpdateSavedWorkspaceRequest): Promise<void> {
+			// you can add your own custom implementation here if you are storing your workspaces
+			// in non-default location (e.g. on the server instead of locally)
+			return super.updateSavedWorkspace(req);
+		}
+
+		public async deleteSavedWorkspace(id: string): Promise<void> {
+			// you can add your own custom implementation here if you are storing your workspaces
+			// in non-default location (e.g. on the server instead of locally)
+			return super.deleteSavedWorkspace(id);
+		}
+
+		public async getSavedPages(query?: string): Promise<Page[]> {
+			// you can add your own custom implementation here if you are storing your pages
+			// in non-default location (e.g. on the server instead of locally)
+			return super.getSavedPages(query);
+		}
+
+		public async getSavedPage(id: string): Promise<Page> {
+			// you can add your own custom implementation here if you are storing your pages
+			// in non-default location (e.g. on the server instead of locally)
+			return super.getSavedPage(id);
+		}
+
+		public async createSavedPage(req: CreateSavedPageRequest): Promise<void> {
+			// you can add your own custom implementation here if you are storing your pages
+			// in non-default location (e.g. on the server instead of locally)
+			return super.createSavedPage(req);
+		}
+
+		public async updateSavedPage(req: UpdateSavedPageRequest): Promise<void> {
+			// you can add your own custom implementation here if you are storing your pages
+			// in non-default location (e.g. on the server instead of locally)
+			return super.updateSavedPage(req);
+		}
+
+		public async deleteSavedPage(id: string): Promise<void> {
+			// you can add your own custom implementation here if you are storing your pages
+			// in non-default location (e.g. on the server instead of locally)
+			await super.deleteSavedPage(id);
+		}
+
+		public async openGlobalContextMenu(req: OpenGlobalContextMenuPayload, callerIdentity: OpenFin.Identity) {
+			// you can customize the browser main menu here
+			const template = req.template;
+			const platform = getCurrentSync();
+			const pages: Page[] = await platform.Storage.getPages();
+			const pagesMenu: OpenFin.MenuItemTemplate[] = [];
+			const menuEntry: GlobalContextMenuItemTemplate = {
+				label: "Open Page",
+				submenu: []
+			};
+			const allOpenPages = await platform.Browser.getAllAttachedPages();
+			if (pages.length > 0) {
+				for (const page of pages) {
+					const pageExists = allOpenPages.some((openPage) => page.pageId === openPage.pageId);
+
+					pagesMenu.push({
+						label: page.title,
+						type: "normal",
+						enabled: !pageExists,
+						data: {
+							type: GlobalContextMenuOptionType.Custom,
+							action: {
+								id: "open-page",
+								customData: { pageId: page.pageId, windowIdentity: callerIdentity }
+							}
+						}
+					});
+				}
+				menuEntry.submenu.push(...pagesMenu);
+				template.push(menuEntry);
+			}
+
+			return super.openGlobalContextMenu(
+				{
+					...req,
+					template
+				},
+				callerIdentity
+			);
+		}
+
+		public async openViewTabContextMenu(
+			req: OpenViewTabContextMenuPayload,
+			callerIdentity: OpenFin.Identity
+		) {
+			// you can customize the view right click context menu here
+			return super.openViewTabContextMenu(
+				{
+					...req
+				},
+				callerIdentity
+			);
+		}
+
+		public async openPageTabContextMenu(
+			req: OpenPageTabContextMenuPayload,
+			callerIdentity: OpenFin.Identity
+		) {
+			// you can customize the page tab right click context menu here
+			return super.openPageTabContextMenu(
+				{
+					...req
+				},
+				callerIdentity
+			);
+		}
+
+		public async handleAnalytics(events: AnalyticsEvent[]) {
+			// you can pass generated workspace analytic events to your own server from here
+		}
+	}
+	return new Override();
+};

--- a/how-to/register-with-browser/client/src/platform.ts
+++ b/how-to/register-with-browser/client/src/platform.ts
@@ -3,10 +3,12 @@ import {
 	CustomButtonActionPayload,
 	init as workspacePlatformInit
 } from "@openfin/workspace-platform";
+import { addPageToWindow } from "./browser";
+import { overrideCallback } from "./platform-override";
 import { getSettings, validateThemes } from "./settings";
 
 export async function init() {
-	console.log("Initialising platform");
+	console.log("Initializing platform");
 	const settings = await getSettings();
 	const browser: BrowserInitConfig = {};
 
@@ -27,10 +29,18 @@ export async function init() {
 	await workspacePlatformInit({
 		browser,
 		theme: validateThemes(settings?.themeProvider?.themes),
+		overrideCallback,
 		customActions: {
 			"custom-save-page-clicked": (payload: CustomButtonActionPayload) => {
 				console.dir({ message: "CUSTOM SAVE PAGE CLICKED", payload });
 				console.dir({ message: "LAYOUT", layout: payload.customData.layout });
+			},
+			"open-page": async (payload: CustomButtonActionPayload) => {
+				const pageId: string = payload?.customData?.pageId;
+				const targetWindowIdentity: OpenFin.Identity = payload?.customData?.windowIdentity;
+				if (pageId !== undefined && targetWindowIdentity !== undefined) {
+					await addPageToWindow(pageId, targetWindowIdentity);
+				}
 			}
 		}
 	});

--- a/how-to/register-with-browser/public/manifest.fin.json
+++ b/how-to/register-with-browser/public/manifest.fin.json
@@ -8,7 +8,7 @@
 	"platform": {
 		"uuid": "launch-browser-from-window",
 		"icon": "http://localhost:8080/favicon.ico",
-		"autoShow": true,
+		"autoShow": false,
 		"providerUrl": "http://localhost:8080/platform/provider.html",
 		"preventQuitOnLastWindowClosed": true,
 		"defaultWindowOptions": {}


### PR DESCRIPTION
We give examples of platform overrides in more complex how-tos but I think we needed a basic entry in register with browser.

This shows the hooks for overriding storage for pages and workspaces, capturing the analytics and adding custom menu entries.

Added an example of how you could have a menu entry to open saved pages and how to place a menu entry in the right place.