### PR TITLE
Update documentation related to endpoints

### DIFF
--- a/how-to/customize-workspace/docs/how-to-add-versioning-support.md
+++ b/how-to/customize-workspace/docs/how-to-add-versioning-support.md
@@ -41,6 +41,83 @@ By default the Version Provider will initialize even without configuration but y
   }
 ```
 
+### Endpoint Ids
+
+This configuration object supports specifying a custom endpoint Id which must exist in the endpoints array. See endpointId below and [How To Define Endpoints](./how-to-define-endpoints.md).
+
+### Full Version Provider Options
+
+```javascript
+{
+ /** The version of the the instance of this platform */
+ appVersion?: string;
+
+ /** You can specify if the platform should stop initializing if the version is less than any of the specified minimum versions */
+ minVersion?: MinimumVersion;
+
+ /** You can specify if the platform should stop initializing if the version is more than any of the specified maximum versions */
+ maxVersion?: MaximumVersion;
+
+ /**
+  * This window will be shown if an endpointId is not specified and min and max criteria has been specified and has not been met.
+  * This window will be shown to the user and the bootstrapping process will be stopped.
+  */
+ versionWindow?: Partial<OpenFin.WindowOptions>;
+
+ /**
+  * If you specify an endpoint then you are telling the platform to send information to this endpoint.
+  * The information sent will be the VersionRequest object.
+  * If you provide minimumVersion and maximumVersion information in the settings then the
+  * platform will use those to calculate what has failed validation (minimum and/or maximum) and pass
+  * those onto the endpoint.
+  *
+  * The endpoint then returns an object with status (this returns the version info you sent, the min/max rules and what has failed. The failures indicate the state of the platform.).
+  * If the status indicates that things need to be managed and should not proceed they will have a windowOptions property. This should be launched and that window will be built to
+  * support what should happen next.
+  * - Should the window tell the user that the setup isn't compatible and offer to shut down the platform?
+  * - Should it try to close the platform and launch a compatible manifest?
+  * - Should it notify the user that a newer version of the app is available and that they should restart?
+  * On the initial request while the platform is running an invalid status will result in the bootstrapping stopping.
+  */
+ endpointId?: string;
+
+ /**
+  * If an endpoint is specified and an interval is specified then you want the platform to call this endpoint on an
+  * interval to see if an update of your application is available.
+  */
+ versionCheckIntervalInSeconds?: number;
+}
+```
+
+### Version Request if Endpoint Id is specified
+
+```javascript
+export interface VersionRequest {
+  /** The collection version information */
+  versionInfo: VersionInfo;
+  /** The configured minimum limits */
+  minVersion?: MinimumVersion;
+  /** The configured maximum limits */
+  maxVersion?: MaximumVersion;
+  /** The version type that failed the minimum requirements */
+  minFail?: VersionType[];
+  /** The version type that failed the maximum requirements */
+  maxFail?: VersionType[];
+}
+```
+
+### Expected Version Response if Endpoint Id is specified
+
+```javascript
+/** If an endpoint has been used to get dynamic criteria what if anything has been the response. */
+export interface VersionResponse {
+  windowOptions?: OpenFin.WindowOptions;
+  status: 'compatible' | 'incompatible' | 'upgradeable';
+}
+```
+
+### Version
+
 ## Min and Max Limits
 
 Minimum and Maximum thresholds can be specified through the minimum and maximum setting by specifying the version type and the full version number (x.x.x.x for runtime and rvm and x.x.x for everything else).

--- a/how-to/customize-workspace/docs/how-to-apply-entitlements.md
+++ b/how-to/customize-workspace/docs/how-to-apply-entitlements.md
@@ -83,6 +83,12 @@ If you need to return different settings by user then you can have a cut down ma
  }
 ```
 
+## Endpoint Ids
+
+- platform-settings
+
+## How the platform checks for settings
+
 The customize workspace settings service will check for an endpoint with an id of "**platform-settings**". Endpoints can have custom logic and can source data using it's preferred approach (rest calls, data from a websocket connection, data from local storage or even mock data).
 
 We have an example auth module that contains an auth provider and an endpoint provider. The purpose of this setup is to let you simulate server side filtering via the client side (so there is no server side logic dependency required in order to get an idea of how it could work). The auth module above has a customData setting that specifies a id to store the selected example user and a list of example users and associated role.

--- a/how-to/customize-workspace/docs/how-to-customize-browser-page-management.md
+++ b/how-to/customize-workspace/docs/how-to-customize-browser-page-management.md
@@ -21,13 +21,15 @@ A workspace platform lets you override the platform implementation so you can co
 
 Instead of modifying this file directly we allow you to specify the destination and source of pages through config and the definition of [endpoints](./how-to-define-endpoints.md).
 
+### Endpoint Ids
+
 Endpoints support an action and request/response function (see [How To Defined Endpoints](./how-to-define-endpoints.md)). Customize workspace checks to see if you have specified the following endpoints:
 
 - page-get
 - page-set
 - page-remove
 
-We also have some additional endpoints that provide supporting information when a page is saved (such as the height/width and position of the window the page resided in at the point of save):
+We also have some additional endpoints that provide supporting information when a page is saved (such as the height/width and position of the window the page resided in at the point of save). **Note**: In the future we are looking at having this information stored as part of the snapshot so these endpoints will not be needed:
 
 - page-bounds-get
 - page-bounds-set

--- a/how-to/customize-workspace/docs/how-to-customize-home.md
+++ b/how-to/customize-workspace/docs/how-to-customize-home.md
@@ -110,7 +110,14 @@ You can use the `/integrations` command to determine which modules are available
 
 An integration module must be `enabled` in the modules list for it to be managed, but if you don't want it to automatically be started you should set `autoStart` to false.
 
-The endpoints `integration-preferences-get` and `integration-preferences-set` are used to store the preferences as to which integrations are enabled. See [How To Define Endpoints](./how-to-define-endpoints.md) for more details.
+### Endpoint Ids
+
+The endpoints the platform looks for are:
+
+- integration-preferences-get
+- integration-preferences-set
+
+If these endpoints are specified then they are used to store the preferences as to which integrations are enabled. See [How To Define Endpoints](./how-to-define-endpoints.md) for more details. This feature lets users toggle the state of the integrations you permit them to see.
 
 ![Home Integrations](./assets/home-integrations.png)
 

--- a/how-to/customize-workspace/docs/how-to-customize-workspace-browser-page-sharing.md
+++ b/how-to/customize-workspace/docs/how-to-customize-workspace-browser-page-sharing.md
@@ -99,6 +99,8 @@ The service is configured via endpoints (see [How To Define Endpoints](./how-to-
 
 ```
 
+## Endpoint Ids
+
 Endpoints support an action and request/response function (see [How To Define Endpoints](./how-to-define-endpoints.md)). Customize workspace checks to see if you have specified the following endpoints when implementing sharing:
 
 - share-get

--- a/how-to/customize-workspace/docs/how-to-customize-workspace-management.md
+++ b/how-to/customize-workspace/docs/how-to-customize-workspace-management.md
@@ -23,6 +23,8 @@ A workspace platform lets you override the platform implementation so you can co
 
 Instead of modifying this file directly we allow you to specify the destination and source of workspaces through config and the definition of [endpoints](./how-to-define-endpoints.md).
 
+### Endpoint Ids
+
 Endpoints support an action and request/response function (see [How To Define Endpoints](./how-to-define-endpoints.md)). Customize workspace checks to see if you have specified the following endpoints:
 
 - workspace-get

--- a/how-to/customize-workspace/docs/how-to-define-endpoints.md
+++ b/how-to/customize-workspace/docs/how-to-define-endpoints.md
@@ -72,15 +72,20 @@ We include examples of endpoint modules in the modules folder:
 - local-storage - shows how you can have an endpoint that can save and fetch from local storage
 - channel - lets you provide endpoint settings that specify a channel api you wish to connect to and whether you wish to pass a payload and return (action) or perform a requestResponse and get something back from the channel
 - inline-apps - can be used to provide an array of apps inline inside of the endpointsProvider through the platform's manifest or the endpointProvider returned from a settings service (see [how to define apps](./how-to-define-apps.md))
+- example-connection-validation - an example of a module that can receive the uuid and payload of an application trying to connect to your platform and return whether or not the connection should be allowed. This module always returns true as it is an example and **not for production use**.
 
 Endpoints can be defined as:
 
+- platform settings - if you specify an endpoint called **platform-settings** then the platform will call it to fetch the settings it should use. See [How To Apply Entitlements](./how-to-apply-entitlements.md)
 - app sources - see [How To Define Apps](./how-to-define-apps.md)
 - workspaces source - see [How To Customize Workspace Management](./how-to-customize-workspace-management.md)
 - page source - see [How To Customize Browser Page Management](./how-to-customize-browser-page-management.md)
 - page bounds source - see [How To Customize Browser Page Management](./how-to-customize-browser-page-management.md)
 - share source - see [How To Customize Workspace And Browser Sharing](./how-to-customize-workspace-browser-page-sharing.md)
-- integration preferences source - see [How To Customize Integrations](./how-to-add-integrations-to-home.md)
+- integration preferences source with integration management - see [How To Customize Home](./how-to-customize-home.md)
+- connection to your platform verification - see [How To Manage Connections To Your Platform](./how-to-manage-connections-to-your-platform.md)
+- an app launch handler - if the **manifestType** of an app is **endpoint** then we will check the endpoints array for the endpoint specified in the manifest property. See - [What Manifest Types Are Supported].
+- version validation - You can configure the versionProvider options to specify an endpointId that should be called. This endpoint will return an object that defines what versions the platform should work against. See - [How To Add Versioning Support](./how-to-add-versioning-support.md)
 
 ## Source Reference
 
@@ -89,5 +94,6 @@ Endpoints can be defined as:
 - local-storage [endpoint](../client/src/modules/endpoints/local-storage/endpoint.ts)
 - channel [endpoint](../client/src/modules/endpoints/channel/endpoint.ts)
 - inline-apps [endpoint](../client/src/modules/endpoints/inline-apps/endpoint.ts)
+- example-connection-validation [endpoint](../client/src/modules/endpoints/example-connection-validation/endpoint.ts)
 
 [<- Back to Table Of Contents](../README.md)

--- a/how-to/customize-workspace/docs/how-to-manage-connections-to-your-platform.md
+++ b/how-to/customize-workspace/docs/how-to-manage-connections-to-your-platform.md
@@ -146,6 +146,10 @@ The connectionProvider has a function that is used to see if a connection is lis
 
 ```
 
+## Endpoint Ids
+
+You can specify an endpoint that will receive the payload passed when an external application tries to connect to your platform. The id is the string specified by **connectionValidationEndpoint** (see below).
+
 The settings are as follows:
 
 - **connectionId**: This is the id of the channel api apps will connect to (apps do not need to connect to it for the broker connection if that is all they are doing). The channel name will be prefixed with the uuid of your platform. Given the example above the channel id will be {youruuid}-{connectionId}: **customize-workspace-workspace-connection**. Connected clients can explicitly call a disconnect function to let the workspace platform they are disconnecting e.g.
@@ -161,5 +165,9 @@ await _connectionService.DispatchAsync("disconnect");
 ## Example of Connecting Clients
 
 - [CSharp Starter - Integrate with Workspace](https://github.com/built-on-openfin/csharp-starter/tree/main/how-to/integrate-with-workspace)
+
+## Example of an Endpoint that accepts a Connection Payload (always returns true, not for production use)
+
+- [example-connection-validation](../client/src/modules/endpoints/example-connection-validation/endpoint.ts)
 
 [<- Back to Table Of Contents](../README.md)

--- a/how-to/customize-workspace/docs/what-manifest-types-are-supported.md
+++ b/how-to/customize-workspace/docs/what-manifest-types-are-supported.md
@@ -29,8 +29,12 @@ Customize workspace supports the following manifest types (for the list in code 
 - **inline-snapshot**: This manifest type expects the manifest setting to have the snapshot json inline rather than a url to a json file.
 - **manifest**: This manifest type expects the manifest setting to point to a json file that is an openfin manifest. An openfin app.
 - **desktop-browser**: This manifest type expects the manifest setting to point to a url which will be launched in the default desktop browser.
-- **endpoint**: An endpoint (see [How To Define Endpoints](./how-to-define-endpoints.md)) is a generic target that supports an action or a request/response. This custom endpoint will be passed the app definition to the action implementation. What happens after that point is down to your own implementation. It is one way of extending launch behavior should you need to.
+- **endpoint**: An endpoint (see [How To Define Endpoints](./how-to-define-endpoints.md)) is a generic target that supports an action or a request/response. This custom endpoint will be passed the app definition to the action implementation. What happens after that point is down to your own implementation. We recommend using the other manifest types but if you wish to try a custom way of launching an app then this gives you one way of extending launch behavior should you need to.
 - **connection**: A connected app (see [How To Manage Connections To Your Platform](./how-to-manage-connections-to-your-platform.md)) could have provided a list of child views that can be launched from home. If a selection is made against one of these entries then it will be sent to the connected app in order for it to launch the requested view.
+
+## Endpoint Ids
+
+The endpoint manifest type can accept custom endpoint ids if none of the supported manifest types cover the use case you are trying to evaluate.
 
 ## Source Reference
 


### PR DESCRIPTION
The endpoints doc already links to the sections that use endpoints but it was missing a few so the list has been updated and the sections now have Endpoint Ids as titles to make it a bit easier to spot consistently.