### PR TITLE
Remove deprecated APIs from dock basic

### DIFF
--- a/how-to/register-with-dock-basic/client/src/dock.ts
+++ b/how-to/register-with-dock-basic/client/src/dock.ts
@@ -2,7 +2,7 @@ import {
 	Dock,
 	DockButtonNames,
 	type RegistrationMetaInfo,
-	type WorkspaceComponentButtonOptions
+	type WorkspaceButtonsConfig
 } from "@openfin/workspace";
 import {
 	CustomActionCallerType,
@@ -17,7 +17,7 @@ import {
  * @param title The title to use for the dock registration.
  * @param icon The icon to use for the dock registration.
  * @param options The options to pass to the dock provider.
- * @param options.workspaceComponents The workspace components options.
+ * @param options.workspaceButtons The workspace buttons.
  * @param options.customIconUrl Use a custom icon url.
  * @param options.customOpenUrl Use a custom open url.
  * @returns The registration details for dock.
@@ -27,7 +27,8 @@ export async function register(
 	title: string,
 	icon: string,
 	options: {
-		workspaceComponents: WorkspaceComponentButtonOptions;
+		workspaceComponents: WorkspaceButtonsConfig;
+		disableUserRearrangement: boolean;
 		customIconUrl: string;
 		customOpenUrl: string;
 	}
@@ -40,6 +41,8 @@ export async function register(
 			title,
 			icon,
 			workspaceComponents: options.workspaceComponents,
+			disableUserRearrangement: options.disableUserRearrangement,
+			skipSavedDockProviderConfig: true,
 			buttons: [
 				{
 					tooltip: "Google",

--- a/how-to/register-with-dock-basic/client/src/provider.ts
+++ b/how-to/register-with-dock-basic/client/src/provider.ts
@@ -88,7 +88,7 @@ async function initializeWorkspaceComponents(): Promise<void> {
 		getApps: async () => [],
 		getLandingPage: async () => ({} as StorefrontLandingPage),
 		getNavigation: async () => [],
-		getFooter: async () => ({} as StorefrontFooter),
+		getFooter: async () => ({ logo: { src: PLATFORM_ICON }, links: [] } as unknown as StorefrontFooter),
 		launchApp: async () => {}
 	});
 }

--- a/how-to/register-with-dock-basic/client/src/provider.ts
+++ b/how-to/register-with-dock-basic/client/src/provider.ts
@@ -1,4 +1,11 @@
-import { Dock } from "@openfin/workspace";
+import {
+	Dock,
+	Home,
+	Storefront,
+	type StorefrontFooter,
+	type StorefrontLandingPage,
+	type WorkspaceButton
+} from "@openfin/workspace";
 import { init } from "@openfin/workspace-platform";
 import { dockGetCustomActions, register } from "./dock";
 
@@ -12,6 +19,7 @@ let showStorefrontButton: HTMLInputElement | null;
 let showWorkspacesButton: HTMLInputElement | null;
 let customIconUrlInput: HTMLInputElement | null;
 let customOpenUrlInput: HTMLInputElement | null;
+let enableRearrangementButton: HTMLInputElement | null;
 
 const PLATFORM_ID = "register-with-dock-basic";
 const PLATFORM_TITLE = "Register With Dock Basic";
@@ -20,7 +28,10 @@ const PLATFORM_ICON = "http://localhost:8080/favicon.ico";
 window.addEventListener("DOMContentLoaded", async () => {
 	// The DOM is ready so initialize the platform
 	// Provide default icons and default theme for the browser windows
-	await initializeWorkspacePlatform(PLATFORM_ICON);
+	await initializeWorkspacePlatform();
+
+	// Initialize dummy workspace components so that the buttons show in the dock.
+	await initializeWorkspaceComponents();
 
 	// Get the DOM elements from the provider.html page and initialize them
 	await initializeDOM();
@@ -28,17 +39,16 @@ window.addEventListener("DOMContentLoaded", async () => {
 
 /**
  * Initialize the workspace platform.
- * @param icon The icon to use in windows.
  */
-async function initializeWorkspacePlatform(icon: string): Promise<void> {
+async function initializeWorkspacePlatform(): Promise<void> {
 	console.log("Initialising workspace platform");
 	await init({
 		browser: {
 			defaultWindowOptions: {
-				icon,
+				icon: PLATFORM_ICON,
 				workspacePlatform: {
 					pages: [],
-					favicon: icon
+					favicon: PLATFORM_ICON
 				}
 			}
 		},
@@ -60,6 +70,30 @@ async function initializeWorkspacePlatform(icon: string): Promise<void> {
 }
 
 /**
+ * Initialize minimal workspace components for home/store so that the buttons show on dock.
+ */
+async function initializeWorkspaceComponents(): Promise<void> {
+	await Home.register({
+		title: PLATFORM_TITLE,
+		id: PLATFORM_ID,
+		icon: PLATFORM_ICON,
+		onUserInput: async () => ({ results: [] }),
+		onResultDispatch: async () => {}
+	});
+
+	await Storefront.register({
+		title: PLATFORM_TITLE,
+		id: PLATFORM_ID,
+		icon: PLATFORM_ICON,
+		getApps: async () => [],
+		getLandingPage: async () => ({} as StorefrontLandingPage),
+		getNavigation: async () => [],
+		getFooter: async () => ({} as StorefrontFooter),
+		launchApp: async () => {}
+	});
+}
+
+/**
  * Initialize the DOM elements.
  */
 async function initializeDOM(): Promise<void> {
@@ -71,6 +105,7 @@ async function initializeDOM(): Promise<void> {
 	showNotificationButton = document.querySelector<HTMLInputElement>("#showNotificationButton");
 	showStorefrontButton = document.querySelector<HTMLInputElement>("#showStorefrontButton");
 	showWorkspacesButton = document.querySelector<HTMLInputElement>("#showWorkspacesButton");
+	enableRearrangementButton = document.querySelector<HTMLInputElement>("#enableRearrangement");
 	customIconUrlInput = document.querySelector<HTMLInputElement>("#customIconUrl");
 	customOpenUrlInput = document.querySelector<HTMLInputElement>("#customOpenUrl");
 
@@ -80,15 +115,26 @@ async function initializeDOM(): Promise<void> {
 		registerButton.addEventListener("click", async () => {
 			setStates(null);
 			try {
+				const workspaceComponents: WorkspaceButton[] = [];
+
+				if (showHomeButton?.checked) {
+					workspaceComponents.push("home");
+				}
+				if (showNotificationButton?.checked) {
+					workspaceComponents.push("notifications");
+				}
+				if (showStorefrontButton?.checked) {
+					workspaceComponents.push("store");
+				}
+				if (showWorkspacesButton?.checked) {
+					workspaceComponents.push("switchWorkspace");
+				}
+
 				// Perform the dock registration which will configure
 				// it and add the buttons/menus
 				await register(PLATFORM_ID, PLATFORM_TITLE, PLATFORM_ICON, {
-					workspaceComponents: {
-						hideHomeButton: !showHomeButton?.checked ?? false,
-						hideNotificationsButton: !showNotificationButton?.checked ?? false,
-						hideStorefrontButton: !showStorefrontButton?.checked ?? false,
-						hideWorkspacesButton: !showWorkspacesButton?.checked ?? false
-					},
+					workspaceComponents,
+					disableUserRearrangement: !enableRearrangementButton?.checked ?? false,
 					customIconUrl: customIconUrlInput?.value ?? "",
 					customOpenUrl: customOpenUrlInput?.value ?? ""
 				});
@@ -128,6 +174,7 @@ function setStates(isRegistered: boolean | null): void {
 		showNotificationButton &&
 		showStorefrontButton &&
 		showWorkspacesButton &&
+		enableRearrangementButton &&
 		customIconUrlInput &&
 		customOpenUrlInput
 	) {
@@ -139,6 +186,7 @@ function setStates(isRegistered: boolean | null): void {
 		showNotificationButton.disabled = isRegistered === null || isRegistered;
 		showStorefrontButton.disabled = isRegistered === null || isRegistered;
 		showWorkspacesButton.disabled = isRegistered === null || isRegistered;
+		enableRearrangementButton.disabled = isRegistered === null || isRegistered;
 		customIconUrlInput.disabled = isRegistered === null || isRegistered;
 		customOpenUrlInput.disabled = isRegistered === null || isRegistered;
 	}

--- a/how-to/register-with-dock-basic/public/manifest.fin.json
+++ b/how-to/register-with-dock-basic/public/manifest.fin.json
@@ -6,7 +6,7 @@
 		"version": "31.112.75.4"
 	},
 	"platform": {
-		"uuid": "launch-dock-basic",
+		"uuid": "register-with-dock-basic",
 		"icon": "http://localhost:8080/favicon.ico",
 		"autoShow": true,
 		"providerUrl": "http://localhost:8080/platform/provider.html",

--- a/how-to/register-with-dock-basic/public/platform/provider.html
+++ b/how-to/register-with-dock-basic/public/platform/provider.html
@@ -53,6 +53,10 @@
 						<label for="showWorkspacesButton">Workspaces Button</label>
 					</fieldset>
 				</div>
+				<fieldset class="row">
+					<input type="checkbox" checked="true" id="enableRearrangement" />
+					<label for="enableRearrangement">Enable Re-arrangement</label>
+				</fieldset>
 				<div class="row wrap gap10">
 					<fieldset class="fill">
 						<label for="customIconUrl">Custom Button Icon Url</label>


### PR DESCRIPTION
* Replaces the deprecated types and apis with the v13 ones
* Adds new disable rearrangement option
* Registers dummy home and store so that the buttons show on dock