### PR TITLE
Added an example that shows the view options for iframes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,12 +21,12 @@ module.exports = {
 		'**/node_modules/*',
 		'**/*.bundle.js',
 		'**/build/**/*.js',
-		'preload.js',
 		'**/wc-fin/*.js',
 		'**/3rd-party/*',
 		'**/*.d.ts',
 		'**/settings.schema.json',
-		'**/reports/*'
+		'**/reports/*',
+		'**/integrate-with-salesforce/public/js/preload.js'
 	],
 	parserOptions: {
 		ecmaVersion: 2020,

--- a/how-to/workspace-platform-starter/public/common/apps.json
+++ b/how-to/workspace-platform-starter/public/common/apps.json
@@ -217,5 +217,44 @@
 			}
 		],
 		"tags": ["view", "irs", "finance"]
+	},
+	{
+		"appId": "openfin-frame",
+		"name": "openfin-frame",
+		"title": "Framed App",
+		"description": "An example of framing an application.",
+		"manifest": {
+			"url": "http://localhost:8080/common/views/frame/index.html",
+			"customData": {
+				"frame": {
+					"url": "http://localhost:8080/common/views/frame/example-content/example.html",
+					"title": "Example Frame"
+				}
+			},
+			"api": {
+				"iframe": {
+					"crossOriginInjection": false,
+					"sameOriginInjection": false
+				}
+			},
+			"fdc3InteropApi": "2.0",
+			"preloadScripts": [
+				{
+					"url": "http://localhost:8080/common/views/frame/preload.js"
+				}
+			]
+		},
+		"manifestType": "inline-view",
+		"icons": [
+			{
+				"src": "http://localhost:8080/common/images/icon-blue.png"
+			}
+		],
+		"contactEmail": "contact@example.com",
+		"supportEmail": "support@example.com",
+		"publisher": "OpenFin",
+		"intents": [],
+		"images": [],
+		"tags": ["developer", "view"]
 	}
 ]

--- a/how-to/workspace-platform-starter/public/common/views/frame/README.md
+++ b/how-to/workspace-platform-starter/public/common/views/frame/README.md
@@ -1,0 +1,115 @@
+# Framed App
+
+This is an example app that shows how to load a piece of content via an iframe and control whether or not they get the fin API.
+
+If the fin api is injected then you can use the fin api or the full fdc3 api.
+
+If the fin api is available (the fdc3 api will also be available if it is available to the view) then the preload script specified in the apps.json file (preload.js) will be included and this adds logic that monitors the iframe's title and updates the views's title so that the content tab reflects the iframed content and not the view.
+
+If the fin api is disabled (and therefore the fdc3 api) for the iframed content then we have an example.html page that loads a script framed.js that enables the title monitoring and provides a basic fdc3 API that supports broadcasting on system/user channels or adding a context listener.
+
+This is just an example of how you can use the OpenFin APIs, browser APIs (postMessage) and OpenFin settings.
+
+## Framed Content
+
+A lot of sites do not allow their content to be contained within an iframe unless it comes from the same origin. Please keep that in mind when trying different urls in the settings of this app.
+
+## Example App Entry in apps.json
+
+```json
+{
+  "appId": "openfin-frame",
+  "name": "openfin-frame",
+  "title": "Framed App",
+  "description": "An example of framing an application.",
+  "manifest": {
+    "url": "http://localhost:8080/common/views/frame/index.html",
+    "customData": {
+      "frame": {
+        "url": "http://localhost:8080/common/views/frame/example-content/example.html",
+        "title": "Example Frame"
+      }
+    },
+    "api": {
+      "iframe": {
+        "crossOriginInjection": false,
+        "sameOriginInjection": false
+      }
+    },
+    "fdc3InteropApi": "2.0",
+    "preloadScripts": [
+      {
+        "url": "http://localhost:8080/common/views/frame/preload.js"
+      }
+    ]
+  },
+  "manifestType": "inline-view",
+  "icons": [
+    {
+      "src": "http://localhost:8080/common/images/icon-blue.png"
+    }
+  ],
+  "contactEmail": "contact@example.com",
+  "supportEmail": "support@example.com",
+  "publisher": "OpenFin",
+  "intents": [],
+  "images": [],
+  "tags": ["developer", "view"]
+}
+```
+
+### Custom Data
+
+```json
+{
+  "manifest": {
+    "url": "http://localhost:8080/common/views/frame/index.html",
+    "customData": {
+      "frame": {
+        "url": "http://localhost:8080/common/views/frame/example-content/example.html",
+        "title": "Example Frame"
+      }
+    }
+  },
+  "manifestType": "inline-view"
+}
+```
+
+Through customData you can specify the url the iframe should load and the default title you want to assign to the view.
+
+### API Settings
+
+```json
+{
+  "manifest": {
+    "url": "http://localhost:8080/common/views/frame/index.html",
+    "api": {
+      "iframe": {
+        "crossOriginInjection": false,
+        "sameOriginInjection": false
+      }
+    }
+  },
+  "manifestType": "inline-view"
+}
+```
+
+In this snippet we are using the view options to specify whether the fdc3 api should be injected into the iframe and what rules there are for that. If the API is disabled and you would still like to have the View Title updating and an example of a basic fdc3 api then we show that the iframed content could load a script to support communication between the framed content and the parent using postMessage.
+
+### Preload
+
+```json
+{
+  "manifest": {
+    "url": "http://localhost:8080/common/views/frame/index.html",
+    "preloadScripts": [
+      {
+        "url": "http://localhost:8080/common/views/frame/preload.js"
+      }
+    ]
+  },
+  "manifestType": "inline-view"
+}
+```
+
+The preload script uses Mutation Observers and postMessage to ensure that the View title is updated as the iframed content's title is updated.

--- a/how-to/workspace-platform-starter/public/common/views/frame/example-content/example.html
+++ b/how-to/workspace-platform-starter/public/common/views/frame/example-content/example.html
@@ -39,7 +39,7 @@
 		</p>
 		<button id="change-title">Change Title</button>
 		<h4>Context Type Received</h4>
-		<p><span id="context-type-received">None</span></p>
+		<p id="context-type-received">None</p>
 		<button id="add-context-listener">Add Context Listener</button>
 		<button id="remove-context-listener">Remove Context Listener</button>
 		<button id="broadcast-context">Broadcast Context</button>

--- a/how-to/workspace-platform-starter/public/common/views/frame/example-content/example.html
+++ b/how-to/workspace-platform-starter/public/common/views/frame/example-content/example.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
+		<title>Example Application To Frame</title>
+		<link rel="icon" type="image/x-icon" href="../../../../favicon.ico" />
+		<link rel="stylesheet" href="../../../style/app.css" />
+		<style>
+			body {
+				height: 100vh;
+				width: 100%;
+				padding: 0px;
+				margin: 0px;
+				overflow: hidden;
+			}
+		</style>
+		<script type="module" src="../framed/framed.js"></script>
+		<script defer="defer" src="./example.index.js"></script>
+	</head>
+	<body class="small col fill gap20">
+		<h3>A Simple Framed Example</h3>
+		<p>
+			This example imports a script framed.js that allows the parent view's title to be updated when this
+			framed content changes it's title (triggered by the button below).
+		</p>
+		<p>
+			If the fin api is injected into the frame and the preload capability is available then the preload.js
+			script brings in the logic to update the title and the framed.js logic will not run.
+		</p>
+		<p>
+			This Framed App example is used to demonstrate that you can control whether the fin api is injected into
+			frames and the available options and how you could still have communication between child and parent
+			without the fin api.
+		</p>
+		<p>
+			The content you try to frame by updating the Framed App Manifest's custom data must support being framed
+			by the origin of the parent.
+		</p>
+		<button id="change-title">Change Title</button>
+		<h4>Context Type Received</h4>
+		<p><span id="context-type-received">None</span></p>
+		<button id="add-context-listener">Add Context Listener</button>
+		<button id="remove-context-listener">Remove Context Listener</button>
+		<button id="broadcast-context">Broadcast Context</button>
+	</body>
+</html>

--- a/how-to/workspace-platform-starter/public/common/views/frame/example-content/example.index.js
+++ b/how-to/workspace-platform-starter/public/common/views/frame/example-content/example.index.js
@@ -1,0 +1,60 @@
+const changeTitle = document.querySelector('#change-title');
+const addContextListener = document.querySelector('#add-context-listener');
+const removeContextListener = document.querySelector('#remove-context-listener');
+const broadcastContext = document.querySelector('#broadcast-context');
+const contextTypeReceivedLabel = document.querySelector('#context-type-received');
+
+const originalTitle = document.title;
+let contextListener;
+
+changeTitle.addEventListener('click', () => {
+	document.title = `${originalTitle} - ${Date.now()}`;
+});
+
+addContextListener.addEventListener('click', async () => {
+	if (window.fdc3) {
+		contextListener = await window.fdc3.addContextListener(null, (context, metaInfo) => {
+			if (context !== undefined) {
+				console.log('Context Received:', context);
+				console.log('MetaInfo Received:', metaInfo);
+				contextTypeReceivedLabel.textContent = context.type;
+			}
+		});
+		addContextListener.disabled = true;
+		removeContextListener.disabled = false;
+	} else {
+		console.log('FDC3 is not available.');
+	}
+});
+removeContextListener.disabled = true;
+removeContextListener.addEventListener('click', () => {
+	if (contextListener !== undefined) {
+		contextListener.unsubscribe();
+		addContextListener.disabled = false;
+		removeContextListener.disabled = true;
+	}
+});
+
+broadcastContext.addEventListener('click', async () => {
+	if (window.fdc3) {
+		window.fdc3.broadcast({
+			type: 'fdc3.instrument',
+			name: 'Tesla Inc',
+			id: {
+				ticker: 'TSLA',
+				ISIN: 'US88160R1014',
+				random: `${Date.now()}`
+			}
+		});
+	} else {
+		console.log('FDC3 is not available.');
+	}
+});
+
+if (window.fdc3) {
+	console.log('FDC3 API available on load.');
+} else {
+	window.addEventListener('fdc3Ready', () => {
+		console.log('FDC3 API is now available.');
+	});
+}

--- a/how-to/workspace-platform-starter/public/common/views/frame/framed/frame.fdc3.js
+++ b/how-to/workspace-platform-starter/public/common/views/frame/framed/frame.fdc3.js
@@ -1,0 +1,116 @@
+const listeners = {};
+const contextCache = {};
+
+/**
+ * Handles the message from the child frame.
+ * @param message message from child frame
+ */
+function handleMessage(message) {
+	switch (message.action) {
+		case 'context-received': {
+			const context = message?.data?.context;
+			const targetContextListeners = listeners[context.type];
+			const allContextListeners = listeners['*'];
+			contextCache['*'] = context;
+			if (context?.type !== undefined) {
+				contextCache[context.type] = context;
+			}
+
+			if (targetContextListeners !== undefined && Array.isArray(targetContextListeners)) {
+				for (const targetListener of targetContextListeners) {
+					targetListener.handler(context, message?.data?.metadata);
+				}
+			}
+
+			if (allContextListeners !== undefined && Array.isArray(allContextListeners)) {
+				for (const allListener of allContextListeners) {
+					allListener.handler(context, message?.data?.metadata);
+				}
+			}
+
+			break;
+		}
+		default: {
+			console.warn(`Unknown action passed from frame: ${message.action}`);
+		}
+	}
+}
+
+/**
+ * Takes a post message event and handles it.
+ * @param event postMessage event that is sent from child frame
+ */
+function handleEvent(event) {
+	console.log('Received event', event);
+	console.log('Acceptable domain', parent.origin);
+	const { data, origin } = event;
+	if (origin === parent.origin) {
+		handleMessage(data);
+	}
+}
+
+window.addEventListener('message', handleEvent, false);
+
+/**
+ * Polyfills randomUUID if running in a non-secure context.
+ * @returns The random UUID.
+ */
+export function randomUUID() {
+	if ('randomUUID' in window.crypto) {
+		// eslint-disable-next-line no-restricted-syntax
+		return window.crypto.randomUUID();
+	}
+	// Polyfill the window.crypto.randomUUID if we are running in a non secure context that doesn't have it
+	// we are still using window.crypto.getRandomValues which is always available
+	// https://stackoverflow.com/a/2117523/2800218
+	/**
+	 * Get random hex value.
+	 * @param c The number to base the random value on.
+	 * @returns The random value.
+	 */
+	function getRandomHex(c) {
+		// eslint-disable-next-line no-bitwise
+		const rnd = window.crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (Number(c) / 4));
+		return (
+			// eslint-disable-next-line no-bitwise
+			(Number(c) ^ rnd).toString(16)
+		);
+	}
+	return '10000000-1000-4000-8000-100000000000'.replace(/[018]/g, getRandomHex);
+}
+
+/**
+ * Returns a reduced fdc3 client api.
+ * @returns fdc3 cut down api
+ */
+export function getFDC3Client() {
+	return {
+		broadcast: async (context) => {
+			parent.postMessage({ action: 'broadcast-context', data: { context } }, '*');
+		},
+		addContextListener: async (contextType, handler) => {
+			const typeId = contextType ?? '*';
+			if (handler === undefined) {
+				throw new Error(
+					'You must specify either null or a specific type of context object to listen for as the first argument and a function to handle the context as the second argument.'
+				);
+			}
+			if (listeners[typeId] === undefined) {
+				listeners[typeId] = [];
+			}
+			const handlerId = randomUUID();
+			listeners[typeId].push({ handlerId, handler });
+			if (contextCache[typeId] !== undefined) {
+				setTimeout(() => {
+					handleMessage({ action: 'context-received', data: { context: contextCache[typeId] } });
+				}, 0);
+			}
+			return {
+				unsubscribe: () => {
+					const handlers = listeners[typeId];
+					listeners[typeId] = handlers.filter((object) => object.handlerId !== handlerId);
+				}
+			};
+		}
+	};
+}

--- a/how-to/workspace-platform-starter/public/common/views/frame/framed/frame.fdc3.js
+++ b/how-to/workspace-platform-starter/public/common/views/frame/framed/frame.fdc3.js
@@ -1,6 +1,8 @@
 const listeners = {};
 const contextCache = {};
 
+window.addEventListener('message', handleEvent, false);
+
 /**
  * Handles the message from the child frame.
  * @param message message from child frame
@@ -48,8 +50,6 @@ function handleEvent(event) {
 		handleMessage(data);
 	}
 }
-
-window.addEventListener('message', handleEvent, false);
 
 /**
  * Polyfills randomUUID if running in a non-secure context.

--- a/how-to/workspace-platform-starter/public/common/views/frame/framed/frame.title.js
+++ b/how-to/workspace-platform-starter/public/common/views/frame/framed/frame.title.js
@@ -1,0 +1,28 @@
+/**
+ * Posts the title to the Framed view.
+ * @param title - The document title that should be show
+ */
+export function updateFrameTitle(title) {
+	console.log(`Notify parent frame of title: ${title}.`);
+	parent.postMessage({ action: 'update-title', data: { title } }, '*');
+}
+
+/**
+ * Watches the current document for when changes to the title occur and notify the parent frame.
+ */
+export function watchPageTitle() {
+	console.log('Start Setup Title Mutation Observer');
+	const title = document.head;
+	try {
+		new MutationObserver((mutations) => {
+			const titleNode = mutations[0].target;
+			if (titleNode.nodeName === 'TITLE' && titleNode.text !== null && titleNode.text !== undefined) {
+				updateFrameTitle(titleNode.text);
+			}
+		}).observe(title, { subtree: true, characterData: true, childList: true });
+	} catch (err) {
+		console.error('Error trying to add title mutation observer', err);
+	}
+	console.log('End Setup Title Mutation Observer');
+	updateFrameTitle(document.title);
+}

--- a/how-to/workspace-platform-starter/public/common/views/frame/framed/framed.js
+++ b/how-to/workspace-platform-starter/public/common/views/frame/framed/framed.js
@@ -1,0 +1,20 @@
+(async () => {
+	// if fdc3 is injected by the OpenFin runtime it will be available before this script runs
+	if (window.fdc3 === undefined) {
+		try {
+			const fdc3Module = await import('./frame.fdc3.js');
+			window.fdc3 = fdc3Module.getFDC3Client();
+			window.dispatchEvent(new Event('fdc3Ready'));
+		} catch (fdc3Error) {
+			console.error('Error setting up fdc3 module.', fdc3Error);
+		}
+	}
+	if (window.fin === undefined) {
+		try {
+			const titleModule = await import('./frame.title.js');
+			titleModule.watchPageTitle();
+		} catch (titleError) {
+			console.error('Error setting up title watch.', titleError);
+		}
+	}
+})();

--- a/how-to/workspace-platform-starter/public/common/views/frame/index.html
+++ b/how-to/workspace-platform-starter/public/common/views/frame/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
+		<title>Frame Application</title>
+		<link rel="icon" type="image/x-icon" href="../../../../favicon.ico" />
+		<style>
+			body {
+				height: 100vh;
+				width: 100%;
+				padding: 0px;
+				margin: 0px;
+				overflow: hidden;
+			}
+
+			iframe {
+				width: 100%;
+				height: 100%;
+				border-width: 0px;
+			}
+		</style>
+		<script defer="defer" src="./index.js"></script>
+	</head>
+	<body></body>
+</html>

--- a/how-to/workspace-platform-starter/public/common/views/frame/index.js
+++ b/how-to/workspace-platform-starter/public/common/views/frame/index.js
@@ -1,5 +1,35 @@
 let acceptableOrigin;
 
+window.addEventListener('DOMContentLoaded', initializeDOM);
+
+/**
+ * Initialize the DOM.
+ */
+async function initializeDOM() {
+	const options = await fin.me.getOptions();
+	if (options?.customData?.frame?.title) {
+		document.title = options.customData.frame.title;
+	}
+	if (options?.customData?.frame?.url) {
+		acceptableOrigin = new URL(options.customData.frame.url).origin;
+		console.log('Setting up message listener.');
+		window.addEventListener('message', handleEvent, false);
+		console.log('Listener added');
+		console.log('Setting framed url.');
+		const frame = document.createElement('iframe');
+		frame.title = options?.customData?.frame?.title;
+		frame.src = options.customData.frame.url;
+		document.body.append(frame);
+
+		fin.me.interop.addContextHandler((context) => {
+			frame.contentWindow.postMessage(
+				{ action: 'context-received', data: { context } },
+				new URL(options.customData.frame.url).origin
+			);
+		});
+	}
+}
+
 /**
  * Handles the message from the child frame.
  * @param message message from child frame
@@ -38,32 +68,3 @@ function handleEvent(event) {
 		handleMessage(data);
 	}
 }
-
-/**
- * Initialize the DOM.
- */
-async function initializeDOM() {
-	const options = await fin.me.getOptions();
-	if (options?.customData?.frame?.title) {
-		document.title = options.customData.frame.title;
-	}
-	if (options?.customData?.frame?.url) {
-		acceptableOrigin = new URL(options.customData.frame.url).origin;
-		console.log('Setting up message listener.');
-		window.addEventListener('message', handleEvent, false);
-		console.log('Listener added');
-		console.log('Setting framed url.');
-		const frame = document.createElement('iframe');
-		frame.title = options?.customData?.frame?.title;
-		frame.src = options.customData.frame.url;
-		document.body.append(frame);
-
-		fin.me.interop.addContextHandler((context) => {
-			frame.contentWindow.postMessage(
-				{ action: 'context-received', data: { context } },
-				new URL(options.customData.frame.url).origin
-			);
-		});
-	}
-}
-window.addEventListener('DOMContentLoaded', initializeDOM);

--- a/how-to/workspace-platform-starter/public/common/views/frame/index.js
+++ b/how-to/workspace-platform-starter/public/common/views/frame/index.js
@@ -1,0 +1,69 @@
+let acceptableOrigin;
+
+/**
+ * Handles the message from the child frame.
+ * @param message message from child frame
+ */
+function handleMessage(message) {
+	switch (message.action) {
+		case 'update-title': {
+			document.title = message?.data?.title;
+			break;
+		}
+		case 'broadcast-context': {
+			try {
+				const context = message?.data?.context;
+				console.log('setting context on system contextual group', context);
+				fin.me.interop.setContext(context);
+			} catch (error) {
+				console.warn('You are not bound to a system context group and are unable to set context', error);
+			}
+			break;
+		}
+		default: {
+			console.warn(`Unknown action passed from frame: ${message.action}`);
+		}
+	}
+}
+
+/**
+ * Takes a post message event and handles it.
+ * @param event postMessage event that is sent from child frame
+ */
+function handleEvent(event) {
+	console.log('Received event', event);
+	console.log('Acceptable domain', acceptableOrigin);
+	const { data, origin } = event;
+	if (origin === acceptableOrigin) {
+		handleMessage(data);
+	}
+}
+
+/**
+ * Initialize the DOM.
+ */
+async function initializeDOM() {
+	const options = await fin.me.getOptions();
+	if (options?.customData?.frame?.title) {
+		document.title = options.customData.frame.title;
+	}
+	if (options?.customData?.frame?.url) {
+		acceptableOrigin = new URL(options.customData.frame.url).origin;
+		console.log('Setting up message listener.');
+		window.addEventListener('message', handleEvent, false);
+		console.log('Listener added');
+		console.log('Setting framed url.');
+		const frame = document.createElement('iframe');
+		frame.title = options?.customData?.frame?.title;
+		frame.src = options.customData.frame.url;
+		document.body.append(frame);
+
+		fin.me.interop.addContextHandler((context) => {
+			frame.contentWindow.postMessage(
+				{ action: 'context-received', data: { context } },
+				new URL(options.customData.frame.url).origin
+			);
+		});
+	}
+}
+window.addEventListener('DOMContentLoaded', initializeDOM);

--- a/how-to/workspace-platform-starter/public/common/views/frame/preload.js
+++ b/how-to/workspace-platform-starter/public/common/views/frame/preload.js
@@ -1,11 +1,10 @@
-if (window == window.top) {
-	return;
+if (window !== window.top) {
+	window.addEventListener('DOMContentLoaded', () => {
+		import('./framed/frame.title.js')
+			.then((module) => {
+				module.watchPageTitle();
+				return true;
+			})
+			.catch((err) => console.error('Error setting up title watch.', err));
+	});
 }
-window.addEventListener('DOMContentLoaded', () => {
-	import('./framed/frame.title.js')
-		.then((module) => {
-			module.watchPageTitle();
-			return true;
-		})
-		.catch((err) => console.error('Error setting up title watch.', err));
-});

--- a/how-to/workspace-platform-starter/public/common/views/frame/preload.js
+++ b/how-to/workspace-platform-starter/public/common/views/frame/preload.js
@@ -1,0 +1,11 @@
+if (window == window.top) {
+	return;
+}
+window.addEventListener('DOMContentLoaded', () => {
+	import('./framed/frame.title.js')
+		.then((module) => {
+			module.watchPageTitle();
+			return true;
+		})
+		.catch((err) => console.error('Error setting up title watch.', err));
+});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"package-for-github": "node ./scripts/package.js --location github",
 		"package-for-aws": "node ./scripts/package.js --location aws",
 		"prettier": "prettier --config .prettierrc --write .",
-		"eslint": "eslint . --ext .js,.mjs,.ts",
+		"eslint": "node --max-old-space-size=5120 ./node_modules/eslint/bin/eslint . --ext .js,.mjs,.ts",
 		"start": "echo You must be in a folder for a specific how-to to use npm run start e.g. ./how-to/register-with-home",
 		"markdownlint": "markdownlint **/*.md --ignore **/node_modules/**",
 		"validate": "npm run prettier & npm run eslint & npm run markdownlint",


### PR DESCRIPTION
We didn't have an example of loading content and using the api view options to disable the fin api. And how would you allow that content to (1) update the view title (2) if needed broadcast and listen to context.