### PR TITLE
Consistent check for type imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -426,6 +426,12 @@ module.exports = {
 				'@typescript-eslint/comma-spacing': ['error'],
 				'@typescript-eslint/consistent-type-assertions': ['error'],
 				'@typescript-eslint/consistent-type-definitions': ['error'],
+				'@typescript-eslint/consistent-type-imports': [
+					'error',
+					{
+						fixStyle: 'inline-type-imports'
+					}
+				],
 				'@typescript-eslint/default-param-last': ['error'],
 				'@typescript-eslint/dot-notation': ['error'],
 				'@typescript-eslint/explicit-function-return-type': ['off'],

--- a/how-to/common/client/src/windows/hidden-window/hidden.ts
+++ b/how-to/common/client/src/windows/hidden-window/hidden.ts
@@ -1,8 +1,8 @@
 import {
-	create,
 	IndicatorColor,
-	NotificationOptions,
-	addEventListener as addNotificationEventListener
+	addEventListener as addNotificationEventListener,
+	create,
+	type NotificationOptions
 } from "@openfin/workspace/notifications";
 
 async function notifyOfLoad() {

--- a/how-to/common/client/src/windows/irs-rfq/irs-rfq.ts
+++ b/how-to/common/client/src/windows/irs-rfq/irs-rfq.ts
@@ -1,12 +1,12 @@
 import {
+	IndicatorColor,
 	addEventListener as addNotificationEventListener,
-	BodyTemplateOptions,
-	ButtonOptions,
 	clear,
 	create,
-	CustomTemplateData,
-	IndicatorColor,
-	NotificationOptions
+	type BodyTemplateOptions,
+	type ButtonOptions,
+	type CustomTemplateData,
+	type NotificationOptions
 } from "@openfin/workspace/notifications";
 import { randomUUID } from "../../lib/uuid";
 import { createContainer, createLabelledForm, createText } from "./notifications";

--- a/how-to/common/client/tsconfig.json
+++ b/how-to/common/client/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/customize-home-templates/client/src/sources/async-contacts/async-contacts-source.ts
+++ b/how-to/customize-home-templates/client/src/sources/async-contacts/async-contacts-source.ts
@@ -1,11 +1,11 @@
 import {
 	CLITemplate,
-	ListPairs,
 	type CLIFilter,
 	type HomeDispatchedSearchResult,
 	type HomeSearchListenerResponse,
 	type HomeSearchResponse,
-	type HomeSearchResult
+	type HomeSearchResult,
+	type ListPairs
 } from "@openfin/workspace";
 import type { AsyncSettings, Contact, ContactFull, ContactsResult } from "./shapes";
 

--- a/how-to/customize-home-templates/client/tsconfig.json
+++ b/how-to/customize-home-templates/client/tsconfig.json
@@ -9,7 +9,6 @@
 		"strict": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/customize-home-templates/server/tsconfig.json
+++ b/how-to/customize-home-templates/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/customize-workspace/client/src/framework/actions.ts
+++ b/how-to/customize-workspace/client/src/framework/actions.ts
@@ -1,12 +1,12 @@
 import type OpenFin from "@openfin/core";
 import {
-	BrowserCreateWindowRequest,
 	CustomActionCallerType,
-	CustomActionPayload,
-	CustomActionsMap,
-	CustomButtonActionPayload,
-	CustomDropdownItemActionPayload,
-	getCurrentSync
+	getCurrentSync,
+	type BrowserCreateWindowRequest,
+	type CustomActionPayload,
+	type CustomActionsMap,
+	type CustomButtonActionPayload,
+	type CustomDropdownItemActionPayload
 } from "@openfin/workspace-platform";
 import { toggleNotificationCenter } from "@openfin/workspace/notifications";
 import { getApp } from "./apps";

--- a/how-to/customize-workspace/client/src/framework/buttons.ts
+++ b/how-to/customize-workspace/client/src/framework/buttons.ts
@@ -1,10 +1,10 @@
 import {
 	BrowserButtonType,
-	BrowserCreateWindowRequest,
-	BrowserWindowModule,
-	CustomBrowserButtonConfig,
 	getCurrentSync,
-	ToolbarButton
+	type BrowserCreateWindowRequest,
+	type BrowserWindowModule,
+	type CustomBrowserButtonConfig,
+	type ToolbarButton
 } from "@openfin/workspace-platform";
 import { checkConditions } from "./conditions";
 import { subscribeLifecycleEvent } from "./lifecycle";

--- a/how-to/customize-workspace/client/src/framework/integrations.ts
+++ b/how-to/customize-workspace/client/src/framework/integrations.ts
@@ -1,12 +1,12 @@
 import {
 	ButtonStyle,
-	CLIFilter,
 	CLITemplate,
-	HomeDispatchedSearchResult,
-	HomeRegistration,
-	HomeSearchListenerResponse,
-	HomeSearchResponse,
-	HomeSearchResult
+	type CLIFilter,
+	type HomeDispatchedSearchResult,
+	type HomeRegistration,
+	type HomeSearchListenerResponse,
+	type HomeSearchResponse,
+	type HomeSearchResult
 } from "@openfin/workspace";
 import { getCurrentSync } from "@openfin/workspace-platform";
 import { checkCondition } from "./conditions";

--- a/how-to/customize-workspace/client/src/framework/launch.ts
+++ b/how-to/customize-workspace/client/src/framework/launch.ts
@@ -1,5 +1,5 @@
 import type OpenFin from "@openfin/core";
-import { BrowserSnapshot, getCurrentSync } from "@openfin/workspace-platform";
+import { getCurrentSync, type BrowserSnapshot } from "@openfin/workspace-platform";
 import { launchConnectedApp } from "./connections";
 import * as endpointProvider from "./endpoint";
 import { createLogger } from "./logger-provider";

--- a/how-to/customize-workspace/client/src/framework/menu.ts
+++ b/how-to/customize-workspace/client/src/framework/menu.ts
@@ -1,11 +1,11 @@
 import {
 	getCurrentSync,
-	GlobalContextMenuItemTemplate,
-	GlobalContextMenuOptionType,
-	PageTabContextMenuItemTemplate,
-	PageTabContextMenuOptionType,
-	ViewTabContextMenuTemplate,
-	ViewTabMenuOptionType
+	type GlobalContextMenuItemTemplate,
+	type GlobalContextMenuOptionType,
+	type PageTabContextMenuItemTemplate,
+	type PageTabContextMenuOptionType,
+	type ViewTabContextMenuTemplate,
+	type ViewTabMenuOptionType
 } from "@openfin/workspace-platform";
 import { checkConditions } from "./conditions";
 import { createLogger } from "./logger-provider";
@@ -16,8 +16,8 @@ import type {
 	MenuEntry,
 	MenuOptionType,
 	MenuPositionOperation,
-	MenusProviderOptions,
 	Menus,
+	MenusProviderOptions,
 	MenuTemplateType,
 	MenuType,
 	RelatedMenuId

--- a/how-to/customize-workspace/client/src/framework/platform/browser.ts
+++ b/how-to/customize-workspace/client/src/framework/platform/browser.ts
@@ -1,10 +1,10 @@
 import type OpenFin from "@openfin/core";
 import {
-	AttachedPage,
-	BrowserCreateWindowRequest,
-	BrowserWindowModule,
 	getCurrentSync,
-	Page
+	type AttachedPage,
+	type BrowserCreateWindowRequest,
+	type BrowserWindowModule,
+	type Page
 } from "@openfin/workspace-platform";
 import { getDefaultToolbarButtons } from "../buttons";
 import * as endpointProvider from "../endpoint";

--- a/how-to/customize-workspace/client/src/framework/platform/interopbroker.ts
+++ b/how-to/customize-workspace/client/src/framework/platform/interopbroker.ts
@@ -1,21 +1,21 @@
 import {
-	AppIdentifier,
-	AppMetadata,
-	ImplementationMetadata,
-	IntentResolution,
-	ResolveError
+	ResolveError,
+	type AppIdentifier,
+	type AppMetadata,
+	type ImplementationMetadata,
+	type IntentResolution
 } from "@finos/fdc3";
 import type OpenFin from "@openfin/core";
 import type { ClientIdentity } from "@openfin/core/src/OpenFin";
 import type { AppIntent } from "@openfin/workspace-platform";
 import type {
+	ApiMetadata,
 	IntentOptions,
-	IntentResolverOptions,
 	IntentPickerResponse,
 	IntentRegistrationEntry,
 	IntentRegistrationPayload,
-	IntentTargetMetaData,
-	ApiMetadata
+	IntentResolverOptions,
+	IntentTargetMetaData
 } from "customize-workspace/shapes/interopbroker-shapes";
 import { getApp, getAppsByIntent, getIntent, getIntentsByContext } from "../apps";
 import * as connectionProvider from "../connections";

--- a/how-to/customize-workspace/client/src/framework/platform/platform-override.ts
+++ b/how-to/customize-workspace/client/src/framework/platform/platform-override.ts
@@ -1,17 +1,17 @@
 import type OpenFin from "@openfin/core";
 import {
-	ColorSchemeOptionType,
-	CreateSavedPageRequest,
-	CreateSavedWorkspaceRequest,
 	getCurrentSync,
-	OpenGlobalContextMenuPayload,
-	OpenPageTabContextMenuPayload,
-	OpenViewTabContextMenuPayload,
-	Page,
-	UpdateSavedPageRequest,
-	UpdateSavedWorkspaceRequest,
-	Workspace,
-	WorkspacePlatformOverrideCallback
+	type ColorSchemeOptionType,
+	type CreateSavedPageRequest,
+	type CreateSavedWorkspaceRequest,
+	type OpenGlobalContextMenuPayload,
+	type OpenPageTabContextMenuPayload,
+	type OpenViewTabContextMenuPayload,
+	type Page,
+	type UpdateSavedPageRequest,
+	type UpdateSavedWorkspaceRequest,
+	type Workspace,
+	type WorkspacePlatformOverrideCallback
 } from "@openfin/workspace-platform";
 import type { AnalyticsEvent } from "@openfin/workspace/common/src/utils/usage-register";
 import * as analyticsProvider from "../analytics";

--- a/how-to/customize-workspace/client/src/framework/platform/platform.ts
+++ b/how-to/customize-workspace/client/src/framework/platform/platform.ts
@@ -1,7 +1,7 @@
 import {
-	BrowserInitConfig,
 	getCurrentSync,
-	init as workspacePlatformInit
+	init as workspacePlatformInit,
+	type BrowserInitConfig
 } from "@openfin/workspace-platform";
 import { getActions } from "../actions";
 import * as analyticsProvider from "../analytics";

--- a/how-to/customize-workspace/client/src/framework/share.ts
+++ b/how-to/customize-workspace/client/src/framework/share.ts
@@ -1,6 +1,6 @@
 import type OpenFin from "@openfin/core";
-import { getCurrentSync, Page } from "@openfin/workspace-platform";
-import { create, IndicatorColor, NotificationOptions } from "@openfin/workspace/notifications";
+import { getCurrentSync, type Page } from "@openfin/workspace-platform";
+import { create, IndicatorColor, type NotificationOptions } from "@openfin/workspace/notifications";
 import { requestResponse } from "./endpoint";
 import { registerListener, removeListener } from "./init-options";
 import { createLogger } from "./logger-provider";

--- a/how-to/customize-workspace/client/src/framework/templates.ts
+++ b/how-to/customize-workspace/client/src/framework/templates.ts
@@ -1,11 +1,11 @@
 import {
 	ButtonStyle,
-	ButtonTemplateFragment,
-	ImageTemplateFragment,
-	PlainContainerTemplateFragment,
-	TemplateFragment,
 	TemplateFragmentTypes,
-	TextTemplateFragment
+	type ButtonTemplateFragment,
+	type ImageTemplateFragment,
+	type PlainContainerTemplateFragment,
+	type TemplateFragment,
+	type TextTemplateFragment
 } from "@openfin/workspace";
 import type * as CSS from "csstype";
 import type { PlatformApp } from "./shapes/app-shapes";

--- a/how-to/customize-workspace/client/src/framework/themes.ts
+++ b/how-to/customize-workspace/client/src/framework/themes.ts
@@ -5,7 +5,7 @@ import { DEFAULT_PALETTES } from "./default-palettes";
 import { fireLifecycleEvent } from "./lifecycle";
 import { createLogger } from "./logger-provider";
 import { getSettings } from "./settings";
-import { ColorSchemeMode, PlatformCustomTheme, PlatformCustomThemes } from "./shapes/theme-shapes";
+import { ColorSchemeMode, type PlatformCustomTheme, type PlatformCustomThemes } from "./shapes/theme-shapes";
 
 const logger = createLogger("Themes");
 

--- a/how-to/customize-workspace/client/src/framework/workspace/dock.ts
+++ b/how-to/customize-workspace/client/src/framework/workspace/dock.ts
@@ -1,4 +1,4 @@
-import { Dock, DockButton, DockButtonNames, RegistrationMetaInfo } from "@openfin/workspace";
+import { Dock, DockButtonNames, type DockButton, type RegistrationMetaInfo } from "@openfin/workspace";
 import type { ColorSchemeMode } from "customize-workspace/shapes/theme-shapes";
 import { ACTION_IDS } from "../actions";
 import { getApp, getAppIcon, getAppsByTag } from "../apps";

--- a/how-to/customize-workspace/client/src/framework/workspace/home.ts
+++ b/how-to/customize-workspace/client/src/framework/workspace/home.ts
@@ -1,12 +1,12 @@
 import {
-	CLIFilter,
-	CLIProvider,
-	CLISearchListenerRequest,
-	CLISearchListenerResponse,
-	CLISearchResponse,
 	Home,
-	HomeDispatchedSearchResult,
-	HomeRegistration
+	type CLIFilter,
+	type CLIProvider,
+	type CLISearchListenerRequest,
+	type CLISearchListenerResponse,
+	type CLISearchResponse,
+	type HomeDispatchedSearchResult,
+	type HomeRegistration
 } from "@openfin/workspace";
 import { getHelpSearchEntries, getSearchResults, itemSelection } from "../integrations";
 import { createLogger } from "../logger-provider";

--- a/how-to/customize-workspace/client/src/framework/workspace/notifications.ts
+++ b/how-to/customize-workspace/client/src/framework/workspace/notifications.ts
@@ -1,12 +1,12 @@
 import type { RegistrationMetaInfo } from "@openfin/workspace";
 import {
-	register as registerPlatform,
+	VERSION,
 	deregister as deregisterPlatform,
-	show as showNotifications,
 	hide as hideNotifications,
-	ShowOptions,
 	provider,
-	VERSION
+	register as registerPlatform,
+	show as showNotifications,
+	type ShowOptions
 } from "@openfin/workspace/notifications";
 import { createLogger } from "../logger-provider";
 import { getSettings } from "../settings";

--- a/how-to/customize-workspace/client/src/framework/workspace/store.ts
+++ b/how-to/customize-workspace/client/src/framework/workspace/store.ts
@@ -1,13 +1,13 @@
 import {
 	Storefront,
-	StorefrontLandingPage,
-	StorefrontNavigationSection,
-	StorefrontFooter,
-	StorefrontProvider,
 	StorefrontTemplate,
-	StorefrontNavigationItem,
-	StorefrontDetailedNavigationItem,
-	RegistrationMetaInfo
+	type RegistrationMetaInfo,
+	type StorefrontDetailedNavigationItem,
+	type StorefrontFooter,
+	type StorefrontLandingPage,
+	type StorefrontNavigationItem,
+	type StorefrontNavigationSection,
+	type StorefrontProvider
 } from "@openfin/workspace";
 import { getApps, getAppsByTag } from "../apps";
 import { launch } from "../launch";

--- a/how-to/customize-workspace/client/src/modules/integrations/emoji/integration.ts
+++ b/how-to/customize-workspace/client/src/modules/integrations/emoji/integration.ts
@@ -1,13 +1,13 @@
 import {
+	ButtonStyle,
 	CLITemplate,
 	type CLIFilter,
 	type HomeDispatchedSearchResult,
 	type HomeSearchListenerResponse,
 	type HomeSearchResponse,
 	type HomeSearchResult,
-	ButtonStyle,
-	TemplateFragment,
-	PlainContainerTemplateFragment
+	type PlainContainerTemplateFragment,
+	type TemplateFragment
 } from "@openfin/workspace";
 import type {
 	IntegrationHelpers,

--- a/how-to/customize-workspace/client/src/modules/integrations/quote/integration.ts
+++ b/how-to/customize-workspace/client/src/modules/integrations/quote/integration.ts
@@ -1,12 +1,12 @@
 import {
+	ButtonStyle,
 	CLITemplate,
 	type CLIFilter,
 	type HomeDispatchedSearchResult,
 	type HomeSearchListenerResponse,
 	type HomeSearchResponse,
 	type HomeSearchResult,
-	TemplateFragment,
-	ButtonStyle
+	type TemplateFragment
 } from "@openfin/workspace";
 import {
 	CategoryScale,

--- a/how-to/customize-workspace/client/tsconfig.json
+++ b/how-to/customize-workspace/client/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"],
 		"paths": {

--- a/how-to/customize-workspace/client/tsconfig.schema.json
+++ b/how-to/customize-workspace/client/tsconfig.schema.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../common/types/fin"],
 		"paths": {

--- a/how-to/customize-workspace/server/express/tsconfig.json
+++ b/how-to/customize-workspace/server/express/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/customize-workspace/server/live/tsconfig.json
+++ b/how-to/customize-workspace/server/live/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/integrate-server-authentication/client/src/platform.ts
+++ b/how-to/integrate-server-authentication/client/src/platform.ts
@@ -1,4 +1,4 @@
-import { init as workspacePlatformInit, BrowserInitConfig } from "@openfin/workspace-platform";
+import { init as workspacePlatformInit, type BrowserInitConfig } from "@openfin/workspace-platform";
 
 export async function init() {
 	console.log("Initialising platform");

--- a/how-to/integrate-server-authentication/client/tsconfig.json
+++ b/how-to/integrate-server-authentication/client/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/integrate-server-authentication/server/tsconfig.json
+++ b/how-to/integrate-server-authentication/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/integrate-with-bloomberg-basic/client/src/bbgtest.ts
+++ b/how-to/integrate-with-bloomberg-basic/client/src/bbgtest.ts
@@ -1,5 +1,11 @@
-import { BloombergConnection, connect, enableLogging, isBloombergTerminalReady } from "@openfin/bloomberg";
-import OpenFin, { fin } from "@openfin/core";
+import {
+	connect,
+	enableLogging,
+	isBloombergTerminalReady,
+	type BloombergConnection
+} from "@openfin/bloomberg";
+import type OpenFin from "@openfin/core";
+import { fin } from "@openfin/core";
 
 let bbgConnection: BloombergConnection;
 let isConnected = false;

--- a/how-to/integrate-with-bloomberg-basic/client/src/platform.ts
+++ b/how-to/integrate-with-bloomberg-basic/client/src/platform.ts
@@ -1,4 +1,4 @@
-import { init as workspacePlatformInit, BrowserInitConfig } from "@openfin/workspace-platform";
+import { init as workspacePlatformInit, type BrowserInitConfig } from "@openfin/workspace-platform";
 import { interopOverride } from "./interopbroker";
 
 export async function init() {

--- a/how-to/integrate-with-bloomberg-basic/client/tsconfig.json
+++ b/how-to/integrate-with-bloomberg-basic/client/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/integrate-with-bloomberg-basic/server/tsconfig.json
+++ b/how-to/integrate-with-bloomberg-basic/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/integrate-with-excel/client/src/home.ts
+++ b/how-to/integrate-with-excel/client/src/home.ts
@@ -1,14 +1,14 @@
 import {
-	App,
-	CLIProvider,
-	CLISearchListenerRequest,
-	CLISearchListenerResponse,
-	CLISearchResponse,
 	CLITemplate,
 	Home,
-	HomeDispatchedSearchResult,
-	HomeSearchResponse,
-	HomeSearchResult
+	type App,
+	type CLIProvider,
+	type CLISearchListenerRequest,
+	type CLISearchListenerResponse,
+	type CLISearchResponse,
+	type HomeDispatchedSearchResult,
+	type HomeSearchResponse,
+	type HomeSearchResult
 } from "@openfin/workspace";
 import { getApps } from "./apps";
 import { getSearchResults, itemSelection } from "./integrations";

--- a/how-to/integrate-with-excel/client/src/integrations/excel/integration-provider.ts
+++ b/how-to/integrate-with-excel/client/src/integrations/excel/integration-provider.ts
@@ -1,6 +1,6 @@
 import type OpenFin from "@openfin/core";
 import type { InteropClient } from "@openfin/core/src/api/interop";
-import { Cell, enableLogging, ExcelApplication, getExcelApplication } from "@openfin/excel";
+import { enableLogging, getExcelApplication, type Cell, type ExcelApplication } from "@openfin/excel";
 import {
 	CLITemplate,
 	type CLIDispatchedSearchResult,

--- a/how-to/integrate-with-excel/client/src/platform.ts
+++ b/how-to/integrate-with-excel/client/src/platform.ts
@@ -1,7 +1,7 @@
 import {
 	init as workspacePlatformInit,
-	BrowserInitConfig,
-	BrowserCreateWindowRequest
+	type BrowserCreateWindowRequest,
+	type BrowserInitConfig
 } from "@openfin/workspace-platform";
 import { getSettings } from "./settings";
 

--- a/how-to/integrate-with-excel/client/tsconfig.json
+++ b/how-to/integrate-with-excel/client/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/integrate-with-excel/server/tsconfig.json
+++ b/how-to/integrate-with-excel/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/integrate-with-ms365-basic/client/src/provider.ts
+++ b/how-to/integrate-with-ms365-basic/client/src/provider.ts
@@ -1,7 +1,7 @@
 import type { User } from "@microsoft/microsoft-graph-types";
-import { connect, Microsoft365Connection, TeamsConnection } from "@openfin/microsoft365";
+import { TeamsConnection, connect, type Microsoft365Connection } from "@openfin/microsoft365";
 import { init as workspacePlatformInit } from "@openfin/workspace-platform";
-import { TENANT_ID, CLIENT_ID, REDIRECT_URL } from "./settings";
+import { CLIENT_ID, REDIRECT_URL, TENANT_ID } from "./settings";
 
 export interface GraphListResponse<T> {
 	value?: T[];

--- a/how-to/integrate-with-ms365-basic/client/tsconfig.json
+++ b/how-to/integrate-with-ms365-basic/client/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/integrate-with-ms365-basic/server/tsconfig.json
+++ b/how-to/integrate-with-ms365-basic/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/integrate-with-ms365/client/src/home.ts
+++ b/how-to/integrate-with-ms365/client/src/home.ts
@@ -1,15 +1,15 @@
 import {
-	App,
-	CLIFilter,
 	CLITemplate,
 	Home,
-	HomeDispatchedSearchResult,
-	HomeProvider,
-	HomeRegistration,
-	HomeSearchListenerRequest,
-	HomeSearchListenerResponse,
-	HomeSearchResponse,
-	HomeSearchResult
+	type App,
+	type CLIFilter,
+	type HomeDispatchedSearchResult,
+	type HomeProvider,
+	type HomeRegistration,
+	type HomeSearchListenerRequest,
+	type HomeSearchListenerResponse,
+	type HomeSearchResponse,
+	type HomeSearchResult
 } from "@openfin/workspace";
 import { getApps } from "./apps";
 import { getHelpSearchEntries, getSearchResults, itemSelection } from "./integrations";

--- a/how-to/integrate-with-ms365/client/src/integrations/ms365/integration-provider.ts
+++ b/how-to/integrate-with-ms365/client/src/integrations/ms365/integration-provider.ts
@@ -4,9 +4,9 @@ import type {
 	Channel,
 	ChatMessage,
 	Contact,
+	DriveItem,
 	Entity,
 	Event,
-	DriveItem,
 	Message,
 	Presence,
 	SearchResponse,
@@ -16,20 +16,20 @@ import type {
 import {
 	connect,
 	enableLogging,
-	GraphResponse,
 	TeamsConnection,
+	type GraphResponse,
 	type Microsoft365Connection
 } from "@openfin/microsoft365";
 import {
 	ButtonStyle,
-	CLIFilter,
 	CLITemplate,
-	HomeDispatchedSearchResult,
-	HomeSearchListenerResponse,
-	HomeSearchResponse,
-	HomeSearchResult,
-	TemplateFragment,
-	TemplateFragmentTypes
+	TemplateFragmentTypes,
+	type CLIFilter,
+	type HomeDispatchedSearchResult,
+	type HomeSearchListenerResponse,
+	type HomeSearchResponse,
+	type HomeSearchResult,
+	type TemplateFragment
 } from "@openfin/workspace";
 import type { CustomPaletteSet } from "@openfin/workspace-platform";
 import type { IntegrationHelpers, IntegrationModule } from "../../shapes/integrations-shapes";

--- a/how-to/integrate-with-ms365/client/src/platform.ts
+++ b/how-to/integrate-with-ms365/client/src/platform.ts
@@ -1,4 +1,4 @@
-import { init as workspacePlatformInit, BrowserInitConfig } from "@openfin/workspace-platform";
+import { init as workspacePlatformInit, type BrowserInitConfig } from "@openfin/workspace-platform";
 import { getSettings } from "./settings";
 import type { CustomSettings } from "./shapes/framework-shapes";
 import { getThemes } from "./themes";

--- a/how-to/integrate-with-ms365/client/src/templates.ts
+++ b/how-to/integrate-with-ms365/client/src/templates.ts
@@ -1,11 +1,11 @@
 import {
 	ButtonStyle,
-	ButtonTemplateFragment,
-	ImageTemplateFragment,
-	PlainContainerTemplateFragment,
-	TemplateFragment,
 	TemplateFragmentTypes,
-	TextTemplateFragment
+	type ButtonTemplateFragment,
+	type ImageTemplateFragment,
+	type PlainContainerTemplateFragment,
+	type TemplateFragment,
+	type TextTemplateFragment
 } from "@openfin/workspace";
 import type * as CSS from "csstype";
 import { getCurrentPalette } from "./themes";

--- a/how-to/integrate-with-ms365/client/src/themes.ts
+++ b/how-to/integrate-with-ms365/client/src/themes.ts
@@ -1,4 +1,4 @@
-import { ColorSchemeOptionType, CustomThemes, getCurrentSync } from "@openfin/workspace-platform";
+import { ColorSchemeOptionType, getCurrentSync, type CustomThemes } from "@openfin/workspace-platform";
 import type { CustomPaletteSet, CustomThemeOptions } from "@openfin/workspace/common/src/api/theming";
 import { DEFAULT_PALETTES } from "./default-palletes";
 import { getSettings } from "./settings";

--- a/how-to/integrate-with-ms365/client/tsconfig.json
+++ b/how-to/integrate-with-ms365/client/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/integrate-with-ms365/server/tsconfig.json
+++ b/how-to/integrate-with-ms365/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/integrate-with-rss/client/src/browser.ts
+++ b/how-to/integrate-with-rss/client/src/browser.ts
@@ -1,6 +1,10 @@
 import type OpenFin from "@openfin/core";
 import type { Page } from "@openfin/workspace";
-import { BrowserCreateWindowRequest, BrowserWindowModule, getCurrentSync } from "@openfin/workspace-platform";
+import {
+	getCurrentSync,
+	type BrowserCreateWindowRequest,
+	type BrowserWindowModule
+} from "@openfin/workspace-platform";
 
 export type LayoutItemExtended =
 	| OpenFin.LayoutItemConfig

--- a/how-to/integrate-with-rss/client/src/home.ts
+++ b/how-to/integrate-with-rss/client/src/home.ts
@@ -1,10 +1,10 @@
 import {
 	Home,
-	HomeDispatchedSearchResult,
-	HomeProvider,
-	HomeSearchListenerRequest,
-	HomeSearchListenerResponse,
-	HomeSearchResponse
+	type HomeDispatchedSearchResult,
+	type HomeProvider,
+	type HomeSearchListenerRequest,
+	type HomeSearchListenerResponse,
+	type HomeSearchResponse
 } from "@openfin/workspace";
 import { getHelpSearchEntries, getSearchResults, itemSelection } from "./integrations";
 import { getSettings } from "./settings";

--- a/how-to/integrate-with-rss/client/src/integrations/rss/integration-provider.ts
+++ b/how-to/integrate-with-rss/client/src/integrations/rss/integration-provider.ts
@@ -2,28 +2,28 @@ import type OpenFin from "@openfin/core";
 import type { ChannelProvider } from "@openfin/core/src/api/interappbus/channel/provider";
 import {
 	CLITemplate,
-	HomeSearchResult,
-	Page,
 	type CLIFilter,
 	type HomeDispatchedSearchResult,
 	type HomeSearchListenerResponse,
-	type HomeSearchResponse
+	type HomeSearchResponse,
+	type HomeSearchResult,
+	type Page
 } from "@openfin/workspace";
 import {
 	addEventListener as addNotificationEventListener,
 	create as createNotification,
-	NotificationActionEvent
+	type NotificationActionEvent
 } from "@openfin/workspace/notifications";
 import { XMLParser } from "fast-xml-parser";
 import type { Integration, IntegrationHelpers, IntegrationModule } from "../../integrations-shapes";
 import {
 	CHANNEL_ACTIONS,
-	RssCache,
-	RssChannelFeedSubscribePayload,
-	RssFeed,
-	RssFeedCache,
-	RssFeedCacheEntry,
-	RssFeedSettings
+	type RssCache,
+	type RssChannelFeedSubscribePayload,
+	type RssFeed,
+	type RssFeedCache,
+	type RssFeedCacheEntry,
+	type RssFeedSettings
 } from "./shapes";
 import { getRssEntryTemplate, getRssFeedTemplate } from "./templates";
 

--- a/how-to/integrate-with-rss/client/src/integrations/rss/templates.ts
+++ b/how-to/integrate-with-rss/client/src/integrations/rss/templates.ts
@@ -1,4 +1,4 @@
-import { ButtonStyle, TemplateFragment } from "@openfin/workspace";
+import { ButtonStyle, type TemplateFragment } from "@openfin/workspace";
 import { createButton, createContainer, createImage, createText } from "../../templates";
 import { getCurrentPalette } from "../../themes";
 

--- a/how-to/integrate-with-rss/client/src/platform.ts
+++ b/how-to/integrate-with-rss/client/src/platform.ts
@@ -1,4 +1,4 @@
-import { init as workspacePlatformInit, BrowserInitConfig } from "@openfin/workspace-platform";
+import { init as workspacePlatformInit, type BrowserInitConfig } from "@openfin/workspace-platform";
 import { getThemes } from "./themes";
 
 export async function init() {

--- a/how-to/integrate-with-rss/client/src/templates.ts
+++ b/how-to/integrate-with-rss/client/src/templates.ts
@@ -1,11 +1,11 @@
 import {
 	ButtonStyle,
-	ButtonTemplateFragment,
-	ImageTemplateFragment,
-	PlainContainerTemplateFragment,
-	TemplateFragment,
 	TemplateFragmentTypes,
-	TextTemplateFragment
+	type ButtonTemplateFragment,
+	type ImageTemplateFragment,
+	type PlainContainerTemplateFragment,
+	type TemplateFragment,
+	type TextTemplateFragment
 } from "@openfin/workspace";
 import type * as CSS from "csstype";
 import { getCurrentPalette } from "./themes";

--- a/how-to/integrate-with-rss/client/tsconfig.json
+++ b/how-to/integrate-with-rss/client/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/integrate-with-rss/server/tsconfig.json
+++ b/how-to/integrate-with-rss/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/integrate-with-salesforce-basic/client/src/provider.ts
+++ b/how-to/integrate-with-salesforce-basic/client/src/provider.ts
@@ -1,7 +1,7 @@
 import {
 	connect,
-	SalesforceRestApiSObjectContact,
 	type SalesforceConnection,
+	type SalesforceRestApiSObjectContact,
 	type SalesforceRestApiSearchResult
 } from "@openfin/salesforce";
 import { getCurrentSync, init as workspacePlatformInit } from "@openfin/workspace-platform";

--- a/how-to/integrate-with-salesforce-basic/client/tsconfig.json
+++ b/how-to/integrate-with-salesforce-basic/client/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/integrate-with-salesforce-basic/server/tsconfig.json
+++ b/how-to/integrate-with-salesforce-basic/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/integrate-with-salesforce/client/src/home.ts
+++ b/how-to/integrate-with-salesforce/client/src/home.ts
@@ -1,13 +1,13 @@
 import {
-	App,
-	CLIFilter,
 	Home,
-	HomeDispatchedSearchResult,
-	HomeProvider,
-	HomeRegistration,
-	HomeSearchListenerRequest,
-	HomeSearchListenerResponse,
-	HomeSearchResponse
+	type App,
+	type CLIFilter,
+	type HomeDispatchedSearchResult,
+	type HomeProvider,
+	type HomeRegistration,
+	type HomeSearchListenerRequest,
+	type HomeSearchListenerResponse,
+	type HomeSearchResponse
 } from "@openfin/workspace";
 import { getHelpSearchEntries, getSearchResults, itemSelection } from "./integrations";
 import { launch } from "./launch";

--- a/how-to/integrate-with-salesforce/client/src/integrations/salesforce/integration-provider.ts
+++ b/how-to/integrate-with-salesforce/client/src/integrations/salesforce/integration-provider.ts
@@ -1,20 +1,20 @@
 import {
 	AuthorizationError,
-	SalesforceRestApiQueryResult,
 	connect,
 	enableLogging,
 	type SalesforceConnection,
+	type SalesforceRestApiQueryResult,
 	type SalesforceRestApiSearchResult
 } from "@openfin/salesforce";
 import {
 	ButtonStyle,
-	CLISearchResultLoading,
 	CLITemplate,
-	CustomTemplate,
 	type CLIDispatchedSearchResult,
 	type CLIFilter,
 	type CLISearchListenerResponse,
+	type CLISearchResultLoading,
 	type CLISearchResultSimpleText,
+	type CustomTemplate,
 	type HomeSearchResponse,
 	type HomeSearchResult,
 	type TemplateFragment

--- a/how-to/integrate-with-salesforce/client/src/platform.ts
+++ b/how-to/integrate-with-salesforce/client/src/platform.ts
@@ -1,4 +1,4 @@
-import { init as workspacePlatformInit, BrowserInitConfig } from "@openfin/workspace-platform";
+import { init as workspacePlatformInit, type BrowserInitConfig } from "@openfin/workspace-platform";
 import { getSettings } from "./settings";
 import type { CustomSettings } from "./shapes/framework-shapes";
 import { getThemes } from "./themes";

--- a/how-to/integrate-with-salesforce/client/src/templates.ts
+++ b/how-to/integrate-with-salesforce/client/src/templates.ts
@@ -1,11 +1,11 @@
 import {
 	ButtonStyle,
-	ButtonTemplateFragment,
-	ImageTemplateFragment,
-	PlainContainerTemplateFragment,
-	TemplateFragment,
 	TemplateFragmentTypes,
-	TextTemplateFragment
+	type ButtonTemplateFragment,
+	type ImageTemplateFragment,
+	type PlainContainerTemplateFragment,
+	type TemplateFragment,
+	type TextTemplateFragment
 } from "@openfin/workspace";
 import type * as CSS from "csstype";
 import { getCurrentPalette } from "./themes";

--- a/how-to/integrate-with-salesforce/client/src/themes.ts
+++ b/how-to/integrate-with-salesforce/client/src/themes.ts
@@ -1,4 +1,4 @@
-import { ColorSchemeOptionType, CustomThemes, getCurrentSync } from "@openfin/workspace-platform";
+import { ColorSchemeOptionType, getCurrentSync, type CustomThemes } from "@openfin/workspace-platform";
 import type { CustomPaletteSet, CustomThemeOptions } from "@openfin/workspace/common/src/api/theming";
 import { DEFAULT_PALETTES } from "./default-palletes";
 import { getSettings } from "./settings";

--- a/how-to/integrate-with-salesforce/client/tsconfig.json
+++ b/how-to/integrate-with-salesforce/client/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/integrate-with-salesforce/server/tsconfig.json
+++ b/how-to/integrate-with-salesforce/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/integrate-with-sso/integrate-with-auth0/client/src/platform.ts
+++ b/how-to/integrate-with-sso/integrate-with-auth0/client/src/platform.ts
@@ -1,4 +1,4 @@
-import { init as workspacePlatformInit, BrowserInitConfig } from "@openfin/workspace-platform";
+import { init as workspacePlatformInit, type BrowserInitConfig } from "@openfin/workspace-platform";
 
 export async function init() {
 	console.log("Initialising platform");

--- a/how-to/integrate-with-sso/integrate-with-auth0/client/tsconfig.json
+++ b/how-to/integrate-with-sso/integrate-with-auth0/client/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../../common/types/fin"]
 	},

--- a/how-to/integrate-with-sso/integrate-with-auth0/server/tsconfig.json
+++ b/how-to/integrate-with-sso/integrate-with-auth0/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/integrate-with-sso/integrate-with-okta/client/src/platform.ts
+++ b/how-to/integrate-with-sso/integrate-with-okta/client/src/platform.ts
@@ -1,4 +1,4 @@
-import { init as workspacePlatformInit, BrowserInitConfig } from "@openfin/workspace-platform";
+import { init as workspacePlatformInit, type BrowserInitConfig } from "@openfin/workspace-platform";
 
 export async function init() {
 	console.log("Initializing platform");

--- a/how-to/integrate-with-sso/integrate-with-okta/client/tsconfig.json
+++ b/how-to/integrate-with-sso/integrate-with-okta/client/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../../common/types/fin"]
 	},

--- a/how-to/integrate-with-sso/integrate-with-okta/server/tsconfig.json
+++ b/how-to/integrate-with-sso/integrate-with-okta/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/register-with-browser/client/src/launchbar.ts
+++ b/how-to/register-with-browser/client/src/launchbar.ts
@@ -1,14 +1,14 @@
 import type OpenFin from "@openfin/core";
 import {
 	BrowserButtonType,
-	PageLayoutDetails,
-	PageWithUpdatableRuntimeAttribs,
 	PanelPosition,
 	getCurrentSync,
 	type BrowserCreateWindowRequest,
 	type BrowserWindowModule,
 	type Page,
 	type PageLayout,
+	type PageLayoutDetails,
+	type PageWithUpdatableRuntimeAttribs,
 	type ToolbarOptions
 } from "@openfin/workspace-platform";
 

--- a/how-to/register-with-browser/client/tsconfig.json
+++ b/how-to/register-with-browser/client/tsconfig.json
@@ -9,7 +9,6 @@
 		"strict": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/register-with-browser/server/tsconfig.json
+++ b/how-to/register-with-browser/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/register-with-dock-basic/client/src/dock.ts
+++ b/how-to/register-with-dock-basic/client/src/dock.ts
@@ -6,9 +6,9 @@ import {
 } from "@openfin/workspace";
 import {
 	CustomActionCallerType,
-	CustomActionPayload,
-	CustomActionsMap,
-	getCurrentSync
+	getCurrentSync,
+	type CustomActionPayload,
+	type CustomActionsMap
 } from "@openfin/workspace-platform";
 
 /**

--- a/how-to/register-with-dock-basic/client/tsconfig.json
+++ b/how-to/register-with-dock-basic/client/tsconfig.json
@@ -9,7 +9,6 @@
 		"strict": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/register-with-dock-basic/server/tsconfig.json
+++ b/how-to/register-with-dock-basic/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/register-with-home-basic/client/tsconfig.json
+++ b/how-to/register-with-home-basic/client/tsconfig.json
@@ -9,7 +9,6 @@
 		"strict": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/register-with-home-basic/server/tsconfig.json
+++ b/how-to/register-with-home-basic/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/register-with-home/client/src/home.ts
+++ b/how-to/register-with-home/client/src/home.ts
@@ -9,8 +9,8 @@ import {
 	type CLISearchListenerRequest,
 	type CLISearchListenerResponse,
 	type CLISearchResponse,
-	type HomeSearchResult,
-	HomeRegistration
+	type HomeRegistration,
+	type HomeSearchResult
 } from "@openfin/workspace";
 import { getCurrentSync, type Page } from "@openfin/workspace-platform";
 import { getApps, launchApp } from "./apps";

--- a/how-to/register-with-home/client/tsconfig.json
+++ b/how-to/register-with-home/client/tsconfig.json
@@ -9,7 +9,6 @@
 		"strict": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/register-with-home/server/tsconfig.json
+++ b/how-to/register-with-home/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/register-with-platform-windows/client/tsconfig.json
+++ b/how-to/register-with-platform-windows/client/tsconfig.json
@@ -9,7 +9,6 @@
 		"strict": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/register-with-platform-windows/server/tsconfig.json
+++ b/how-to/register-with-platform-windows/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/register-with-store-basic/client/tsconfig.json
+++ b/how-to/register-with-store-basic/client/tsconfig.json
@@ -9,7 +9,6 @@
 		"strict": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/register-with-store-basic/server/tsconfig.json
+++ b/how-to/register-with-store-basic/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/register-with-store/client/tsconfig.json
+++ b/how-to/register-with-store/client/tsconfig.json
@@ -9,7 +9,6 @@
 		"strict": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/register-with-store/server/tsconfig.json
+++ b/how-to/register-with-store/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/support-context-and-intents/client/src/browser.ts
+++ b/how-to/support-context-and-intents/client/src/browser.ts
@@ -1,5 +1,5 @@
 import type OpenFin from "@openfin/core";
-import { getCurrentSync, Page } from "@openfin/workspace-platform";
+import { getCurrentSync, type Page } from "@openfin/workspace-platform";
 
 export async function getPage(pageId: string) {
 	const platform = getCurrentSync();

--- a/how-to/support-context-and-intents/client/src/home.ts
+++ b/how-to/support-context-and-intents/client/src/home.ts
@@ -1,15 +1,15 @@
 import {
-	App,
-	CLIDispatchedSearchResult,
-	CLIFilter,
 	CLIFilterOptionType,
-	CLIProvider,
-	CLISearchListenerRequest,
-	CLISearchListenerResponse,
-	CLISearchResponse,
 	CLITemplate,
 	Home,
-	HomeSearchResult
+	type App,
+	type CLIDispatchedSearchResult,
+	type CLIFilter,
+	type CLIProvider,
+	type CLISearchListenerRequest,
+	type CLISearchListenerResponse,
+	type CLISearchResponse,
+	type HomeSearchResult
 } from "@openfin/workspace";
 import type { Page } from "@openfin/workspace-platform";
 import { getApps } from "./apps";

--- a/how-to/support-context-and-intents/client/src/launch.ts
+++ b/how-to/support-context-and-intents/client/src/launch.ts
@@ -1,6 +1,6 @@
 import type OpenFin from "@openfin/core";
 import type { App } from "@openfin/workspace";
-import { BrowserSnapshot, getCurrentSync } from "@openfin/workspace-platform";
+import { getCurrentSync, type BrowserSnapshot } from "@openfin/workspace-platform";
 import { getSettings } from "./settings";
 import { randomUUID } from "./uuid";
 

--- a/how-to/support-context-and-intents/client/src/platform.ts
+++ b/how-to/support-context-and-intents/client/src/platform.ts
@@ -1,4 +1,4 @@
-import { BrowserInitConfig, init as workspacePlatformInit } from "@openfin/workspace-platform";
+import { init as workspacePlatformInit, type BrowserInitConfig } from "@openfin/workspace-platform";
 import { interopOverride } from "./interopbroker";
 import { getSettings, validateThemes } from "./settings";
 

--- a/how-to/support-context-and-intents/client/src/store.ts
+++ b/how-to/support-context-and-intents/client/src/store.ts
@@ -1,13 +1,13 @@
 import {
 	Storefront,
-	StorefrontLandingPage,
-	StorefrontNavigationSection,
-	StorefrontFooter,
-	App,
-	StorefrontProvider,
 	StorefrontTemplate,
-	StorefrontNavigationItem,
-	StorefrontDetailedNavigationItem
+	type App,
+	type StorefrontDetailedNavigationItem,
+	type StorefrontFooter,
+	type StorefrontLandingPage,
+	type StorefrontNavigationItem,
+	type StorefrontNavigationSection,
+	type StorefrontProvider
 } from "@openfin/workspace";
 import { getApps, getAppsByTag } from "./apps";
 import { launch } from "./launch";

--- a/how-to/support-context-and-intents/client/tsconfig.json
+++ b/how-to/support-context-and-intents/client/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/support-context-and-intents/server/tsconfig.json
+++ b/how-to/support-context-and-intents/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/use-notifications/client/tsconfig.json
+++ b/how-to/use-notifications/client/tsconfig.json
@@ -9,7 +9,6 @@
 		"strict": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/use-notifications/server/tsconfig.json
+++ b/how-to/use-notifications/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/use-theming-basic/client/src/provider.ts
+++ b/how-to/use-theming-basic/client/src/provider.ts
@@ -2,9 +2,9 @@ import type { Context } from "@openfin/core/src/OpenFin";
 import { Home } from "@openfin/workspace";
 import {
 	ColorSchemeOptionType,
-	CustomThemeOptionsWithScheme,
 	getCurrentSync,
-	init
+	init,
+	type CustomThemeOptionsWithScheme
 } from "@openfin/workspace-platform";
 import { register } from "./home";
 

--- a/how-to/use-theming-basic/client/tsconfig.json
+++ b/how-to/use-theming-basic/client/tsconfig.json
@@ -9,7 +9,6 @@
 		"strict": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/use-theming-basic/server/tsconfig.json
+++ b/how-to/use-theming-basic/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/use-theming/client/src/dock.ts
+++ b/how-to/use-theming/client/src/dock.ts
@@ -1,4 +1,4 @@
-import { Dock, DockButtonNames, DockProvider } from "@openfin/workspace";
+import { Dock, DockButtonNames, type DockProvider } from "@openfin/workspace";
 
 const providerId = "use-theming";
 

--- a/how-to/use-theming/client/src/home.ts
+++ b/how-to/use-theming/client/src/home.ts
@@ -1,13 +1,13 @@
 import {
-	CLIDispatchedSearchResult,
-	CLIProvider,
-	CLISearchListenerRequest,
-	CLISearchListenerResponse,
-	CLISearchResponse,
 	CLITemplate,
 	Home,
-	HomeSearchResult,
-	RegistrationMetaInfo
+	type CLIDispatchedSearchResult,
+	type CLIProvider,
+	type CLISearchListenerRequest,
+	type CLISearchListenerResponse,
+	type CLISearchResponse,
+	type HomeSearchResult,
+	type RegistrationMetaInfo
 } from "@openfin/workspace";
 import { getCurrentSync } from "@openfin/workspace-platform";
 import { getApps } from "./apps";

--- a/how-to/use-theming/client/src/platform-override.ts
+++ b/how-to/use-theming/client/src/platform-override.ts
@@ -1,8 +1,8 @@
 import type OpenFin from "@openfin/core";
 import {
-	ColorSchemeOptionType,
 	getCurrentSync,
-	WorkspacePlatformOverrideCallback
+	type ColorSchemeOptionType,
+	type WorkspacePlatformOverrideCallback
 } from "@openfin/workspace-platform";
 import { setColorScheme, updateBrowserWindowButtonsColorScheme } from "./themes";
 

--- a/how-to/use-theming/client/src/store.ts
+++ b/how-to/use-theming/client/src/store.ts
@@ -1,14 +1,14 @@
 import {
 	Storefront,
-	App,
-	StorefrontLandingPage,
-	StorefrontNavigationSection,
-	StorefrontFooter,
-	StorefrontProvider,
-	StorefrontTemplate
+	StorefrontTemplate,
+	type App,
+	type StorefrontFooter,
+	type StorefrontLandingPage,
+	type StorefrontNavigationSection,
+	type StorefrontProvider
 } from "@openfin/workspace";
 import { getCurrentSync } from "@openfin/workspace-platform";
-import { getApps, themeBuilderApp, notificationStudio, processManager, developerContent } from "./apps";
+import { developerContent, getApps, notificationStudio, processManager, themeBuilderApp } from "./apps";
 
 const providerId = "use-theming";
 

--- a/how-to/use-theming/client/src/themes.ts
+++ b/how-to/use-theming/client/src/themes.ts
@@ -1,10 +1,10 @@
 import type OpenFin from "@openfin/core";
 import {
 	BrowserButtonType,
-	BrowserWindowModule,
 	ColorSchemeOptionType,
 	getCurrentSync,
-	ToolbarButton
+	type BrowserWindowModule,
+	type ToolbarButton
 } from "@openfin/workspace-platform";
 import type { CustomPaletteSet } from "@openfin/workspace/common/src/api/theming";
 import { DEFAULT_PALETTES } from "./default-palettes";

--- a/how-to/use-theming/client/tsconfig.json
+++ b/how-to/use-theming/client/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/use-theming/server/tsconfig.json
+++ b/how-to/use-theming/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/how-to/workspace-native-window-integration/client/src/home.ts
+++ b/how-to/workspace-native-window-integration/client/src/home.ts
@@ -1,17 +1,17 @@
 import {
-	App,
-	CLIDispatchedSearchResult,
-	CLIFilter,
 	CLIFilterOptionType,
-	CLIProvider,
-	CLISearchListenerRequest,
-	CLISearchListenerResponse,
-	CLISearchResponse,
 	CLITemplate,
 	Home,
-	HomeSearchResponse,
-	HomeSearchResult,
-	TemplateFragment
+	type App,
+	type CLIDispatchedSearchResult,
+	type CLIFilter,
+	type CLIProvider,
+	type CLISearchListenerRequest,
+	type CLISearchListenerResponse,
+	type CLISearchResponse,
+	type HomeSearchResponse,
+	type HomeSearchResult,
+	type TemplateFragment
 } from "@openfin/workspace";
 import type { BrowserSnapshot } from "@openfin/workspace-platform";
 import { getApps } from "./apps";

--- a/how-to/workspace-native-window-integration/client/src/native-window-integration.ts
+++ b/how-to/workspace-native-window-integration/client/src/native-window-integration.ts
@@ -1,7 +1,7 @@
 import type OpenFin from "@openfin/core";
 import {
-	ClientConfiguration,
-	NativeWindowIntegrationClient
+	NativeWindowIntegrationClient,
+	type ClientConfiguration
 } from "@openfin/native-window-integration-client";
 import asset from "@openfin/native-window-integration-client/lib/provider.zip";
 import type { App } from "@openfin/workspace-platform";

--- a/how-to/workspace-native-window-integration/client/src/platform.ts
+++ b/how-to/workspace-native-window-integration/client/src/platform.ts
@@ -1,4 +1,4 @@
-import { init as workspacePlatformInit, BrowserInitConfig } from "@openfin/workspace-platform";
+import { init as workspacePlatformInit, type BrowserInitConfig } from "@openfin/workspace-platform";
 import { overrideCallback } from "./browser";
 
 export async function init() {

--- a/how-to/workspace-native-window-integration/client/src/template.ts
+++ b/how-to/workspace-native-window-integration/client/src/template.ts
@@ -1,4 +1,4 @@
-import { ButtonStyle, TemplateFragment, TemplateFragmentTypes } from "@openfin/workspace";
+import { ButtonStyle, TemplateFragmentTypes, type TemplateFragment } from "@openfin/workspace";
 
 const WORKSPACE_ACTIONS = {
 	delete: "workspace-delete",

--- a/how-to/workspace-native-window-integration/client/src/workspace.ts
+++ b/how-to/workspace-native-window-integration/client/src/workspace.ts
@@ -1,4 +1,4 @@
-import { BrowserSnapshot, getCurrentSync } from "@openfin/workspace-platform";
+import { getCurrentSync, type BrowserSnapshot } from "@openfin/workspace-platform";
 import { PlatformStorage } from "./platform-storage";
 
 export interface ISavedWorkspace {

--- a/how-to/workspace-native-window-integration/client/tsconfig.json
+++ b/how-to/workspace-native-window-integration/client/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node",
 		"types": ["../../common/types/fin"]
 	},

--- a/how-to/workspace-native-window-integration/server/tsconfig.json
+++ b/how-to/workspace-native-window-integration/server/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	},
 	"include": ["./src/**/*.ts"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -370,7 +370,14 @@
 			},
 			"devDependencies": {
 				"@okta/okta-auth-js": "^7.2.0",
-				"@openfin/core": "30.74.13"
+				"@openfin/core": "30.74.13",
+				"@types/express": "^4.17.17",
+				"@types/node": "^18.16.0",
+				"express": "^4.18.2",
+				"ts-loader": "^9.4.2",
+				"typescript": "^4.9.5",
+				"webpack": "^5.80.0",
+				"webpack-cli": "^5.0.2"
 			}
 		},
 		"how-to/register-with-browser": {
@@ -29999,7 +30006,14 @@
 				"@okta/okta-auth-js": "^7.2.0",
 				"@openfin/core": "30.74.13",
 				"@openfin/workspace": "12.6.6",
-				"@openfin/workspace-platform": "12.6.6"
+				"@openfin/workspace-platform": "12.6.6",
+				"@types/express": "^4.17.17",
+				"@types/node": "^18.16.0",
+				"express": "^4.18.2",
+				"ts-loader": "^9.4.2",
+				"typescript": "^4.9.5",
+				"webpack": "^5.80.0",
+				"webpack-cli": "^5.0.2"
 			}
 		},
 		"openfin-workspace--integrate-with-rss": {

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
-		"importsNotUsedAsValues": "error",
 		"moduleResolution": "node"
 	}
 }


### PR DESCRIPTION
Remove `importNotUsedAsValues` from `tsconfig.json` as this will soon be deprecated, instead use eslint `@typescript-eslint/consistent-type-imports` rule.