### PR TITLE
Add example primary and secondary buttons to store

### DIFF
--- a/how-to/register-with-store-basic/client/src/apps.ts
+++ b/how-to/register-with-store-basic/client/src/apps.ts
@@ -23,7 +23,24 @@ export const experoApp: App = {
 			src: "http://localhost:8080/common/images/previews/expero-news-view.png"
 		}
 	],
-	tags: ["expero", "view", "interop"]
+	tags: ["expero", "view", "interop"],
+	primaryButton: {
+		title: "Open App",
+		action: {
+			id: "launch-app"
+		}
+	},
+	secondaryButtons: [
+		{
+			title: "Open Web Site",
+			action: {
+				id: "open-web-site",
+				customData: {
+					url: "https://www.experoinc.com/"
+				}
+			}
+		}
+	]
 };
 
 export const notificationStudio: App = {

--- a/how-to/register-with-store-basic/client/src/provider.ts
+++ b/how-to/register-with-store-basic/client/src/provider.ts
@@ -1,10 +1,33 @@
-import { init as workspacePlatformInit } from "@openfin/workspace-platform";
-import { register, deregister, show, hide } from "./store";
+import {
+	CustomActionCallerType,
+	getCurrentSync,
+	init as workspacePlatformInit
+} from "@openfin/workspace-platform";
+import { getApps } from "./apps";
+import { deregister, hide, register, show } from "./store";
 
 async function init() {
 	await workspacePlatformInit({
-		browser: {}
+		browser: {},
+		customActions: {
+			"open-web-site": async (payload) => {
+				if (payload.callerType === CustomActionCallerType.StoreCustomButton) {
+					window.open(payload.customData?.url as string);
+				}
+			},
+			"launch-app": async (payload) => {
+				if (payload.callerType === CustomActionCallerType.StoreCustomButton) {
+					const apps = await getApps();
+					const app = apps.find((a) => a.appId === payload.appId);
+					if (app) {
+						const platform = getCurrentSync();
+						await platform.launchApp({ app });
+					}
+				}
+			}
+		}
 	});
+
 	const registerStore = document.querySelector<HTMLButtonElement>("#register");
 	const showStore = document.querySelector<HTMLButtonElement>("#show");
 	const hideStore = document.querySelector<HTMLButtonElement>("#hide");

--- a/how-to/register-with-store-basic/client/src/store.ts
+++ b/how-to/register-with-store-basic/client/src/store.ts
@@ -16,8 +16,8 @@ export async function register() {
 	console.log("Initialising the storefront provider.");
 	const provider = await getStoreProvider();
 	try {
-		await Storefront.register(provider);
-		console.log("Storefront provider initialised.");
+		const metaInfo = await Storefront.register(provider);
+		console.log("Storefront provider initialised.", metaInfo);
 	} catch (err) {
 		console.error("An error was encountered while trying to register the content store provider", err);
 	}


### PR DESCRIPTION
Add example primary and secondary buttons to the expero app in store basic
![image](https://user-images.githubusercontent.com/5030334/220558425-ee8b7431-228f-4184-85fe-a51b6d0691e0.png)
