### PR TITLE
Launch snapshot additionally searches pages for view ids

### DIFF
--- a/how-to/customize-workspace/client/src/framework/launch.ts
+++ b/how-to/customize-workspace/client/src/framework/launch.ts
@@ -208,7 +208,14 @@ async function launchSnapshot(snapshotApp: PlatformApp): Promise<PlatformAppIden
 		const viewIds: PlatformAppIdentifier[] = [];
 
 		for (const currentWindow of windows) {
-			const getViewIdsForLayout = findViewNames(currentWindow.layout);
+			let getViewIdsForLayout = findViewNames(currentWindow.layout);
+			if (Array.isArray(currentWindow.workspacePlatform?.pages)) {
+				for (const page of currentWindow.workspacePlatform.pages) {
+					getViewIdsForLayout = getViewIdsForLayout.concat(findViewNames(page.layout));
+				}
+			}
+			getViewIdsForLayout = [...new Set(getViewIdsForLayout)];
+
 			if (getViewIdsForLayout.length === 0) {
 				const uuid = randomUUID();
 				const name = `${snapshotApp.appId}/${uuid}`;


### PR DESCRIPTION
When launchSnapshot searched for views to check if a window existed it only looked at the window.layout.

For a workspace browser snapshot this might not be populated, instead window.workspacePlatform.pages.layout might be instead, so thee layouts in the pages need to be checked as well.