### PR TITLE
Rationalize the dock types

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -32,7 +32,7 @@
 - Added Module helpers showPopupMenu for common functionality
 - Added conditions now support passing `callerType`and `context`
 - Added `include-in-snapshot` composite module which has both actions and conditions to display browser toolbar buttons which can control if a window is included in a snapshot, disabled by default
-- Change `apps` and `buttons` in the dock config have been deprecated and replaced with `entries` which can contain the combined data from the old properties, the old properties will be read for now.
+- FUTURE BREAKING CHANGE `apps` and `buttons` in the dock config have been deprecated and replaced with `entries` which can contain the combined data from the old properties, the old properties will be read for now.
 
 ## v13.1
 

--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Added Module helpers showPopupMenu for common functionality
 - Added conditions now support passing `callerType`and `context`
 - Added `include-in-snapshot` composite module which has both actions and conditions to display browser toolbar buttons which can control if a window is included in a snapshot, disabled by default
+- Change `apps` and `buttons` in the dock config have been deprecated and replaced with `entries` which can contain the combined data from the old properties, the old properties will be read for now.
 
 ## v13.1
 

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/conditions-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/conditions-shapes.ts
@@ -1,6 +1,6 @@
 import type OpenFin from "@openfin/core";
 import type { WorkspacePlatformModule } from "@openfin/workspace-platform";
-import type { DockButtonAction, DockButtonApp, DockButtonDropdown } from "./dock-shapes";
+import type { DockButtonTypes } from "./dock-shapes";
 import type { InitOptionsHandler, InitOptionsHandlerOptions } from "./init-options-shapes";
 import type { MenuEntry } from "./menu-shapes";
 import type { ModuleEntry, ModuleHelpers, ModuleImplementation, ModuleList } from "./module-shapes";
@@ -54,7 +54,7 @@ export interface ConditionContextDock extends ConditionContext {
 	/**
 	 * Data from the caller.
 	 */
-	customData?: DockButtonApp | DockButtonAction | DockButtonDropdown;
+	customData?: DockButtonTypes;
 }
 
 /**

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/dock-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/dock-shapes.ts
@@ -79,6 +79,11 @@ export interface DockButtonAppsByTag extends DockButtonBase {
 	 * against the tags associated with apps returned from the app data sources.
 	 */
 	tags?: string[];
+
+	/**
+	 * Text to display if there are no entries because there are no tagged apps.
+	 */
+	noEntries?: string;
 }
 
 /**
@@ -118,6 +123,11 @@ export interface DockButtonDropdown extends DockButtonBase {
 	 * List of button options
 	 */
 	options: (Omit<DockButtonApp, "iconUrl"> | Omit<DockButtonAction, "iconUrl">)[];
+
+	/**
+	 * Text to display if there are no entries because conditions have excluded options.
+	 */
+	noEntries?: string;
 }
 
 /**

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/dock-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/dock-shapes.ts
@@ -28,14 +28,21 @@ export interface DockProviderOptions {
 	};
 
 	/**
-	 * What apps should be made available via the dock
+	 * What apps, actions or drop downs should be made available via the dock.
 	 */
-	apps?: DockButtonApp[];
+	entries?: DockButtonTypes[];
 
 	/**
-	 * What custom actions should be made available via the dock
+	 * What apps should be made available via the dock, this property is deprecated, use entries.
+	 * @deprecated
 	 */
-	buttons?: (DockButtonAction | DockButtonDropdown)[];
+	apps?: DockButtonAppsByTag[];
+
+	/**
+	 * What custom actions should be made available via the dock, this property is deprecated, use entries.
+	 * @deprecated
+	 */
+	buttons?: (DockButtonApp | DockButtonAction | DockButtonDropdown)[];
 }
 
 /**
@@ -59,9 +66,9 @@ export interface DockButtonBase {
 }
 
 /**
- * A single app or a list of apps
+ * A single app or a list of apps that are defined by the tags in the app definitions.
  */
-export interface DockButtonApp extends DockButtonBase {
+export interface DockButtonAppsByTag extends DockButtonBase {
 	/**
 	 * Should this entry show a single app or a group of apps.
 	 */
@@ -75,18 +82,23 @@ export interface DockButtonApp extends DockButtonBase {
 }
 
 /**
- * A button which launched an app or action.
+ * A button which launches an app by it's or or a custom action.
+ */
+export interface DockButtonApp extends DockButtonBase {
+	/**
+	 * Launch an app by it's id.
+	 */
+	appId: string;
+}
+
+/**
+ * A button which launches an app by it's or or a custom action.
  */
 export interface DockButtonAction extends DockButtonBase {
 	/**
-	 * Should this action launch a specific app (the icon and tooltip will be pulled from the app if possible)
+	 * Launch an action.
 	 */
-	appId?: string;
-
-	/**
-	 * If an appId isn't provided then provide details related to the action
-	 */
-	action?: {
+	action: {
 		/**
 		 * The id of the action to fire
 		 */
@@ -105,5 +117,10 @@ export interface DockButtonDropdown extends DockButtonBase {
 	/**
 	 * List of button options
 	 */
-	options: Omit<DockButtonAction, "iconUrl">[];
+	options: (Omit<DockButtonApp, "iconUrl"> | Omit<DockButtonAction, "iconUrl">)[];
 }
+
+/**
+ * All of the button types for the dock.
+ */
+export type DockButtonTypes = DockButtonAppsByTag | DockButtonApp | DockButtonAction | DockButtonDropdown;

--- a/how-to/workspace-platform-starter/client/src/framework/workspace/dock.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/workspace/dock.ts
@@ -176,14 +176,14 @@ async function addEntryAsApp(
 	let tooltip = entry.tooltip;
 	let iconUrl = entry.iconUrl;
 
-	if (!tooltip || !iconUrl) {
+	if (!isStringValue(tooltip) || !isStringValue(iconUrl)) {
 		// No tooltip or icon set, so use the values from the app
 		const app = await getApp(entry.appId);
 		if (app) {
-			if (!tooltip) {
+			if (!isStringValue(tooltip)) {
 				tooltip = app.title;
 			}
-			if (!iconUrl) {
+			if (!isStringValue(iconUrl)) {
 				iconUrl = getAppIcon(app);
 			}
 		}
@@ -341,7 +341,7 @@ async function addEntriesByAppTag(
 			}
 		} else if (entry.display === "group") {
 			// Group display so show a drop down with all the entries in it
-			if (!entry.tooltip) {
+			if (!isStringValue(entry.tooltip)) {
 				logger.error("You must specify the tooltip for a grouped DockButtonAppsByTag");
 			} else {
 				let iconUrl = entry.iconUrl;
@@ -349,7 +349,7 @@ async function addEntriesByAppTag(
 
 				for (const dockApp of dockApps) {
 					// If the config doesn't specify an icon, just use the icon from the first entry
-					if (!iconUrl) {
+					if (!isStringValue(iconUrl)) {
 						iconUrl = getAppIcon(dockApp);
 					}
 

--- a/how-to/workspace-platform-starter/client/src/framework/workspace/dock.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/workspace/dock.ts
@@ -159,7 +159,7 @@ async function buildButtons(): Promise<DockButton[]> {
 }
 
 /**
- * Add an entry to the dock as an app
+ * Add an entry to the dock as an app.
  * @param buttons The list of buttons to add to.
  * @param entry The entry details.
  * @param iconFolder The folder for icons.
@@ -204,7 +204,7 @@ async function addEntryAsApp(
 }
 
 /**
- * Add an entry to the dock as an action
+ * Add an entry to the dock as an action.
  * @param buttons The list of buttons to add to.
  * @param entry The entry details.
  * @param iconFolder The folder for icons.
@@ -229,11 +229,12 @@ async function addEntryAsAction(
 }
 
 /**
- * Add an entry to the dock as an drop down
+ * Add an entry to the dock as an drop down.
  * @param buttons The list of buttons to add to.
  * @param entry The entry details.
  * @param iconFolder The folder for icons.
  * @param colorSchemeMode The color scheme
+ * @param platform The workspace platform for checking conditions.
  */
 async function addEntriesAsDropdown(
 	buttons: DockButton[],

--- a/how-to/workspace-platform-starter/client/types/module/shapes/conditions-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/conditions-shapes.d.ts
@@ -1,6 +1,6 @@
 import type OpenFin from "@openfin/core";
 import type { WorkspacePlatformModule } from "@openfin/workspace-platform";
-import type { DockButtonAction, DockButtonApp, DockButtonDropdown } from "./dock-shapes";
+import type { DockButtonTypes } from "./dock-shapes";
 import type { InitOptionsHandler, InitOptionsHandlerOptions } from "./init-options-shapes";
 import type { MenuEntry } from "./menu-shapes";
 import type { ModuleEntry, ModuleHelpers, ModuleImplementation, ModuleList } from "./module-shapes";
@@ -47,7 +47,7 @@ export interface ConditionContextDock extends ConditionContext {
 	/**
 	 * Data from the caller.
 	 */
-	customData?: DockButtonApp | DockButtonAction | DockButtonDropdown;
+	customData?: DockButtonTypes;
 }
 /**
  * Type for the browser context in condition callbacks.

--- a/how-to/workspace-platform-starter/client/types/module/shapes/dock-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/dock-shapes.d.ts
@@ -24,13 +24,19 @@ export interface DockProviderOptions {
 		hideStorefrontButton?: boolean;
 	};
 	/**
-	 * What apps should be made available via the dock
+	 * What apps, actions or drop downs should be made available via the dock.
 	 */
-	apps?: DockButtonApp[];
+	entries?: DockButtonTypes[];
 	/**
-	 * What custom actions should be made available via the dock
+	 * What apps should be made available via the dock, this property is deprecated, use entries.
+	 * @deprecated
 	 */
-	buttons?: (DockButtonAction | DockButtonDropdown)[];
+	apps?: DockButtonAppsByTag[];
+	/**
+	 * What custom actions should be made available via the dock, this property is deprecated, use entries.
+	 * @deprecated
+	 */
+	buttons?: (DockButtonApp | DockButtonAction | DockButtonDropdown)[];
 }
 /**
  * Shared properties for dock buttons.
@@ -50,9 +56,9 @@ export interface DockButtonBase {
 	conditions?: string[];
 }
 /**
- * A single app or a list of apps
+ * A single app or a list of apps that are defined by the tags in the app definitions.
  */
-export interface DockButtonApp extends DockButtonBase {
+export interface DockButtonAppsByTag extends DockButtonBase {
 	/**
 	 * Should this entry show a single app or a group of apps.
 	 */
@@ -64,17 +70,22 @@ export interface DockButtonApp extends DockButtonBase {
 	tags?: string[];
 }
 /**
- * A button which launched an app or action.
+ * A button which launches an app by it's or or a custom action.
+ */
+export interface DockButtonApp extends DockButtonBase {
+	/**
+	 * Launch an app by it's id.
+	 */
+	appId: string;
+}
+/**
+ * A button which launches an app by it's or or a custom action.
  */
 export interface DockButtonAction extends DockButtonBase {
 	/**
-	 * Should this action launch a specific app (the icon and tooltip will be pulled from the app if possible)
+	 * Launch an action.
 	 */
-	appId?: string;
-	/**
-	 * If an appId isn't provided then provide details related to the action
-	 */
-	action?: {
+	action: {
 		/**
 		 * The id of the action to fire
 		 */
@@ -92,5 +103,9 @@ export interface DockButtonDropdown extends DockButtonBase {
 	/**
 	 * List of button options
 	 */
-	options: Omit<DockButtonAction, "iconUrl">[];
+	options: (Omit<DockButtonApp, "iconUrl"> | Omit<DockButtonAction, "iconUrl">)[];
 }
+/**
+ * All of the button types for the dock.
+ */
+export type DockButtonTypes = DockButtonAppsByTag | DockButtonApp | DockButtonAction | DockButtonDropdown;

--- a/how-to/workspace-platform-starter/client/types/module/shapes/dock-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/dock-shapes.d.ts
@@ -68,6 +68,10 @@ export interface DockButtonAppsByTag extends DockButtonBase {
 	 * against the tags associated with apps returned from the app data sources.
 	 */
 	tags?: string[];
+	/**
+	 * Text to display if there are no entries because there are no tagged apps.
+	 */
+	noEntries?: string;
 }
 /**
  * A button which launches an app by it's or or a custom action.
@@ -104,6 +108,10 @@ export interface DockButtonDropdown extends DockButtonBase {
 	 * List of button options
 	 */
 	options: (Omit<DockButtonApp, "iconUrl"> | Omit<DockButtonAction, "iconUrl">)[];
+	/**
+	 * Text to display if there are no entries because conditions have excluded options.
+	 */
+	noEntries?: string;
 }
 /**
  * All of the button types for the dock.

--- a/how-to/workspace-platform-starter/public/schemas/settings.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/settings.schema.json
@@ -50,7 +50,7 @@
             "$ref": "#/definitions/__type_14"
         },
         "AppAssetInfo": {
-            "$ref": "#/definitions/__type_42"
+            "$ref": "#/definitions/__type_44"
         },
         "AppEndpointOptions": {
             "anyOf": [
@@ -298,7 +298,7 @@
             "type": "object"
         },
         "ApplicationIdentity": {
-            "$ref": "#/definitions/__type_31"
+            "$ref": "#/definitions/__type_33"
         },
         "Array": {
             "items": {
@@ -564,7 +564,7 @@
             "type": "object"
         },
         "CertificationInfo": {
-            "$ref": "#/definitions/__type_41"
+            "$ref": "#/definitions/__type_43"
         },
         "ColorSchemeOption": {
             "enum": [
@@ -695,7 +695,7 @@
             "$ref": "#/definitions/__type_15"
         },
         "ContextGroupStates": {
-            "$ref": "#/definitions/__type_38"
+            "$ref": "#/definitions/__type_40"
         },
         "ContextMenuOptions": {
             "$ref": "#/definitions/__type_8"
@@ -1009,7 +1009,7 @@
             "type": "object"
         },
         "DeepPartial": {
-            "$ref": "#/definitions/__type_29"
+            "$ref": "#/definitions/__type_31"
         },
         "DipRect": {
             "additionalProperties": false,
@@ -1028,15 +1028,15 @@
             "type": "object"
         },
         "DipScaleRects": {
-            "$ref": "#/definitions/__type_35"
+            "$ref": "#/definitions/__type_37"
         },
         "DockButtonAction": {
             "additionalProperties": false,
-            "description": "A button which launched an app or action.",
+            "description": "A button which launches an app by it's or or a custom action.",
             "properties": {
                 "action": {
                     "additionalProperties": false,
-                    "description": "If an appId isn't provided then provide details related to the action",
+                    "description": "Launch an action.",
                     "properties": {
                         "customData": {
                             "description": "data that should be passed to the action"
@@ -1051,8 +1051,33 @@
                     ],
                     "type": "object"
                 },
+                "conditions": {
+                    "description": "Condition to determine if the item should be shown.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "iconUrl": {
+                    "description": "The icon to use to distinguish this entry from others",
+                    "type": "string"
+                },
+                "tooltip": {
+                    "description": "The tooltip to be shown for this button/entry",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "action"
+            ],
+            "type": "object"
+        },
+        "DockButtonApp": {
+            "additionalProperties": false,
+            "description": "A button which launches an app by it's or or a custom action.",
+            "properties": {
                 "appId": {
-                    "description": "Should this action launch a specific app (the icon and tooltip will be pulled from the app if possible)",
+                    "description": "Launch an app by it's id.",
                     "type": "string"
                 },
                 "conditions": {
@@ -1071,11 +1096,14 @@
                     "type": "string"
                 }
             },
+            "required": [
+                "appId"
+            ],
             "type": "object"
         },
-        "DockButtonApp": {
+        "DockButtonAppsByTag": {
             "additionalProperties": false,
-            "description": "A single app or a list of apps",
+            "description": "A single app or a list of apps that are defined by the tags in the app definitions.",
             "properties": {
                 "conditions": {
                     "description": "Condition to determine if the item should be shown.",
@@ -1131,7 +1159,14 @@
                 "options": {
                     "description": "List of button options",
                     "items": {
-                        "$ref": "#/definitions/Omit<DockButtonAction,\"iconUrl\">"
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/Omit_1"
+                            },
+                            {
+                                "$ref": "#/definitions/Omit_2"
+                            }
+                        ]
                     },
                     "type": "array"
                 },
@@ -1145,21 +1180,41 @@
             ],
             "type": "object"
         },
+        "DockButtonTypes": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/DockButtonAppsByTag"
+                },
+                {
+                    "$ref": "#/definitions/DockButtonApp"
+                },
+                {
+                    "$ref": "#/definitions/DockButtonAction"
+                },
+                {
+                    "$ref": "#/definitions/DockButtonDropdown"
+                }
+            ],
+            "description": "All of the button types for the dock."
+        },
         "DockProviderOptions": {
             "additionalProperties": false,
             "description": "Options for the dock provider.",
             "properties": {
                 "apps": {
-                    "description": "What apps should be made available via the dock",
+                    "description": "What apps should be made available via the dock, this property is deprecated, use entries.",
                     "items": {
-                        "$ref": "#/definitions/DockButtonApp"
+                        "$ref": "#/definitions/DockButtonAppsByTag"
                     },
                     "type": "array"
                 },
                 "buttons": {
-                    "description": "What custom actions should be made available via the dock",
+                    "description": "What custom actions should be made available via the dock, this property is deprecated, use entries.",
                     "items": {
                         "anyOf": [
+                            {
+                                "$ref": "#/definitions/DockButtonApp"
+                            },
                             {
                                 "$ref": "#/definitions/DockButtonAction"
                             },
@@ -1167,6 +1222,13 @@
                                 "$ref": "#/definitions/DockButtonDropdown"
                             }
                         ]
+                    },
+                    "type": "array"
+                },
+                "entries": {
+                    "description": "What apps, actions or drop downs should be made available via the dock.",
+                    "items": {
+                        "$ref": "#/definitions/DockButtonTypes"
                     },
                     "type": "array"
                 },
@@ -1244,7 +1306,7 @@
             "type": "object"
         },
         "ExternalProcessRequestType": {
-            "$ref": "#/definitions/__type_39"
+            "$ref": "#/definitions/__type_41"
         },
         "FavoriteProviderOptions": {
             "additionalProperties": false,
@@ -1506,7 +1568,7 @@
             "$ref": "#/definitions/__type_3"
         },
         "Identity_1": {
-            "$ref": "#/definitions/__type_30"
+            "$ref": "#/definitions/__type_32"
         },
         "Image": {
             "additionalProperties": false,
@@ -1676,7 +1738,7 @@
             "$ref": "#/definitions/__type_11"
         },
         "LaunchExternalProcessListener": {
-            "$ref": "#/definitions/__type_40"
+            "$ref": "#/definitions/__type_42"
         },
         "LayoutColumn": {
             "additionalProperties": false,
@@ -2740,10 +2802,10 @@
             "type": "object"
         },
         "MonitorDetails": {
-            "$ref": "#/definitions/__type_37"
+            "$ref": "#/definitions/__type_39"
         },
         "MonitorInfo": {
-            "$ref": "#/definitions/__type_33"
+            "$ref": "#/definitions/__type_35"
         },
         "NotificationProviderOptions": {
             "additionalProperties": false,
@@ -2802,43 +2864,11 @@
         "Omit": {
             "$ref": "#/definitions/__type_25"
         },
-        "Omit<DockButtonAction,\"iconUrl\">": {
-            "additionalProperties": false,
-            "properties": {
-                "action": {
-                    "additionalProperties": false,
-                    "description": "If an appId isn't provided then provide details related to the action",
-                    "properties": {
-                        "customData": {
-                            "description": "data that should be passed to the action"
-                        },
-                        "id": {
-                            "description": "The id of the action to fire",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "id"
-                    ],
-                    "type": "object"
-                },
-                "appId": {
-                    "description": "Should this action launch a specific app (the icon and tooltip will be pulled from the app if possible)",
-                    "type": "string"
-                },
-                "conditions": {
-                    "description": "Condition to determine if the item should be shown.",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "tooltip": {
-                    "description": "The tooltip to be shown for this button/entry",
-                    "type": "string"
-                }
-            },
-            "type": "object"
+        "Omit_1": {
+            "$ref": "#/definitions/__type_29"
+        },
+        "Omit_2": {
+            "$ref": "#/definitions/__type_30"
         },
         "Page": {
             "additionalProperties": false,
@@ -3411,7 +3441,7 @@
             "type": "object"
         },
         "Point": {
-            "$ref": "#/definitions/__type_34"
+            "$ref": "#/definitions/__type_36"
         },
         "PreDefinedButtonConfig": {
             "additionalProperties": false,
@@ -3464,7 +3494,7 @@
             "$ref": "#/definitions/__type_6"
         },
         "RectangleByEdgePositions": {
-            "$ref": "#/definitions/__type_36"
+            "$ref": "#/definitions/__type_38"
         },
         "ResizeRegion": {
             "$ref": "#/definitions/__type_10"
@@ -3502,7 +3532,7 @@
             "type": "object"
         },
         "Snapshot": {
-            "$ref": "#/definitions/__type_32"
+            "$ref": "#/definitions/__type_34"
         },
         "SnapshotSourceConnection": {
             "additionalProperties": false,
@@ -6207,6 +6237,85 @@
         "__type_29": {
             "additionalProperties": false,
             "properties": {
+                "appId": {
+                    "description": "Launch an app by it's id.",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Condition to determine if the item should be shown.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "tooltip": {
+                    "description": "The tooltip to be shown for this button/entry",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "appId"
+            ],
+            "type": "object"
+        },
+        "__type_3": {
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "description": "The name of the component",
+                    "type": "string"
+                },
+                "uuid": {
+                    "description": "Universally unique identifier of the compenent",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "uuid"
+            ],
+            "type": "object"
+        },
+        "__type_30": {
+            "additionalProperties": false,
+            "properties": {
+                "action": {
+                    "additionalProperties": false,
+                    "description": "Launch an action.",
+                    "properties": {
+                        "customData": {
+                            "description": "data that should be passed to the action"
+                        },
+                        "id": {
+                            "description": "The id of the action to fire",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "id"
+                    ],
+                    "type": "object"
+                },
+                "conditions": {
+                    "description": "Condition to determine if the item should be shown.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "tooltip": {
+                    "description": "The tooltip to be shown for this button/entry",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "action"
+            ],
+            "type": "object"
+        },
+        "__type_31": {
+            "additionalProperties": false,
+            "properties": {
                 "clientAPIVersion": {
                     "description": "version of client SDK,  set by the API",
                     "type": "string"
@@ -6262,51 +6371,33 @@
             },
             "type": "object"
         },
-        "__type_3": {
-            "additionalProperties": false,
-            "properties": {
-                "name": {
-                    "description": "The name of the component",
-                    "type": "string"
-                },
-                "uuid": {
-                    "description": "Universally unique identifier of the compenent",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "uuid"
-            ],
-            "type": "object"
-        },
-        "__type_30": {
-            "additionalProperties": false,
-            "properties": {
-                "name": {
-                    "description": "The name of the component",
-                    "type": "string"
-                },
-                "uuid": {
-                    "description": "Universally unique identifier of the compenent",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "__type_31": {
-            "additionalProperties": false,
-            "properties": {
-                "uuid": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "uuid"
-            ],
-            "type": "object"
-        },
         "__type_32": {
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "description": "The name of the component",
+                    "type": "string"
+                },
+                "uuid": {
+                    "description": "Universally unique identifier of the compenent",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "__type_33": {
+            "additionalProperties": false,
+            "properties": {
+                "uuid": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "uuid"
+            ],
+            "type": "object"
+        },
+        "__type_34": {
             "additionalProperties": false,
             "properties": {
                 "interopSnapshotDetails": {
@@ -6353,7 +6444,7 @@
             ],
             "type": "object"
         },
-        "__type_33": {
+        "__type_35": {
             "additionalProperties": false,
             "properties": {
                 "deviceScaleFactor": {
@@ -6450,7 +6541,7 @@
             ],
             "type": "object"
         },
-        "__type_34": {
+        "__type_36": {
             "additionalProperties": false,
             "properties": {
                 "x": {
@@ -6468,7 +6559,7 @@
             ],
             "type": "object"
         },
-        "__type_35": {
+        "__type_37": {
             "additionalProperties": false,
             "properties": {
                 "dipRect": {
@@ -6484,7 +6575,7 @@
             ],
             "type": "object"
         },
-        "__type_36": {
+        "__type_38": {
             "additionalProperties": false,
             "properties": {
                 "bottom": {
@@ -6508,7 +6599,7 @@
             ],
             "type": "object"
         },
-        "__type_37": {
+        "__type_39": {
             "additionalProperties": false,
             "properties": {
                 "available": {
@@ -6566,7 +6657,25 @@
             ],
             "type": "object"
         },
-        "__type_38": {
+        "__type_4": {
+            "additionalProperties": false,
+            "description": "Configures how new content (e,g, from `window.open` or a link) is opened.",
+            "properties": {
+                "rules": {
+                    "description": "List of rules for creation of new content.",
+                    "items": {
+                        "$ref": "#/definitions/ContentCreationRule<ContentCreationBehaviorNames>",
+                        "description": "A rule for creating content in OpenFin; maps a content type to the way in which\nnewly-opened content of that type will be handled."
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "rules"
+            ],
+            "type": "object"
+        },
+        "__type_40": {
             "additionalProperties": {
                 "additionalProperties": {
                     "additionalProperties": false,
@@ -6597,7 +6706,7 @@
             },
             "type": "object"
         },
-        "__type_39": {
+        "__type_41": {
             "additionalProperties": false,
             "properties": {
                 "alias": {
@@ -6634,29 +6743,11 @@
             },
             "type": "object"
         },
-        "__type_4": {
-            "additionalProperties": false,
-            "description": "Configures how new content (e,g, from `window.open` or a link) is opened.",
-            "properties": {
-                "rules": {
-                    "description": "List of rules for creation of new content.",
-                    "items": {
-                        "$ref": "#/definitions/ContentCreationRule<ContentCreationBehaviorNames>",
-                        "description": "A rule for creating content in OpenFin; maps a content type to the way in which\nnewly-opened content of that type will be handled."
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "rules"
-            ],
-            "type": "object"
-        },
-        "__type_40": {
+        "__type_42": {
             "additionalProperties": false,
             "type": "object"
         },
-        "__type_41": {
+        "__type_43": {
             "additionalProperties": false,
             "properties": {
                 "publickey": {
@@ -6677,7 +6768,7 @@
             },
             "type": "object"
         },
-        "__type_42": {
+        "__type_44": {
             "additionalProperties": false,
             "properties": {
                 "alias": {

--- a/how-to/workspace-platform-starter/public/schemas/settings.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/settings.schema.json
@@ -1124,6 +1124,10 @@
                     "description": "The icon to use to distinguish this entry from others",
                     "type": "string"
                 },
+                "noEntries": {
+                    "description": "Text to display if there are no entries because there are no tagged apps.",
+                    "type": "string"
+                },
                 "tags": {
                     "description": "The tags to use to find the single app or a collection of apps that need to be listed. This will be compared\nagainst the tags associated with apps returned from the app data sources.",
                     "items": {
@@ -1154,6 +1158,10 @@
                 },
                 "iconUrl": {
                     "description": "The icon to use to distinguish this entry from others",
+                    "type": "string"
+                },
+                "noEntries": {
+                    "description": "Text to display if there are no entries because conditions have excluded options.",
                     "type": "string"
                 },
                 "options": {


### PR DESCRIPTION
Rationalizes the dock button types, separates the `appId` and `action` types.
Deprecates `buttons` and `apps` properties of dockprovider and introduces `entries`, which can be any combination of the original types.