### PR TITLE
Updated example module and secondmanifest

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -530,7 +530,7 @@ module.exports = {
 				'@typescript-eslint/no-unsafe-assignment': ['off'],
 				'@typescript-eslint/no-unsafe-call': ['off'],
 				'@typescript-eslint/no-unsafe-member-access': ['off'],
-				'@typescript-eslint/no-unsafe-return': ['error'],
+				'@typescript-eslint/no-unsafe-return': ['off'],
 				'@typescript-eslint/no-unsafe-enum-comparison': ['off'],
 				'@typescript-eslint/no-unused-expressions': ['error'],
 				'@typescript-eslint/no-unused-vars': [

--- a/how-to/customize-workspace/client/src/framework/fdc3/1.2/mapper.ts
+++ b/how-to/customize-workspace/client/src/framework/fdc3/1.2/mapper.ts
@@ -37,7 +37,7 @@ function getManifest(app: AppDefinition): unknown {
 }
 
 function getTags(app: AppDefinition & { tags?: string[] }): string[] {
-	const tags: string[] = app.tags ?? [];
+	const tags: string[] = app.tags ?? app.categories ?? [];
 	if (tags.length === 0) {
 		tags.push(app.manifestType);
 	}

--- a/how-to/customize-workspace/client/src/framework/shapes/fdc3-1-2-shapes.ts
+++ b/how-to/customize-workspace/client/src/framework/shapes/fdc3-1-2-shapes.ts
@@ -60,6 +60,8 @@ export interface AppDefinition {
 	customConfig?: CustomConfig;
 	/** The list of intents implemented by the Application */
 	intents?: AppIntents[];
+	/** categories is not part of the FDC3 1.2 spec but we support tags in our own platform app structure and an equivalent categories was added to FDC3 2.0 so we map it if we find it in an FDC3 1.2 directory */
+	categories?: string[];
 }
 
 /** The successful response expected from a FDC3 1.2 request when all applications are requested. */

--- a/how-to/customize-workspace/client/src/modules/auth/example/shapes.ts
+++ b/how-to/customize-workspace/client/src/modules/auth/example/shapes.ts
@@ -26,4 +26,5 @@ export interface ExampleUserRoleMapping {
 	excludeAppsWithTag: string[];
 	preferredScheme: string;
 	excludeMenuAction: string[];
+	excludeMenuModule: string[];
 }

--- a/how-to/customize-workspace/client/src/modules/auth/example/shapes.ts
+++ b/how-to/customize-workspace/client/src/modules/auth/example/shapes.ts
@@ -28,3 +28,5 @@ export interface ExampleUserRoleMapping {
 	excludeMenuAction: string[];
 	excludeMenuModule: string[];
 }
+
+export type AppWithTagsOrCategories = { [id: string]: unknown } & { categories?: []; tags?: [] };

--- a/how-to/customize-workspace/client/src/modules/composite/about/conditions.ts
+++ b/how-to/customize-workspace/client/src/modules/composite/about/conditions.ts
@@ -46,7 +46,6 @@ export class AboutConditions implements Conditions {
 
 		conditionMap["has-about"] = async () => this._sharedState.aboutWindow !== undefined;
 
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 		return conditionMap;
 	}
 }

--- a/how-to/customize-workspace/client/src/modules/composite/pages/menus.ts
+++ b/how-to/customize-workspace/client/src/modules/composite/pages/menus.ts
@@ -151,8 +151,6 @@ export class PageMenus implements Menus<PageMenuSettings> {
 				menuItemsToReturn.push(showPageMenuEntry);
 			}
 
-			// even thought the array is typed eslint will still complain so the rule is disabled here
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 			return menuItemsToReturn;
 		}
 	}

--- a/how-to/customize-workspace/client/src/modules/composite/windows/menus.ts
+++ b/how-to/customize-workspace/client/src/modules/composite/windows/menus.ts
@@ -126,8 +126,6 @@ export class WindowMenus implements Menus<WindowMenuSettings> {
 				menuItemsToReturn[0].separator = this._settings.separator ?? "before";
 			}
 
-			// even thought the array is typed eslint will still complain so the rule is disabled here
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 			return menuItemsToReturn;
 		}
 	}

--- a/how-to/customize-workspace/client/src/modules/endpoints/inline-apps/endpoint.ts
+++ b/how-to/customize-workspace/client/src/modules/endpoints/inline-apps/endpoint.ts
@@ -42,7 +42,6 @@ export class InlineAppModuleEndpoint implements Endpoint {
 			`Returning ${results.length} app entries from the inline apps endpoint with id: ${endpointDefinition.id}`
 		);
 
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 		return results;
 	}
 }

--- a/how-to/customize-workspace/public/apps-fdc3-1-2.json
+++ b/how-to/customize-workspace/public/apps-fdc3-1-2.json
@@ -6,6 +6,7 @@
 			"name": "fdc3-broadcast-view",
 			"title": "Context using FDC3 (1.2)",
 			"description": "This is an example view used to demonstrate the broadcasting and listening of passed context objects using the fdc3 api.",
+			"categories": ["developer tools", "tools", "training"],
 			"manifest": "https://built-on-openfin.github.io/dev-extensions/extensions/v12.6.0/interop/fdc3/context/fdc3-broadcast-view.json",
 			"manifestType": "view",
 			"icons": [
@@ -28,6 +29,7 @@
 			"name": "fdc3-intent-view",
 			"title": "Intents using FDC3 (1.2)",
 			"description": "This view allows you to experiment with the raising and listening of intents using the fdc3 api.",
+			"categories": ["developer tools", "tools", "training"],
 			"manifest": "https://built-on-openfin.github.io/dev-extensions/extensions/v12.6.0/interop/fdc3/intent/fdc3-intent-view.json",
 			"manifestType": "view",
 			"icons": [
@@ -105,6 +107,7 @@
 			"name": "fdc3-workbench",
 			"title": "FDC3 Workbench (1.2)",
 			"description": "Launch the official FDC3 Workbench with FDC3 1.2 enabled.",
+			"categories": ["developer tools", "tools", "training"],
 			"manifest": "http://localhost:8080/common/views/fdc3/workbench/fdc3-workbench.view.fin.json",
 			"manifestType": "view",
 			"icons": [

--- a/how-to/customize-workspace/public/schemas/fdc3v1.2-appd.schema.json
+++ b/how-to/customize-workspace/public/schemas/fdc3v1.2-appd.schema.json
@@ -9,6 +9,13 @@
 					"description": "The unique application identifier located within a specific application directory instance.",
 					"type": "string"
 				},
+				"categories": {
+					"description": "categories is not part of the FDC3 1.2 spec but we support tags in our own platform app structure and an equivalent categories was added to FDC3 2.0 so we map it if we find it in an FDC3 1.2 directory",
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
 				"contactEmail": {
 					"description": "E-mail to receive queries about the application",
 					"type": "string"

--- a/how-to/customize-workspace/public/second.manifest.fin.json
+++ b/how-to/customize-workspace/public/second.manifest.fin.json
@@ -94,7 +94,7 @@
 							"sales": {
 								"excludeAppsWithTag": ["tools", "developer", "versions"],
 								"preferredScheme": "light",
-								"excludeMenuAction": ["developer-inspect", "raise-create-app-definition-intent"]
+								"excludeMenuModule": ["developer-menus"]
 							}
 						}
 					}


### PR DESCRIPTION
The structure of the manifest was updated to use urls instead of endpoints and the developer menu options was moved from inline menu options to a menu module. The example auth module needed to be updated to reflect this change. We extended it to support menu modules and to also support urls regardless of their format (platform app array, fdc3 1.2 or fdc3 2.0). We extended the fdc3 1.2 definition to support categories that was introduced in fdc3 2.0. These get mapped to tags in a platform app. We still support specifying tags in an fdc3 1.2 directory if provided but the schema was aligned with FDC3 2,0.