### PR TITLE
Disable saved config for dock

### DIFF
--- a/how-to/workspace-platform-starter/client/src/framework/workspace/dock.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/workspace/dock.ts
@@ -98,7 +98,9 @@ async function buildDockProvider(buttons: DockButton[]): Promise<DockProvider | 
 					!registeredBootstrapOptions?.notifications ||
 					dockProviderOptions.workspaceComponents?.hideNotificationsButton
 			},
-			buttons
+			buttons,
+			skipSavedDockProviderConfig: true,
+			disableUserRearrangement: true
 		};
 	}
 }


### PR DESCRIPTION
Don't save the config for dock, otherwise the custom menus don't get populated