### PR TITLE
Dynamic dock menus

### DIFF
--- a/how-to/workspace-platform-starter/client/src/framework/apps.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/apps.ts
@@ -90,17 +90,19 @@ export async function init(
 		}
 		supportedManifestTypes = options?.manifestTypes ?? [];
 
-		let updateInProgress = false;
-		window.setInterval(async () => {
-			if (!updateInProgress) {
-				updateInProgress = true;
-				try {
-					await getEntries();
-				} finally {
-					updateInProgress = false;
+		if (cacheDuration > 0) {
+			let updateInProgress = false;
+			window.setInterval(async () => {
+				if (!updateInProgress) {
+					updateInProgress = true;
+					try {
+						await getEntries();
+					} finally {
+						updateInProgress = false;
+					}
 				}
-			}
-		}, cacheDuration);
+			}, cacheDuration);
+		}
 	}
 }
 

--- a/how-to/workspace-platform-starter/client/src/framework/apps.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/apps.ts
@@ -1,5 +1,7 @@
+import { getCurrentSync } from "@openfin/workspace-platform";
 import { getConnectedApps } from "./connections";
 import { addDirectoryEndpoint, getPlatformApps, init as directoryInit } from "./directory";
+import { fireLifecycleEvent } from "./lifecycle";
 import { createLogger } from "./logger-provider";
 import { MANIFEST_TYPES } from "./manifest-types";
 import type { AppFilterOptions, AppProviderOptions, AppsForIntent, PlatformApp } from "./shapes/app-shapes";
@@ -9,7 +11,6 @@ import { isEmpty, isNumber, randomUUID } from "./utils";
 
 const logger = createLogger("Apps");
 
-let lastCacheUpdate: number = 0;
 let cachedApps: PlatformApp[] = [];
 let cacheDuration = 0;
 let isInitialized: boolean = false;
@@ -88,6 +89,10 @@ export async function init(
 			cacheDuration += options?.cacheDurationInMinutes * 60 * 1000;
 		}
 		supportedManifestTypes = options?.manifestTypes ?? [];
+
+		window.setInterval(async () => {
+			await getEntries();
+		}, cacheDuration);
 	}
 }
 
@@ -142,34 +147,31 @@ export async function getApps(appFilter?: AppFilterOptions): Promise<PlatformApp
  */
 async function getEntries(): Promise<PlatformApp[]> {
 	if (isEmpty(getEntriesResolvers)) {
-		const now = Date.now();
-
 		getEntriesResolvers = [];
 
-		if (now - lastCacheUpdate > cacheDuration) {
-			logger.info("Apps cache expired refreshing");
-			lastCacheUpdate = now;
+		logger.info("Apps cache expired refreshing");
 
-			const apps: PlatformApp[] = [];
-			try {
-				logger.info("Getting directory apps.");
-				const directoryApps = await getPlatformApps();
-				apps.push(...directoryApps);
+		const apps: PlatformApp[] = [];
+		try {
+			logger.info("Getting directory apps.");
+			const directoryApps = await getPlatformApps();
+			apps.push(...directoryApps);
 
-				logger.info("Getting connected apps.");
-				const connectedApps = await getConnectedApps();
-				if (connectedApps.length > 0) {
-					logger.info(
-						`Adding ${connectedApps.length} apps from connected apps to the apps list to be validated`
-					);
-					apps.push(...connectedApps);
-				}
-			} catch (error) {
-				logger.error("Error fetching apps.", error);
+			logger.info("Getting connected apps.");
+			const connectedApps = await getConnectedApps();
+			if (connectedApps.length > 0) {
+				logger.info(
+					`Adding ${connectedApps.length} apps from connected apps to the apps list to be validated`
+				);
+				apps.push(...connectedApps);
 			}
-
-			cachedApps = await validateEntries(apps);
+		} catch (error) {
+			logger.error("Error fetching apps.", error);
 		}
+
+		const lastCachedAppsJson = JSON.stringify(cachedApps);
+
+		cachedApps = await validateEntries(apps);
 
 		if (getEntriesResolvers.length > 0) {
 			logger.info("Resolving getEntry promises");
@@ -180,18 +182,25 @@ async function getEntries(): Promise<PlatformApp[]> {
 		}
 
 		getEntriesResolvers = undefined;
-	} else {
-		return new Promise<PlatformApp[]>((resolve) => {
-			if (getEntriesResolvers) {
-				logger.info("Storing getEntry resolver");
-				getEntriesResolvers.push(resolve);
-			} else {
-				resolve(cachedApps);
-			}
-		});
+
+		const cachedAppJson = JSON.stringify(cachedApps);
+
+		if (cachedAppJson !== lastCachedAppsJson) {
+			const platform = getCurrentSync();
+			await fireLifecycleEvent(platform, "apps-changed");
+		}
+
+		return cachedApps;
 	}
 
-	return cachedApps;
+	return new Promise<PlatformApp[]>((resolve) => {
+		if (getEntriesResolvers) {
+			logger.info("Storing getEntry resolver");
+			getEntriesResolvers.push(resolve);
+		} else {
+			resolve(cachedApps);
+		}
+	});
 }
 
 /**

--- a/how-to/workspace-platform-starter/client/src/framework/apps.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/apps.ts
@@ -90,8 +90,16 @@ export async function init(
 		}
 		supportedManifestTypes = options?.manifestTypes ?? [];
 
+		let updateInProgress = false;
 		window.setInterval(async () => {
-			await getEntries();
+			if (!updateInProgress) {
+				updateInProgress = true;
+				try {
+					await getEntries();
+				} finally {
+					updateInProgress = false;
+				}
+			}
 		}, cacheDuration);
 	}
 }

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/lifecycle-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/lifecycle-shapes.ts
@@ -13,7 +13,8 @@ export type LifecycleEvents =
 	| "before-quit"
 	| "theme-changed"
 	| "workspace-changed"
-	| "page-changed";
+	| "page-changed"
+	| "apps-changed";
 
 /**
  * The type for a lifecycle event handler.

--- a/how-to/workspace-platform-starter/client/types/module/shapes/lifecycle-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/lifecycle-shapes.d.ts
@@ -12,7 +12,8 @@ export type LifecycleEvents =
 	| "before-quit"
 	| "theme-changed"
 	| "workspace-changed"
-	| "page-changed";
+	| "page-changed"
+	| "apps-changed";
 /**
  * The type for a lifecycle event handler.
  */


### PR DESCRIPTION
- Update the apps at regular interval, instead of on request
- If apps list has changed fire new lifecycle event `apps-changed`
- Dock subscribes to `apps-changed` and refreshes if any config is different