### PR TITLE
Don't show splash if preventQuitOnLastWindowClosed not set

### DIFF
--- a/how-to/workspace-platform-starter/client/src/framework/platform/platform-splash.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/platform/platform-splash.ts
@@ -12,7 +12,9 @@ export async function open(): Promise<void> {
 	const manifest = await app.getManifest();
 
 	if (manifest?.platform?.preventQuitOnLastWindowClosed !== true) {
-		console.warn("The manifest does not contain the platform.preventQuitOnLastWindowClosed flag set to true, the splash screen can not be shown without this flag set");
+		console.warn(
+			"The manifest does not contain the platform.preventQuitOnLastWindowClosed flag set to true, the splash screen can not be shown without this flag set"
+		);
 		return;
 	}
 

--- a/how-to/workspace-platform-starter/client/src/framework/platform/platform-splash.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/platform/platform-splash.ts
@@ -11,6 +11,11 @@ export async function open(): Promise<void> {
 	const app = await fin.Application.getCurrent();
 	const manifest = await app.getManifest();
 
+	if (manifest?.platform?.preventQuitOnLastWindowClosed !== true) {
+		console.warn("The manifest does not contain the platform.preventQuitOnLastWindowClosed flag set to true, the splash screen can not be shown without this flag set");
+		return;
+	}
+
 	const customSettings = await getManifestCustomSettings();
 
 	const disabled = customSettings?.splashScreenProvider?.disabled ?? false;


### PR DESCRIPTION
Without the preventQuitOnLastWindowClosed  flag in the manifest the splash screen closing would case the platform to exit.