### PR TITLE
Add support for favorites in store

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Added trayProvider which will show a tray icon, lets you customize the icon, activation button and menu entries
 - Added an example endpoint module: favorites-local-storage with a README showing how it can be wired up if you wanted to looking at using he favoriteClient from a module you are building.
 - Added apps in Home can now be favorited, you can see all your favorite apps with the `/fav` command
+- Added Store also supports the favorites functionality with secondary app buttons, this can be disabled for store by setting `StorefrontProviderOptions.favoritesEnabled` to false
 
 ## v13.1
 

--- a/how-to/workspace-platform-starter/client/src/framework/lifecycle.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/lifecycle.ts
@@ -52,10 +52,10 @@ export async function init(
  * @param lifecycleEvent The event to fire.
  * @param customData Any custom data to pass to the handlers.
  */
-export async function fireLifecycleEvent(
+export async function fireLifecycleEvent<T = unknown>(
 	platform: WorkspacePlatformModule,
 	lifecycleEvent: LifecycleEvents,
-	customData?: unknown
+	customData?: T
 ): Promise<void> {
 	logger.info(`Request to fire lifecycle event ${lifecycleEvent} received`);
 	const eventHandlers = allLifecycleEvents[lifecycleEvent];
@@ -75,15 +75,15 @@ export async function fireLifecycleEvent(
  * @param lifecycleHandler The handler to call for the event.
  * @returns The subscription id which can be used to unsubscribe.
  */
-export function subscribeLifecycleEvent(
+export function subscribeLifecycleEvent<T = unknown>(
 	lifecycleEvent: LifecycleEvents,
-	lifecycleHandler: LifecycleHandler
+	lifecycleHandler: LifecycleHandler<T>
 ): string {
 	const subscriptionId = randomUUID();
 	const handlers = allLifecycleEvents[lifecycleEvent] ?? [];
 	handlers.push({
 		id: subscriptionId,
-		handler: lifecycleHandler
+		handler: lifecycleHandler as LifecycleHandler
 	});
 	allLifecycleEvents[lifecycleEvent] = handlers;
 	logger.info(

--- a/how-to/workspace-platform-starter/client/src/framework/lifecycle.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/lifecycle.ts
@@ -50,12 +50,12 @@ export async function init(
  * Fire a lifecycle event.
  * @param platform The platform.
  * @param lifecycleEvent The event to fire.
- * @param customData Any custom data to pass to the handlers.
+ * @param payload Any custom data to pass to the handlers.
  */
 export async function fireLifecycleEvent<T = unknown>(
 	platform: WorkspacePlatformModule,
 	lifecycleEvent: LifecycleEvents,
-	customData?: T
+	payload?: T
 ): Promise<void> {
 	logger.info(`Request to fire lifecycle event ${lifecycleEvent} received`);
 	const eventHandlers = allLifecycleEvents[lifecycleEvent];
@@ -64,7 +64,7 @@ export async function fireLifecycleEvent<T = unknown>(
 		logger.info(`Notifying ${subscribers.length} subscribers of lifecycle event ${lifecycleEvent}`);
 		for (const idHandler of subscribers) {
 			logger.info(`Notifying subscriber ${idHandler.id} of event ${lifecycleEvent}`);
-			await idHandler.handler(platform, customData);
+			await idHandler.handler(platform, payload);
 		}
 	}
 }

--- a/how-to/workspace-platform-starter/client/src/framework/modules.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/modules.ts
@@ -259,6 +259,7 @@ export function getDefaultHelpers(): ModuleHelpers {
 			logger.info("getApps: getting public apps for module.");
 			return getApps({ private: false });
 		},
+		getApp,
 		getCurrentThemeId,
 		getCurrentIconFolder,
 		getCurrentPalette,

--- a/how-to/workspace-platform-starter/client/src/framework/platform/platform-override.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/platform/platform-override.ts
@@ -207,11 +207,11 @@ export function overrideCallback(
 			}
 
 			const platform = getCurrentSync();
-			await fireLifecycleEvent(platform, "workspace-changed", {
+			await fireLifecycleEvent<WorkspaceChangedLifecyclePayload>(platform, "workspace-changed", {
 				action: "create",
 				id: req.workspace.workspaceId,
 				workspace: req.workspace
-			} as WorkspaceChangedLifecyclePayload);
+			});
 		}
 
 		/**
@@ -255,11 +255,11 @@ export function overrideCallback(
 			}
 
 			const platform = getCurrentSync();
-			await fireLifecycleEvent(platform, "workspace-changed", {
+			await fireLifecycleEvent<WorkspaceChangedLifecyclePayload>(platform, "workspace-changed", {
 				action: "update",
 				id: req.workspace.workspaceId,
 				workspace: req.workspace
-			} as WorkspaceChangedLifecyclePayload);
+			});
 		}
 
 		/**
@@ -286,10 +286,10 @@ export function overrideCallback(
 			}
 
 			const platform = getCurrentSync();
-			await fireLifecycleEvent(platform, "workspace-changed", {
+			await fireLifecycleEvent<WorkspaceChangedLifecyclePayload>(platform, "workspace-changed", {
 				action: "delete",
 				id
-			} as WorkspaceChangedLifecyclePayload);
+			});
 		}
 
 		/**
@@ -406,11 +406,11 @@ export function overrideCallback(
 				logger.info(`Saved page with id: ${req.page.pageId} to default storage`);
 			}
 
-			await fireLifecycleEvent(platform, "page-changed", {
+			await fireLifecycleEvent<PageChangedLifecyclePayload>(platform, "page-changed", {
 				action: "create",
 				id: req.page.pageId,
 				page: req.page
-			} as PageChangedLifecyclePayload);
+			});
 		}
 
 		/**
@@ -453,11 +453,11 @@ export function overrideCallback(
 			}
 
 			const platform = getCurrentSync();
-			await fireLifecycleEvent(platform, "page-changed", {
+			await fireLifecycleEvent<PageChangedLifecyclePayload>(platform, "page-changed", {
 				action: "update",
 				id: req.page.pageId,
 				page: req.page
-			} as PageChangedLifecyclePayload);
+			});
 		}
 
 		/**
@@ -482,10 +482,10 @@ export function overrideCallback(
 				logger.info(`Removed page with id: ${id} from custom storage`);
 			}
 			const platform = getCurrentSync();
-			await fireLifecycleEvent(platform, "page-changed", {
+			await fireLifecycleEvent<PageChangedLifecyclePayload>(platform, "page-changed", {
 				action: "delete",
 				id
-			} as PageChangedLifecyclePayload);
+			});
 		}
 
 		/**

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/lifecycle-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/lifecycle-shapes.ts
@@ -21,10 +21,7 @@ export type LifecycleEvents =
 /**
  * The type for a lifecycle event handler.
  */
-export type LifecycleHandler<T = unknown> = (
-	platform: WorkspacePlatformModule,
-	customData?: T
-) => Promise<void>;
+export type LifecycleHandler<T = unknown> = (platform: WorkspacePlatformModule, payload?: T) => Promise<void>;
 
 /**
  * Map of the lifecycle event handlers.

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/lifecycle-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/lifecycle-shapes.ts
@@ -1,5 +1,6 @@
 import type { Workspace } from "@openfin/workspace";
 import type { Page, WorkspacePlatformModule } from "@openfin/workspace-platform";
+import type { FavoriteEntry } from "./favorite-shapes";
 import type { ModuleHelpers, ModuleImplementation, ModuleList } from "./module-shapes";
 
 /**
@@ -20,7 +21,10 @@ export type LifecycleEvents =
 /**
  * The type for a lifecycle event handler.
  */
-export type LifecycleHandler = (platform: WorkspacePlatformModule, customData?: unknown) => Promise<void>;
+export type LifecycleHandler<T = unknown> = (
+	platform: WorkspacePlatformModule,
+	customData?: T
+) => Promise<void>;
 
 /**
  * Map of the lifecycle event handlers.
@@ -84,4 +88,19 @@ export interface PageChangedLifecyclePayload {
 	 * The page data.
 	 */
 	page?: Page;
+}
+
+/**
+ * Event payload for the favorite changed lifecycle event.
+ */
+export interface FavoriteChangedLifecyclePayload {
+	/**
+	 * The action that happened to the favorite.
+	 */
+	action: "set" | "delete";
+
+	/**
+	 * The favorite entry.
+	 */
+	favorite: FavoriteEntry;
 }

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/module-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/module-shapes.ts
@@ -79,6 +79,13 @@ export interface ModuleHelpers {
 	getApps?(): Promise<PlatformApp[]>;
 
 	/**
+	 * Get the app by id.
+	 * @param id The id of the app to get.
+	 * @returns The app id it exists.
+	 */
+	getApp?(id: string): Promise<PlatformApp | undefined>;
+
+	/**
 	 * Get the current theme id.
 	 * @returns The current theme id.
 	 */

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/module-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/module-shapes.ts
@@ -163,7 +163,10 @@ export interface ModuleHelpers {
 	 * @param lifecycleHandler The handle for the event.
 	 * @returns A subscription id to be used with unsubscribe.
 	 */
-	subscribeLifecycleEvent?(lifecycleEvent: LifecycleEvents, lifecycleHandler: LifecycleHandler): string;
+	subscribeLifecycleEvent?<T = unknown>(
+		lifecycleEvent: LifecycleEvents,
+		lifecycleHandler: LifecycleHandler<T>
+	): string;
 
 	/**
 	 * Unsubscribe from lifecycle events.

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/store-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/store-shapes.ts
@@ -117,6 +117,11 @@ export interface StorefrontProviderOptions {
 	 * Secondary buttons added to all store entries.
 	 */
 	secondaryButtons?: StoreButtonConfig[];
+
+	/**
+	 * Enable favorites, defaults to true.
+	 */
+	favoritesEnabled?: boolean;
 }
 
 /**

--- a/how-to/workspace-platform-starter/client/src/framework/workspace/store.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/workspace/store.ts
@@ -598,7 +598,7 @@ function calculateButtons(
 			configPrimaryButton ?? {
 				title: "Launch",
 				action: {
-					id: "launch-app",
+					id: PLATFORM_ACTION_IDS.launchApp,
 					customData: app
 				}
 			},

--- a/how-to/workspace-platform-starter/client/src/framework/workspace/store.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/workspace/store.ts
@@ -65,9 +65,9 @@ export async function register(
 
 				favChangedSubscriptionId = subscribeLifecycleEvent<FavoriteChangedLifecyclePayload>(
 					"favorite-changed",
-					async (_: unknown, customData?: FavoriteChangedLifecyclePayload) => {
-						if (!isEmpty(customData)) {
-							await updateAppFavoriteButtons(customData);
+					async (_: unknown, payload?: FavoriteChangedLifecyclePayload) => {
+						if (!isEmpty(payload)) {
+							await updateAppFavoriteButtons(payload);
 						}
 					}
 				);

--- a/how-to/workspace-platform-starter/client/src/framework/workspace/store.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/workspace/store.ts
@@ -2,22 +2,29 @@ import {
 	Storefront,
 	StorefrontTemplate,
 	type RegistrationMetaInfo,
+	type StoreButtonConfig,
+	type StoreRegistration,
 	type StorefrontDetailedNavigationItem,
 	type StorefrontFooter,
 	type StorefrontLandingPage,
 	type StorefrontNavigationItem,
 	type StorefrontNavigationSection
 } from "@openfin/workspace";
-import { getApps, getAppsByTag } from "../apps";
+import { PLATFORM_ACTION_IDS } from "../actions";
+import { getApp, getApps, getAppsByTag } from "../apps";
+import * as favoriteProvider from "../favorite";
 import { launch } from "../launch";
+import { subscribeLifecycleEvent, unsubscribeLifecycleEvent } from "../lifecycle";
 import { createLogger } from "../logger-provider";
+import type { PlatformApp } from "../shapes/app-shapes";
+import { FAVORITE_TYPE_NAME_APP, type FavoriteEntry } from "../shapes/favorite-shapes";
+import type { FavoriteChangedLifecyclePayload } from "../shapes/lifecycle-shapes";
 import type {
 	StorefrontProviderOptions,
 	StorefrontSettingsLandingPageRow,
 	StorefrontSettingsNavigationItem
-} from "../shapes";
-import type { PlatformApp } from "../shapes/app-shapes";
-import { isEmpty } from "../utils";
+} from "../shapes/store-shapes";
+import { isEmpty, isStringValue, randomUUID } from "../utils";
 
 const TOP_ROW_LIMIT = 4;
 const MIDDLE_ROW_LIMIT = 6;
@@ -26,7 +33,8 @@ const BOTTOM_ROW_LIMIT = 3;
 const logger = createLogger("Store");
 
 let storeProviderOptions: StorefrontProviderOptions | undefined;
-let registrationInfo: RegistrationMetaInfo | undefined;
+let registrationInfo: StoreRegistration | undefined;
+let favChangedSubscriptionId: string | undefined;
 
 /**
  * Register the store component.
@@ -54,6 +62,16 @@ export async function register(
 						await launch(app as PlatformApp);
 					}
 				});
+
+				favChangedSubscriptionId = subscribeLifecycleEvent<FavoriteChangedLifecyclePayload>(
+					"favorite-changed",
+					async (_: unknown, customData?: FavoriteChangedLifecyclePayload) => {
+						if (!isEmpty(customData)) {
+							await updateAppFavoriteButtons(customData);
+						}
+					}
+				);
+
 				logger.info("Version:", registrationInfo);
 				logger.info("Storefront provider initialized");
 			} catch (err) {
@@ -72,8 +90,13 @@ export async function register(
 export async function deregister(): Promise<void> {
 	if (registrationInfo) {
 		logger.info("About to deregister Store.");
+		if (isStringValue(favChangedSubscriptionId)) {
+			unsubscribeLifecycleEvent(favChangedSubscriptionId, "favorite-changed");
+			favChangedSubscriptionId = undefined;
+		}
 		if (storeProviderOptions) {
 			await Storefront.deregister(storeProviderOptions.id);
+			registrationInfo = undefined;
 		}
 	} else {
 		logger.warn(
@@ -342,7 +365,7 @@ async function getLandingPage(): Promise<StorefrontLandingPage> {
 				)}. Only ${MIDDLE_ROW_LIMIT} will be shown.`
 			);
 		}
-		const validatedMiddleRowApps = addButtons(middleRowApps.slice(0, MIDDLE_ROW_LIMIT)) as [
+		const validatedMiddleRowApps = (await addButtons(middleRowApps.slice(0, MIDDLE_ROW_LIMIT))) as [
 			PlatformApp?,
 			PlatformApp?,
 			PlatformApp?,
@@ -493,26 +516,136 @@ async function getLandingPageRow(
  * @param apps The list of apps to add the buttons to.
  * @returns The list of augmented apps.
  */
-function addButtons(apps: PlatformApp[]): PlatformApp[] {
+async function addButtons(apps: PlatformApp[]): Promise<PlatformApp[]> {
 	const primaryButton = storeProviderOptions?.primaryButton;
 	const secondaryButtons = storeProviderOptions?.secondaryButtons;
+
+	const favInfo = favoriteProvider.getInfo();
+	const favoriteApps: { [typeId: string]: FavoriteEntry } = {};
+	let showFavorites = false;
+
+	if (
+		(storeProviderOptions?.favoritesEnabled ?? true) &&
+		favInfo.isEnabled &&
+		(isEmpty(favInfo.enabledTypes) || favInfo.enabledTypes.includes(FAVORITE_TYPE_NAME_APP))
+	) {
+		showFavorites = true;
+		const favorites = await favoriteProvider.getSavedFavorites(FAVORITE_TYPE_NAME_APP);
+		if (favorites) {
+			for (const fav of favorites) {
+				favoriteApps[fav.typeId] = fav;
+			}
+		}
+	}
+
 	const isArray = !isEmpty(secondaryButtons) && Array.isArray(secondaryButtons);
-	if (!isEmpty(primaryButton) || isArray) {
+	if (!isEmpty(primaryButton) || isArray || showFavorites) {
 		return apps.map((app) => ({
 			...app,
-			primaryButton: app.primaryButton ?? primaryButton,
-			secondaryButtons:
-				app.secondaryButtons ?? isArray
-					? secondaryButtons?.map((secondary) => ({
-							title: secondary.title,
-							action: {
-								id: secondary.action.id,
-								customData: secondary.action.customData ?? app
-							}
-					  }))
-					: undefined
+			...calculateButtons(app, primaryButton, secondaryButtons, showFavorites, favoriteApps[app.appId])
 		}));
 	}
 
 	return apps;
+}
+
+/**
+ * Add the buttons to the application.
+ * @param app The app to add the buttons to.
+ * @param configPrimaryButton The primary button config.
+ * @param configSecondaryButtons The secondary button config.
+ * @param showFavorites Show favorites buttons.
+ * @param favoriteEntry The favorite details.
+ * @returns The update app with buttons.
+ */
+function calculateButtons(
+	app: PlatformApp,
+	configPrimaryButton: StoreButtonConfig | undefined,
+	configSecondaryButtons: StoreButtonConfig[] | undefined,
+	showFavorites: boolean,
+	favoriteEntry?: FavoriteEntry
+): {
+	primaryButton: StoreButtonConfig;
+	secondaryButtons: StoreButtonConfig[];
+} {
+	const appSecondaryButtons =
+		configSecondaryButtons?.map((secondary) => ({
+			title: secondary.title,
+			action: {
+				id: secondary.action.id,
+				customData: secondary.action.customData ?? app
+			}
+		})) ?? [];
+
+	if (showFavorites) {
+		appSecondaryButtons.push({
+			title: favoriteEntry ? "Remove Favorite" : "Add Favorite",
+			action: {
+				id: favoriteEntry ? PLATFORM_ACTION_IDS.favoriteRemove : PLATFORM_ACTION_IDS.favoriteAdd,
+				customData: favoriteEntry ?? {
+					id: randomUUID(),
+					type: FAVORITE_TYPE_NAME_APP,
+					typeId: app.appId,
+					label: app.title,
+					icon: getAppIcon(app)
+				}
+			}
+		});
+	}
+
+	return {
+		primaryButton: app.primaryButton ??
+			configPrimaryButton ?? {
+				title: "Launch",
+				action: {
+					id: "launch-app",
+					customData: app
+				}
+			},
+		secondaryButtons: appSecondaryButtons
+	};
+}
+
+/**
+ * Get the icon for an application.
+ * @param app The application to get the icon for.
+ * @returns The icon.
+ */
+function getAppIcon(app: PlatformApp): string | undefined {
+	if (Array.isArray(app.icons) && app.icons.length > 0) {
+		return app.icons[0].src;
+	}
+}
+
+/**
+ * Update the app buttons if the favorites have changed.
+ * @param payload The payload of the favorite change.
+ */
+async function updateAppFavoriteButtons(payload: FavoriteChangedLifecyclePayload): Promise<void> {
+	const favorite: FavoriteEntry = payload.favorite;
+
+	if (
+		(storeProviderOptions?.favoritesEnabled ?? true) &&
+		!isEmpty(registrationInfo) &&
+		!isEmpty(favorite) &&
+		(payload.action === "set" || payload.action === "delete") &&
+		favorite.type === FAVORITE_TYPE_NAME_APP
+	) {
+		const app = await getApp(favorite.typeId);
+
+		if (!isEmpty(app)) {
+			await registrationInfo.updateAppCardButtons({
+				appId: favorite.typeId,
+				...calculateButtons(
+					app,
+					storeProviderOptions?.primaryButton,
+					storeProviderOptions?.secondaryButtons,
+					true,
+					favorite
+				)
+			});
+		} else {
+			logger.warn(`Favorite update for appId ${favorite.typeId} which does not exist`);
+		}
+	}
 }

--- a/how-to/workspace-platform-starter/client/src/modules/integrations/apps/integration.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/integrations/apps/integration.ts
@@ -622,9 +622,10 @@ export class AppProvider implements IntegrationModule<AppSettings> {
 		if (
 			!isEmpty(this._lastResponse) &&
 			this._integrationHelpers?.getFavoriteClient &&
-			!isEmpty(favorite) &&
 			(payload.action === "set" || payload.action === "delete") &&
-			favorite.type === FAVORITE_TYPE_NAME_APP
+			!isEmpty(favorite) &&
+			favorite.type === FAVORITE_TYPE_NAME_APP &&
+			this._lastAppResults
 		) {
 			const favClient = await this._integrationHelpers.getFavoriteClient();
 			if (favClient) {
@@ -635,7 +636,11 @@ export class AppProvider implements IntegrationModule<AppSettings> {
 					if (this._lastQuery === favInfo.command && payload.action === "delete") {
 						this._lastResponse.revoke(favorite.typeId);
 					} else if (this._lastAppResults) {
-						const lastApp = this._lastAppResults.find((a) => a.appId === favorite.typeId);
+						let lastApp = this._lastAppResults.find((a) => a.appId === favorite.typeId);
+
+						if (!lastApp && this._integrationHelpers.getApp) {
+							lastApp = await this._integrationHelpers.getApp(favorite.typeId);
+						}
 
 						if (!isEmpty(lastApp)) {
 							const rebuilt = await this.mapAppEntryToSearchEntry(

--- a/how-to/workspace-platform-starter/client/src/modules/integrations/apps/integration.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/integrations/apps/integration.ts
@@ -144,9 +144,9 @@ export class AppProvider implements IntegrationModule<AppSettings> {
 			this._favChangedSubscriptionId =
 				this._integrationHelpers.subscribeLifecycleEvent<FavoriteChangedLifecyclePayload>(
 					"favorite-changed",
-					async (_: unknown, customData?: FavoriteChangedLifecyclePayload) => {
-						if (!isEmpty(customData)) {
-							await this.updateAppFavoriteButtons(customData);
+					async (_: unknown, payload?: FavoriteChangedLifecyclePayload) => {
+						if (!isEmpty(payload)) {
+							await this.updateAppFavoriteButtons(payload);
 						}
 					}
 				);

--- a/how-to/workspace-platform-starter/client/src/modules/integrations/apps/integration.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/integrations/apps/integration.ts
@@ -7,6 +7,7 @@ import type {
 	HomeSearchResponse,
 	HomeSearchResult
 } from "@openfin/workspace";
+import type { FavoriteChangedLifecyclePayload } from "workspace-platform-starter/shapes";
 import type { ManifestTypeId, PlatformApp } from "workspace-platform-starter/shapes/app-shapes";
 import {
 	FAVORITE_TYPE_NAME_APP,
@@ -105,6 +106,16 @@ export class AppProvider implements IntegrationModule<AppSettings> {
 	private _lastResultIds?: string[];
 
 	/**
+	 * Subscription id for theme-changed lifecycle event.
+	 */
+	private _themeChangedSubscriptionId: string | undefined;
+
+	/**
+	 * Subscription id for favorite-changed lifecycle event.
+	 */
+	private _favChangedSubscriptionId: string | undefined;
+
+	/**
 	 * Initialize the module.
 	 * @param definition The definition of the module from configuration include custom options.
 	 * @param loggerCreator For logging entries.
@@ -123,9 +134,43 @@ export class AppProvider implements IntegrationModule<AppSettings> {
 		this._providerId = definition.id;
 
 		if (this._integrationHelpers.subscribeLifecycleEvent) {
-			this._integrationHelpers.subscribeLifecycleEvent("theme-changed", async () => {
-				await this.rebuildResults();
-			});
+			this._themeChangedSubscriptionId = this._integrationHelpers.subscribeLifecycleEvent(
+				"theme-changed",
+				async () => {
+					await this.rebuildResults();
+				}
+			);
+
+			this._favChangedSubscriptionId =
+				this._integrationHelpers.subscribeLifecycleEvent<FavoriteChangedLifecyclePayload>(
+					"favorite-changed",
+					async (_: unknown, customData?: FavoriteChangedLifecyclePayload) => {
+						if (!isEmpty(customData)) {
+							await this.updateAppFavoriteButtons(customData);
+						}
+					}
+				);
+		}
+	}
+
+	/**
+	 * Close down any resources being used by the module.
+	 * @returns Nothing.
+	 */
+	public async closedown(): Promise<void> {
+		if (this._integrationHelpers?.unsubscribeLifecycleEvent) {
+			if (isStringValue(this._themeChangedSubscriptionId)) {
+				this._integrationHelpers.unsubscribeLifecycleEvent(this._themeChangedSubscriptionId, "theme-changed");
+				this._themeChangedSubscriptionId = undefined;
+			}
+
+			if (isStringValue(this._favChangedSubscriptionId)) {
+				this._integrationHelpers.unsubscribeLifecycleEvent(
+					this._favChangedSubscriptionId,
+					"favorite-changed"
+				);
+				this._favChangedSubscriptionId = undefined;
+			}
 		}
 	}
 
@@ -185,43 +230,21 @@ export class AppProvider implements IntegrationModule<AppSettings> {
 				if (this._integrationHelpers?.getFavoriteClient) {
 					const favClient = await this._integrationHelpers.getFavoriteClient();
 					if (favClient) {
-						const favInfo = favClient.getInfo();
-						if (favInfo) {
-							let favoriteId: string | undefined = result.data?.favouriteId;
-							if (result.action.name.startsWith("un")) {
-								if (!isEmpty(favoriteId) && favClient.deleteSavedFavorite) {
-									await favClient.deleteSavedFavorite(favoriteId);
-									favoriteId = undefined;
-								}
-							} else if (favClient.setSavedFavorite) {
-								favoriteId = randomUUID();
-								await favClient.setSavedFavorite({
-									id: randomUUID(),
-									type: FAVORITE_TYPE_NAME_APP,
-									typeId: result.key,
-									label: result.title,
-									icon: result.icon
-								});
+						if (result.action.name.startsWith("un")) {
+							if (!isEmpty(result.data?.favoriteId) && favClient.deleteSavedFavorite) {
+								await favClient.deleteSavedFavorite(result.data.favoriteId);
 							}
-							const colorScheme = (await this._integrationHelpers?.getCurrentColorSchemeMode()) ?? "dark";
-
-							if (this._lastQuery === favInfo.command && isEmpty(favoriteId)) {
-								lastResponse.revoke(result.key);
-							} else {
-								const rebuilt = await this.mapAppEntryToSearchEntry(
-									result.data.app,
-									this._settings?.manifestTypeMapping,
-									favInfo,
-									favoriteId,
-									colorScheme
-								);
-
-								if (rebuilt) {
-									lastResponse.respond([rebuilt]);
-								}
-							}
-							handled = true;
+						} else if (favClient.setSavedFavorite) {
+							await favClient.setSavedFavorite({
+								id: randomUUID(),
+								type: FAVORITE_TYPE_NAME_APP,
+								typeId: result.key,
+								label: result.title,
+								icon: result.icon
+							});
 						}
+
+						handled = true;
 					}
 				}
 			} else if (this._integrationHelpers?.launchApp) {
@@ -586,6 +609,50 @@ export class AppProvider implements IntegrationModule<AppSettings> {
 			}
 			this._lastResponse.respond(appResponse.results);
 			this._logger?.info("Results rebuilt.");
+		}
+	}
+
+	/**
+	 * Update the app buttons if the favorites have changed.
+	 * @param payload The payload of the favorite change.
+	 */
+	private async updateAppFavoriteButtons(payload: FavoriteChangedLifecyclePayload): Promise<void> {
+		const favorite: FavoriteEntry = payload.favorite;
+
+		if (
+			!isEmpty(this._lastResponse) &&
+			this._integrationHelpers?.getFavoriteClient &&
+			!isEmpty(favorite) &&
+			(payload.action === "set" || payload.action === "delete") &&
+			favorite.type === FAVORITE_TYPE_NAME_APP
+		) {
+			const favClient = await this._integrationHelpers.getFavoriteClient();
+			if (favClient) {
+				const favInfo = favClient.getInfo();
+				if (favInfo) {
+					const colorScheme = (await this._integrationHelpers?.getCurrentColorSchemeMode()) ?? "dark";
+
+					if (this._lastQuery === favInfo.command && payload.action === "delete") {
+						this._lastResponse.revoke(favorite.typeId);
+					} else if (this._lastAppResults) {
+						const lastApp = this._lastAppResults.find((a) => a.appId === favorite.typeId);
+
+						if (!isEmpty(lastApp)) {
+							const rebuilt = await this.mapAppEntryToSearchEntry(
+								lastApp,
+								this._settings?.manifestTypeMapping,
+								favInfo,
+								payload.action === "set" ? favorite.id : undefined,
+								colorScheme
+							);
+
+							if (rebuilt) {
+								this._lastResponse.respond([rebuilt]);
+							}
+						}
+					}
+				}
+			}
 		}
 	}
 }

--- a/how-to/workspace-platform-starter/client/src/modules/integrations/pages/integration.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/integrations/pages/integration.ts
@@ -111,22 +111,19 @@ export class PagesProvider implements IntegrationModule<PagesSettings> {
 		if (this._integrationHelpers.subscribeLifecycleEvent) {
 			this._integrationHelpers.subscribeLifecycleEvent<PageChangedLifecyclePayload>(
 				"page-changed",
-				async (
-					platform: WorkspacePlatformModule,
-					customData?: PageChangedLifecyclePayload
-				): Promise<void> => {
-					if (customData?.action === "create") {
+				async (platform: WorkspacePlatformModule, payload?: PageChangedLifecyclePayload): Promise<void> => {
+					if (payload?.action === "create") {
 						await this.rebuildResults(platform);
-					} else if (customData?.action === "update") {
-						const lastResult = this._lastResults?.find((res) => res.key === customData.id);
-						if (lastResult && customData.page) {
-							lastResult.title = customData.page.title;
-							lastResult.data.workspaceTitle = customData.page.title;
-							(lastResult.templateContent as CustomTemplate).data.title = customData.page.title;
+					} else if (payload?.action === "update") {
+						const lastResult = this._lastResults?.find((res) => res.key === payload.id);
+						if (lastResult && payload.page) {
+							lastResult.title = payload.page.title;
+							lastResult.data.workspaceTitle = payload.page.title;
+							(lastResult.templateContent as CustomTemplate).data.title = payload.page.title;
 							this.resultAddUpdate([lastResult]);
 						}
-					} else if (customData?.action === "delete") {
-						this.resultRemove(customData.id);
+					} else if (payload?.action === "delete") {
+						this.resultRemove(payload.id);
 					}
 				}
 			);

--- a/how-to/workspace-platform-starter/client/src/modules/integrations/pages/integration.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/integrations/pages/integration.ts
@@ -109,22 +109,24 @@ export class PagesProvider implements IntegrationModule<PagesSettings> {
 		this._definition = definition;
 
 		if (this._integrationHelpers.subscribeLifecycleEvent) {
-			this._integrationHelpers.subscribeLifecycleEvent(
+			this._integrationHelpers.subscribeLifecycleEvent<PageChangedLifecyclePayload>(
 				"page-changed",
-				async (platform: WorkspacePlatformModule, unknownPayload: unknown): Promise<void> => {
-					const payload = unknownPayload as PageChangedLifecyclePayload;
-					if (payload.action === "create") {
+				async (
+					platform: WorkspacePlatformModule,
+					customData?: PageChangedLifecyclePayload
+				): Promise<void> => {
+					if (customData?.action === "create") {
 						await this.rebuildResults(platform);
-					} else if (payload.action === "update") {
-						const lastResult = this._lastResults?.find((res) => res.key === payload.id);
-						if (lastResult && payload.page) {
-							lastResult.title = payload.page.title;
-							lastResult.data.workspaceTitle = payload.page.title;
-							(lastResult.templateContent as CustomTemplate).data.title = payload.page.title;
+					} else if (customData?.action === "update") {
+						const lastResult = this._lastResults?.find((res) => res.key === customData.id);
+						if (lastResult && customData.page) {
+							lastResult.title = customData.page.title;
+							lastResult.data.workspaceTitle = customData.page.title;
+							(lastResult.templateContent as CustomTemplate).data.title = customData.page.title;
 							this.resultAddUpdate([lastResult]);
 						}
-					} else if (payload.action === "delete") {
-						this.resultRemove(payload.id);
+					} else if (customData?.action === "delete") {
+						this.resultRemove(customData.id);
 					}
 				}
 			);

--- a/how-to/workspace-platform-starter/client/src/modules/integrations/workspaces/integration.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/integrations/workspaces/integration.ts
@@ -125,22 +125,22 @@ export class WorkspacesProvider implements IntegrationModule<WorkspacesSettings>
 				"workspace-changed",
 				async (
 					platform: WorkspacePlatformModule,
-					customData?: WorkspaceChangedLifecyclePayload
+					payload?: WorkspaceChangedLifecyclePayload
 				): Promise<void> => {
-					if (customData?.action === "create") {
+					if (payload?.action === "create") {
 						if (!isEmpty(this._lastQuery) && !this._lastQuery.startsWith("/w ")) {
 							await this.rebuildResults(platform);
 						}
-					} else if (customData?.action === "update") {
-						const lastResult = this._lastResults?.find((res) => res.key === customData.id);
-						if (lastResult && customData.workspace) {
-							lastResult.title = customData.workspace.title;
-							lastResult.data.workspaceTitle = customData.workspace.title;
-							(lastResult.templateContent as CustomTemplate).data.title = customData.workspace.title;
+					} else if (payload?.action === "update") {
+						const lastResult = this._lastResults?.find((res) => res.key === payload.id);
+						if (lastResult && payload.workspace) {
+							lastResult.title = payload.workspace.title;
+							lastResult.data.workspaceTitle = payload.workspace.title;
+							(lastResult.templateContent as CustomTemplate).data.title = payload.workspace.title;
 							this.resultAddUpdate([lastResult]);
 						}
-					} else if (customData?.action === "delete") {
-						this.resultRemove(customData.id);
+					} else if (payload?.action === "delete") {
+						this.resultRemove(payload.id);
 					}
 				}
 			);

--- a/how-to/workspace-platform-starter/client/src/modules/integrations/workspaces/integration.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/integrations/workspaces/integration.ts
@@ -121,24 +121,26 @@ export class WorkspacesProvider implements IntegrationModule<WorkspacesSettings>
 		this._logger = loggerCreator("WorkspacesProvider");
 
 		if (this._integrationHelpers.subscribeLifecycleEvent) {
-			this._integrationHelpers.subscribeLifecycleEvent(
+			this._integrationHelpers.subscribeLifecycleEvent<WorkspaceChangedLifecyclePayload>(
 				"workspace-changed",
-				async (platform: WorkspacePlatformModule, payload: unknown): Promise<void> => {
-					const wsPayload = payload as WorkspaceChangedLifecyclePayload;
-					if (wsPayload.action === "create") {
+				async (
+					platform: WorkspacePlatformModule,
+					customData?: WorkspaceChangedLifecyclePayload
+				): Promise<void> => {
+					if (customData?.action === "create") {
 						if (!isEmpty(this._lastQuery) && !this._lastQuery.startsWith("/w ")) {
 							await this.rebuildResults(platform);
 						}
-					} else if (wsPayload.action === "update") {
-						const lastResult = this._lastResults?.find((res) => res.key === wsPayload.id);
-						if (lastResult && wsPayload.workspace) {
-							lastResult.title = wsPayload.workspace.title;
-							lastResult.data.workspaceTitle = wsPayload.workspace.title;
-							(lastResult.templateContent as CustomTemplate).data.title = wsPayload.workspace.title;
+					} else if (customData?.action === "update") {
+						const lastResult = this._lastResults?.find((res) => res.key === customData.id);
+						if (lastResult && customData.workspace) {
+							lastResult.title = customData.workspace.title;
+							lastResult.data.workspaceTitle = customData.workspace.title;
+							(lastResult.templateContent as CustomTemplate).data.title = customData.workspace.title;
 							this.resultAddUpdate([lastResult]);
 						}
-					} else if (wsPayload.action === "delete") {
-						this.resultRemove(wsPayload.id);
+					} else if (customData?.action === "delete") {
+						this.resultRemove(customData.id);
 					}
 				}
 			);

--- a/how-to/workspace-platform-starter/client/types/module/shapes/lifecycle-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/lifecycle-shapes.d.ts
@@ -19,10 +19,7 @@ export type LifecycleEvents =
 /**
  * The type for a lifecycle event handler.
  */
-export type LifecycleHandler<T = unknown> = (
-	platform: WorkspacePlatformModule,
-	customData?: T
-) => Promise<void>;
+export type LifecycleHandler<T = unknown> = (platform: WorkspacePlatformModule, payload?: T) => Promise<void>;
 /**
  * Map of the lifecycle event handlers.
  */

--- a/how-to/workspace-platform-starter/client/types/module/shapes/lifecycle-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/lifecycle-shapes.d.ts
@@ -1,5 +1,6 @@
 import type { Workspace } from "@openfin/workspace";
 import type { Page, WorkspacePlatformModule } from "@openfin/workspace-platform";
+import type { FavoriteEntry } from "./favorite-shapes";
 import type { ModuleHelpers, ModuleImplementation, ModuleList } from "./module-shapes";
 /**
  * Events that can be triggered through the lifecycle.
@@ -18,7 +19,10 @@ export type LifecycleEvents =
 /**
  * The type for a lifecycle event handler.
  */
-export type LifecycleHandler = (platform: WorkspacePlatformModule, customData?: unknown) => Promise<void>;
+export type LifecycleHandler<T = unknown> = (
+	platform: WorkspacePlatformModule,
+	customData?: T
+) => Promise<void>;
 /**
  * Map of the lifecycle event handlers.
  */
@@ -73,4 +77,17 @@ export interface PageChangedLifecyclePayload {
 	 * The page data.
 	 */
 	page?: Page;
+}
+/**
+ * Event payload for the favorite changed lifecycle event.
+ */
+export interface FavoriteChangedLifecyclePayload {
+	/**
+	 * The action that happened to the favorite.
+	 */
+	action: "set" | "delete";
+	/**
+	 * The favorite entry.
+	 */
+	favorite: FavoriteEntry;
 }

--- a/how-to/workspace-platform-starter/client/types/module/shapes/module-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/module-shapes.d.ts
@@ -142,7 +142,10 @@ export interface ModuleHelpers {
 	 * @param lifecycleHandler The handle for the event.
 	 * @returns A subscription id to be used with unsubscribe.
 	 */
-	subscribeLifecycleEvent?(lifecycleEvent: LifecycleEvents, lifecycleHandler: LifecycleHandler): string;
+	subscribeLifecycleEvent?<T = unknown>(
+		lifecycleEvent: LifecycleEvents,
+		lifecycleHandler: LifecycleHandler<T>
+	): string;
 	/**
 	 * Unsubscribe from lifecycle events.
 	 * @param subscriptionId The id of the subscription.

--- a/how-to/workspace-platform-starter/client/types/module/shapes/module-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/module-shapes.d.ts
@@ -67,6 +67,12 @@ export interface ModuleHelpers {
 	 */
 	getApps?(): Promise<PlatformApp[]>;
 	/**
+	 * Get the app by id.
+	 * @param id The id of the app to get.
+	 * @returns The app id it exists.
+	 */
+	getApp?(id: string): Promise<PlatformApp | undefined>;
+	/**
 	 * Get the current theme id.
 	 * @returns The current theme id.
 	 */

--- a/how-to/workspace-platform-starter/client/types/module/shapes/store-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/store-shapes.d.ts
@@ -100,6 +100,10 @@ export interface StorefrontProviderOptions {
 	 * Secondary buttons added to all store entries.
 	 */
 	secondaryButtons?: StoreButtonConfig[];
+	/**
+	 * Enable favorites, defaults to true.
+	 */
+	favoritesEnabled?: boolean;
 }
 /**
  * A navigation item.

--- a/how-to/workspace-platform-starter/public/schemas/settings.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/settings.schema.json
@@ -3604,6 +3604,10 @@
             "additionalProperties": false,
             "description": "Store Provider Options",
             "properties": {
+                "favoritesEnabled": {
+                    "description": "Enable favorites, defaults to true.",
+                    "type": "boolean"
+                },
                 "footer": {
                     "$ref": "#/definitions/StorefrontFooter",
                     "description": "The configuration of the footer for the store"


### PR DESCRIPTION
Add support for favorites in store
- StoreProvider added `favouritesEnabled` flag
- Subsribing to lifecycle events can now pass generic param to type the `customData`
- `favorite-changed ` payload type added, `id` changed to whole `favorite` object
- Favorite delete now looks up the entry so that it can be passed to `favorite-changed`
- Added global actions for `favorite-add` and `favorite-remove` which require the entry as `customData`
- Updated apps integration to response to `favorite-changed` event
- Added getApp method to integration helpers
![image](https://github.com/built-on-openfin/workspace-starter/assets/5030334/bc4885c9-05c2-4150-b4c9-8e88aff2905d)
