### PR TITLE
Add new lifecyle events for workspaces and pages

### DIFF
--- a/how-to/customize-workspace/client/src/framework/lifecycle.ts
+++ b/how-to/customize-workspace/client/src/framework/lifecycle.ts
@@ -39,7 +39,8 @@ export async function init(
 
 export async function fireLifecycleEvent(
 	platform: WorkspacePlatformModule,
-	lifecycleEvent: LifecycleEvents
+	lifecycleEvent: LifecycleEvents,
+	customData?: unknown
 ): Promise<void> {
 	logger.info(`Request to fire lifecycle event ${lifecycleEvent} received`);
 	if (Array.isArray(allLifecycleEvents[lifecycleEvent])) {
@@ -47,7 +48,7 @@ export async function fireLifecycleEvent(
 		logger.info(`Notifying ${subscribers.length} subscribers of lifecycle event ${lifecycleEvent}`);
 		for (const idHandler of subscribers) {
 			logger.info(`Notifying subscriber ${idHandler.id} of event ${lifecycleEvent}`);
-			await idHandler.handler(platform);
+			await idHandler.handler(platform, customData);
 		}
 	}
 }

--- a/how-to/customize-workspace/client/src/framework/platform/platform-override.ts
+++ b/how-to/customize-workspace/client/src/framework/platform/platform-override.ts
@@ -13,6 +13,10 @@ import {
 	WorkspacePlatformOverrideCallback
 } from "@openfin/workspace-platform";
 import type { AnalyticsEvent } from "@openfin/workspace/common/src/utils/usage-register";
+import type {
+	PageChangedLifecyclePayload,
+	WorkspaceChangedLifecyclePayload
+} from "customize-workspace/shapes";
 import * as analyticsProvider from "../analytics";
 import { getDefaultToolbarButtons, updateBrowserWindowButtonsColorScheme } from "../buttons";
 import * as endpointProvider from "../endpoint";
@@ -101,7 +105,17 @@ export const overrideCallback: WorkspacePlatformOverrideCallback = async (Worksp
 				return;
 			}
 			logger.info(`Saving workspace to default storage for workspace id: ${req.workspace.workspaceId}`);
-			return super.createSavedWorkspace(req);
+
+			const res = await super.createSavedWorkspace(req);
+
+			const platform = getCurrentSync();
+			await fireLifecycleEvent(platform, "workspace-changed", {
+				action: "create",
+				id: req.workspace.workspaceId,
+				workspace: req.workspace
+			} as WorkspaceChangedLifecyclePayload);
+
+			return res;
 		}
 
 		public async updateSavedWorkspace(req: UpdateSavedWorkspaceRequest): Promise<void> {
@@ -126,7 +140,17 @@ export const overrideCallback: WorkspacePlatformOverrideCallback = async (Worksp
 			logger.info(
 				`Saving updated workspace to default storage for workspace id: ${req.workspace.workspaceId}.`
 			);
-			return super.updateSavedWorkspace(req);
+
+			const res = await super.updateSavedWorkspace(req);
+
+			const platform = getCurrentSync();
+			await fireLifecycleEvent(platform, "workspace-changed", {
+				action: "update",
+				id: req.workspace.workspaceId,
+				workspace: req.workspace
+			} as WorkspaceChangedLifecyclePayload);
+
+			return res;
 		}
 
 		public async deleteSavedWorkspace(id: string): Promise<void> {
@@ -144,7 +168,16 @@ export const overrideCallback: WorkspacePlatformOverrideCallback = async (Worksp
 				return;
 			}
 			logger.info(`Deleting workspace from default storage for workspace id: ${id}`);
-			return super.deleteSavedWorkspace(id);
+
+			const res = await super.deleteSavedWorkspace(id);
+
+			const platform = getCurrentSync();
+			await fireLifecycleEvent(platform, "workspace-changed", {
+				action: "delete",
+				id
+			} as WorkspaceChangedLifecyclePayload);
+
+			return res;
 		}
 
 		public async getSavedPages(query?: string): Promise<Page[]> {
@@ -201,7 +234,17 @@ export const overrideCallback: WorkspacePlatformOverrideCallback = async (Worksp
 				return;
 			}
 			logger.info(`creating saved page and saving to default storage. PageId: ${req.page.pageId}`);
-			return super.createSavedPage(req);
+
+			const res = await super.createSavedPage(req);
+
+			const platform = getCurrentSync();
+			await fireLifecycleEvent(platform, "page-changed", {
+				action: "create",
+				id: req.page.pageId,
+				page: req.page
+			} as PageChangedLifecyclePayload);
+
+			return res;
 		}
 
 		public async updateSavedPage(req: UpdateSavedPageRequest): Promise<void> {
@@ -225,7 +268,17 @@ export const overrideCallback: WorkspacePlatformOverrideCallback = async (Worksp
 				return;
 			}
 			logger.info(`updating saved page and saving to default storage with page id: ${req.page.pageId}`);
-			return super.updateSavedPage(req);
+
+			const res = await super.updateSavedPage(req);
+
+			const platform = getCurrentSync();
+			await fireLifecycleEvent(platform, "page-changed", {
+				action: "update",
+				id: req.page.pageId,
+				page: req.page
+			} as PageChangedLifecyclePayload);
+
+			return res;
 		}
 
 		public async deleteSavedPage(id: string): Promise<void> {
@@ -245,7 +298,16 @@ export const overrideCallback: WorkspacePlatformOverrideCallback = async (Worksp
 				return;
 			}
 			logger.info(`deleting saved page from default storage. PageId: ${id}`);
-			await super.deleteSavedPage(id);
+
+			const res = await super.deleteSavedPage(id);
+
+			const platform = getCurrentSync();
+			await fireLifecycleEvent(platform, "page-changed", {
+				action: "delete",
+				id
+			} as PageChangedLifecyclePayload);
+
+			return res;
 		}
 
 		public async openGlobalContextMenu(req: OpenGlobalContextMenuPayload, callerIdentity: OpenFin.Identity) {

--- a/how-to/customize-workspace/client/src/framework/shapes/lifecycle-shapes.ts
+++ b/how-to/customize-workspace/client/src/framework/shapes/lifecycle-shapes.ts
@@ -1,3 +1,4 @@
+import type { Page, Workspace } from "@openfin/workspace";
 import type { WorkspacePlatformModule } from "@openfin/workspace-platform";
 import type { ModuleHelpers, ModuleImplementation, ModuleList } from "./module-shapes";
 
@@ -7,9 +8,11 @@ export type LifecycleEvents =
 	| "auth-before-logged-out"
 	| "after-bootstrap"
 	| "before-quit"
-	| "theme-changed";
+	| "theme-changed"
+	| "workspace-changed"
+	| "page-changed";
 
-export type LifecycleHandler = (platform: WorkspacePlatformModule) => Promise<void>;
+export type LifecycleHandler = (platform: WorkspacePlatformModule, customData?: unknown) => Promise<void>;
 
 export type LifecycleEventMap = {
 	[key in LifecycleEvents]?: LifecycleHandler;
@@ -28,3 +31,15 @@ export interface Lifecycle<O = unknown, H = ModuleHelpers> extends ModuleImpleme
  * that is called when an authenticated session is expired
  * */
 export type LifecycleProviderOptions = ModuleList;
+
+export interface WorkspaceChangedLifecyclePayload {
+	action: "create" | "update" | "delete";
+	id: string;
+	workspace?: Workspace;
+}
+
+export interface PageChangedLifecyclePayload {
+	action: "create" | "update" | "delete";
+	id: string;
+	page?: Page;
+}

--- a/how-to/customize-workspace/client/src/modules/integrations/pages/integration.ts
+++ b/how-to/customize-workspace/client/src/modules/integrations/pages/integration.ts
@@ -118,6 +118,10 @@ export class PagesProvider implements IntegrationModule<PagesSettings> {
 				}
 			}
 		);
+		this._integrationHelpers.subscribeLifecycleEvent("theme-changed", async () => {
+			const platform: WorkspacePlatformModule = this._integrationHelpers.getPlatform();
+			await this.rebuildResults(platform);
+		});
 	}
 
 	/**

--- a/how-to/customize-workspace/client/src/modules/integrations/workspaces/integration.ts
+++ b/how-to/customize-workspace/client/src/modules/integrations/workspaces/integration.ts
@@ -131,6 +131,10 @@ export class WorkspacesProvider implements IntegrationModule<WorkspacesSettings>
 				}
 			}
 		);
+		this._integrationHelpers.subscribeLifecycleEvent("theme-changed", async () => {
+			const platform: WorkspacePlatformModule = this._integrationHelpers.getPlatform();
+			await this.rebuildResults(platform);
+		});
 	}
 
 	/**


### PR DESCRIPTION
* Update lifecycle events to have optional payloads.
* Added new lifecycle events for `workspace-changed` and `page-changed`, these are triggered from platform override and can have payloads of `create`, `update` or `delete`
* Workspaces integration updated to use `workspace-changed` lifecycle event, so that the results list in home property represents the state of the workspaces.
* Pages integration updated to use `page-changed` lifecycle event, so that the results list in home property represents the state of the pages.
* Updated the cards to be more inline with current formatting.