### PR TITLE
Include the user info when firing logged in event

### DIFF
--- a/how-to/workspace-platform-starter/client/src/framework/bootstrapper.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/bootstrapper.ts
@@ -199,29 +199,19 @@ export async function init(): Promise<boolean> {
 		logger.info("Setting up listeners for authentication events");
 		// platform is instantiated and authentication if required is given. Watch for session
 		// expiry
-		authProvider.subscribe("logged-in", async () => {
+		authProvider.subscribe("logged-in", async (user: unknown) => {
 			// what behavior do you want to do when someone logs in
 			// potentially the inverse if you hid something on session expiration
 			await fireLifecycleEvent(platform, "auth-logged-in", {
-				user: await authProvider.getUserInfo()
+				user
 			} as LoggedInLifecyclePayload);
 		});
-
-		// If the user is already logged in then we must fire the lifecycle event immediately
-		const isAuthenticationRequired = await authProvider.isAuthenticationRequired();
-		if (!isAuthenticationRequired) {
-			// Fire the event on the next cycle to allow the bootstrapping process to complete
-			setTimeout(async () => {
-				await fireLifecycleEvent(platform, "auth-logged-in", {
-					user: await authProvider.getUserInfo()
-				} as LoggedInLifecyclePayload);
-			}, 0);
-		}
 
 		authProvider.subscribe("session-expired", async () => {
 			// session expired. What do you want to do with the platform when the user needs to log back in.
 			await fireLifecycleEvent(platform, "auth-session-expired");
 		});
+
 		authProvider.subscribe("before-logged-out", async () => {
 			// what behavior do you want to do when someone logs in
 			// do you want to save anything before they log themselves out

--- a/how-to/workspace-platform-starter/client/src/framework/bootstrapper.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/bootstrapper.ts
@@ -199,7 +199,7 @@ export async function init(): Promise<boolean> {
 		logger.info("Setting up listeners for authentication events");
 		// platform is instantiated and authentication if required is given. Watch for session
 		// expiry
-		authProvider.subscribe("logged-in", async (user: unknown) => {
+		authProvider.subscribe("logged-in", async (user?: unknown) => {
 			// what behavior do you want to do when someone logs in
 			// potentially the inverse if you hid something on session expiration
 			await fireLifecycleEvent(platform, "auth-logged-in", {

--- a/how-to/workspace-platform-starter/client/src/framework/lifecycle.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/lifecycle.ts
@@ -8,15 +8,19 @@ import type {
 	LifecycleProviderOptions
 } from "./shapes/lifecycle-shapes";
 import type { ModuleDefinition, ModuleEntry, ModuleHelpers } from "./shapes/module-shapes";
-import { randomUUID } from "./utils";
+import { isEmpty, randomUUID } from "./utils";
 
 let modules: ModuleEntry<Lifecycle, unknown, unknown, ModuleDefinition>[] = [];
 const logger = createLogger("Lifecycle");
 const allLifecycleEvents: {
 	[key in LifecycleEvents]?: {
-		id: string;
-		handler: LifecycleHandler;
-	}[];
+		subscribers: {
+			id: string;
+			handler: LifecycleHandler;
+		}[];
+		platform?: WorkspacePlatformModule;
+		lastPayload?: unknown;
+	};
 } = {};
 
 /**
@@ -59,10 +63,13 @@ export async function fireLifecycleEvent<T = unknown>(
 ): Promise<void> {
 	logger.info(`Request to fire lifecycle event ${lifecycleEvent} received`);
 	const eventHandlers = allLifecycleEvents[lifecycleEvent];
-	if (Array.isArray(eventHandlers)) {
-		const subscribers = [...eventHandlers];
-		logger.info(`Notifying ${subscribers.length} subscribers of lifecycle event ${lifecycleEvent}`);
-		for (const idHandler of subscribers) {
+	if (!isEmpty(eventHandlers)) {
+		eventHandlers.platform = platform;
+		eventHandlers.lastPayload = payload;
+		logger.info(
+			`Notifying ${eventHandlers.subscribers.length} subscribers of lifecycle event ${lifecycleEvent}`
+		);
+		for (const idHandler of eventHandlers.subscribers) {
 			logger.info(`Notifying subscriber ${idHandler.id} of event ${lifecycleEvent}`);
 			await idHandler.handler(platform, payload);
 		}
@@ -80,8 +87,15 @@ export function subscribeLifecycleEvent<T = unknown>(
 	lifecycleHandler: LifecycleHandler<T>
 ): string {
 	const subscriptionId = randomUUID();
-	const handlers = allLifecycleEvents[lifecycleEvent] ?? [];
-	handlers.push({
+	const handlers: {
+		subscribers: {
+			id: string;
+			handler: LifecycleHandler;
+		}[];
+		lastPayload?: unknown;
+		platform?: WorkspacePlatformModule;
+	} = allLifecycleEvents[lifecycleEvent] ?? { subscribers: [] };
+	handlers.subscribers.push({
 		id: subscriptionId,
 		handler: lifecycleHandler as LifecycleHandler
 	});
@@ -89,6 +103,17 @@ export function subscribeLifecycleEvent<T = unknown>(
 	logger.info(
 		`Subscription for lifecycle event ${lifecycleEvent} received. Subscription id: ${subscriptionId} returned`
 	);
+
+	// Call the lifecycle handler immediately on the next cycle with the last payload
+	// If the platform is set then fireLifecycleEvent has been called at least once
+	if (!isEmpty(handlers.platform)) {
+		setTimeout(async () => {
+			if (!isEmpty(handlers.platform) && !isEmpty(handlers.lastPayload)) {
+				await lifecycleHandler(handlers.platform, handlers.lastPayload as T);
+			}
+		}, 0);
+	}
+
 	return subscriptionId;
 }
 
@@ -99,11 +124,12 @@ export function subscribeLifecycleEvent<T = unknown>(
  */
 export function unsubscribeLifecycleEvent(subscriptionId: string, lifecycleEvent: LifecycleEvents): void {
 	logger.info(`Request to unsubscribe from lifecycle event ${lifecycleEvent} with id: ${subscriptionId}`);
-	const handlers = allLifecycleEvents[lifecycleEvent];
-	if (handlers) {
-		const idx = handlers.findIndex((l) => l.id === subscriptionId);
+	const eventHandlers = allLifecycleEvents[lifecycleEvent];
+	if (!isEmpty(eventHandlers)) {
+		const subscribers = eventHandlers.subscribers;
+		const idx = subscribers.findIndex((l) => l.id === subscriptionId);
 		if (idx >= 0) {
-			handlers.splice(idx, 1);
+			subscribers.splice(idx, 1);
 		}
 	}
 }

--- a/how-to/workspace-platform-starter/client/src/framework/lifecycle.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/lifecycle.ts
@@ -108,7 +108,7 @@ export function subscribeLifecycleEvent<T = unknown>(
 	// If the platform is set then fireLifecycleEvent has been called at least once
 	if (!isEmpty(handlers.platform)) {
 		setTimeout(async () => {
-			if (!isEmpty(handlers.platform) && !isEmpty(handlers.lastPayload)) {
+			if (!isEmpty(handlers.platform)) {
 				await lifecycleHandler(handlers.platform, handlers.lastPayload as T);
 			}
 		}, 0);

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/auth-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/auth-shapes.ts
@@ -4,7 +4,12 @@ import type { ModuleHelpers, ModuleImplementation, ModuleList } from "./module-s
  * Auth Provider Options. Specify a single auth module if your application requires authentication before allowing the
  * user to use the platform.
  */
-export type AuthProviderOptions = ModuleList;
+export interface AuthProviderOptions extends ModuleList {
+	/**
+	 * Include the user information when the logged in event is called
+	 */
+	includeLoggedInUserInfo?: boolean;
+}
 
 /**
  * Definition for module which provides authentication features.

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/lifecycle-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/lifecycle-shapes.ts
@@ -1,7 +1,8 @@
 import type { Workspace } from "@openfin/workspace";
-import type { Page, WorkspacePlatformModule } from "@openfin/workspace-platform";
+import type { CustomPaletteSet, Page, WorkspacePlatformModule } from "@openfin/workspace-platform";
 import type { FavoriteEntry } from "./favorite-shapes";
 import type { ModuleHelpers, ModuleImplementation, ModuleList } from "./module-shapes";
+import type { ColorSchemeMode } from "./theme-shapes";
 
 /**
  * Events that can be triggered through the lifecycle.
@@ -110,4 +111,19 @@ export interface LoggedInLifecyclePayload {
 	 * The user details.
 	 */
 	user?: unknown;
+}
+
+/**
+ * Theme changed in event payload.
+ */
+export interface ThemeChangedLifecyclePayload {
+	/**
+	 * The theme mode.
+	 */
+	schemeType?: ColorSchemeMode;
+
+	/**
+	 * The payload.
+	 */
+	payload?: CustomPaletteSet;
 }

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/lifecycle-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/lifecycle-shapes.ts
@@ -114,7 +114,7 @@ export interface LoggedInLifecyclePayload {
 }
 
 /**
- * Theme changed in event payload.
+ * Theme changed event payload.
  */
 export interface ThemeChangedLifecyclePayload {
 	/**

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/lifecycle-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/lifecycle-shapes.ts
@@ -101,3 +101,13 @@ export interface FavoriteChangedLifecyclePayload {
 	 */
 	favorite: FavoriteEntry;
 }
+
+/**
+ * Logged in event payload.
+ */
+export interface LoggedInLifecyclePayload {
+	/**
+	 * The user details.
+	 */
+	user: unknown;
+}

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/lifecycle-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/lifecycle-shapes.ts
@@ -109,5 +109,5 @@ export interface LoggedInLifecyclePayload {
 	/**
 	 * The user details.
 	 */
-	user: unknown;
+	user?: unknown;
 }

--- a/how-to/workspace-platform-starter/client/src/framework/themes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/themes.ts
@@ -1,10 +1,11 @@
 import type OpenFin from "@openfin/core";
-import { ColorSchemeOptionType, getCurrentSync } from "@openfin/workspace-platform";
 import type { CustomPaletteSet } from "@openfin/workspace-platform";
+import { ColorSchemeOptionType, getCurrentSync } from "@openfin/workspace-platform";
 import { DEFAULT_PALETTES } from "./default-palettes";
 import { fireLifecycleEvent } from "./lifecycle";
 import { createLogger } from "./logger-provider";
 import { getSettings } from "./settings";
+import type { ThemeChangedLifecyclePayload } from "./shapes/lifecycle-shapes";
 import { ColorSchemeMode, type PlatformCustomTheme, type PlatformCustomThemes } from "./shapes/theme-shapes";
 import { isEmpty, isStringValue } from "./utils";
 
@@ -149,7 +150,13 @@ export async function notifyColorScheme(): Promise<void> {
 	const platform = getCurrentSync();
 	const settings = await getSettings();
 
-	await fireLifecycleEvent(platform, "theme-changed");
+	const schemeType = await getCurrentColorSchemeMode();
+	const palette = await getCurrentPalette();
+
+	await fireLifecycleEvent(platform, "theme-changed", {
+		schemeType,
+		palette
+	} as ThemeChangedLifecyclePayload);
 
 	const appSessionContextGroup = await fin.me.interop.joinSessionContextGroup("platform/events");
 
@@ -157,8 +164,8 @@ export async function notifyColorScheme(): Promise<void> {
 		type: "platform.theme",
 		prefix: settings?.themeProvider?.cssVarPrefix,
 		schemeNames: settings?.themeProvider?.schemaNames,
-		schemeType: await getCurrentColorSchemeMode(),
-		palette: await getCurrentPalette()
+		schemeType,
+		palette
 	} as OpenFin.Context);
 }
 

--- a/how-to/workspace-platform-starter/client/types/module/shapes/auth-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/auth-shapes.d.ts
@@ -5,7 +5,7 @@ import type { ModuleHelpers, ModuleImplementation, ModuleList } from "./module-s
  */
 export interface AuthProviderOptions extends ModuleList {
 	/**
-	 * Include the user information when the logged in event is called, defaults to true
+	 * Include the user information when the logged in event is called
 	 */
 	includeLoggedInUserInfo?: boolean;
 }

--- a/how-to/workspace-platform-starter/client/types/module/shapes/auth-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/auth-shapes.d.ts
@@ -3,7 +3,12 @@ import type { ModuleHelpers, ModuleImplementation, ModuleList } from "./module-s
  * Auth Provider Options. Specify a single auth module if your application requires authentication before allowing the
  * user to use the platform.
  */
-export type AuthProviderOptions = ModuleList;
+export interface AuthProviderOptions extends ModuleList {
+	/**
+	 * Include the user information when the logged in event is called, defaults to true
+	 */
+	includeLoggedInUserInfo?: boolean;
+}
 /**
  * Definition for module which provides authentication features.
  */

--- a/how-to/workspace-platform-starter/client/types/module/shapes/lifecycle-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/lifecycle-shapes.d.ts
@@ -1,7 +1,8 @@
 import type { Workspace } from "@openfin/workspace";
-import type { Page, WorkspacePlatformModule } from "@openfin/workspace-platform";
+import type { CustomPaletteSet, Page, WorkspacePlatformModule } from "@openfin/workspace-platform";
 import type { FavoriteEntry } from "./favorite-shapes";
 import type { ModuleHelpers, ModuleImplementation, ModuleList } from "./module-shapes";
+import type { ColorSchemeMode } from "./theme-shapes";
 /**
  * Events that can be triggered through the lifecycle.
  */
@@ -96,4 +97,17 @@ export interface LoggedInLifecyclePayload {
 	 * The user details.
 	 */
 	user?: unknown;
+}
+/**
+ * Theme changed in event payload.
+ */
+export interface ThemeChangedLifecyclePayload {
+	/**
+	 * The theme mode.
+	 */
+	schemeType?: ColorSchemeMode;
+	/**
+	 * The payload.
+	 */
+	payload?: CustomPaletteSet;
 }

--- a/how-to/workspace-platform-starter/client/types/module/shapes/lifecycle-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/lifecycle-shapes.d.ts
@@ -95,5 +95,5 @@ export interface LoggedInLifecyclePayload {
 	/**
 	 * The user details.
 	 */
-	user: unknown;
+	user?: unknown;
 }

--- a/how-to/workspace-platform-starter/client/types/module/shapes/lifecycle-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/lifecycle-shapes.d.ts
@@ -88,3 +88,12 @@ export interface FavoriteChangedLifecyclePayload {
 	 */
 	favorite: FavoriteEntry;
 }
+/**
+ * Logged in event payload.
+ */
+export interface LoggedInLifecyclePayload {
+	/**
+	 * The user details.
+	 */
+	user: unknown;
+}

--- a/how-to/workspace-platform-starter/client/types/module/shapes/lifecycle-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/lifecycle-shapes.d.ts
@@ -99,7 +99,7 @@ export interface LoggedInLifecyclePayload {
 	user?: unknown;
 }
 /**
- * Theme changed in event payload.
+ * Theme changed event payload.
  */
 export interface ThemeChangedLifecyclePayload {
 	/**

--- a/how-to/workspace-platform-starter/public/schemas/settings.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/settings.schema.json
@@ -25,7 +25,7 @@
             "type": "object"
         },
         "ActionsProviderOptions": {
-            "$ref": "#/definitions/ModuleList_3",
+            "$ref": "#/definitions/ModuleList_2",
             "description": "List of modules."
         },
         "AnalyticsProviderOptions": {
@@ -334,8 +334,22 @@
             "type": "array"
         },
         "AuthProviderOptions": {
-            "$ref": "#/definitions/ModuleList",
-            "description": "List of modules."
+            "additionalProperties": false,
+            "description": "Auth Provider Options. Specify a single auth module if your application requires authentication before allowing the\nuser to use the platform.",
+            "properties": {
+                "includeLoggedInUserInfo": {
+                    "description": "Include the user information when the logged in event is called",
+                    "type": "boolean"
+                },
+                "modules": {
+                    "description": "The list of modules.",
+                    "items": {
+                        "$ref": "#/definitions/ModuleDefinition<unknown>"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
         },
         "AutoResizeOptions": {
             "$ref": "#/definitions/__type_24"
@@ -575,7 +589,7 @@
             "type": "string"
         },
         "ConditionsProviderOptions": {
-            "$ref": "#/definitions/ModuleList_4",
+            "$ref": "#/definitions/ModuleList_3",
             "description": "List of modules."
         },
         "Connection": {
@@ -1601,7 +1615,7 @@
             "type": "object"
         },
         "InitOptionsProviderOptions": {
-            "$ref": "#/definitions/ModuleList_1",
+            "$ref": "#/definitions/ModuleList",
             "description": "List of modules."
         },
         "IntegrationModuleDefinition<unknown>": {
@@ -1891,14 +1905,14 @@
             "type": "object"
         },
         "LifecycleProviderOptions": {
-            "$ref": "#/definitions/ModuleList_5",
+            "$ref": "#/definitions/ModuleList_4",
             "description": "List of modules."
         },
         "LockUnlockPageConfig": {
             "$ref": "#/definitions/__type_27"
         },
         "LoggerProviderOptions": {
-            "$ref": "#/definitions/ModuleList_2",
+            "$ref": "#/definitions/ModuleList_1",
             "description": "List of modules."
         },
         "LowCodeIntegrationDefinition": {
@@ -2727,7 +2741,7 @@
         },
         "ModuleList": {
             "additionalProperties": false,
-            "description": "Auth Provider Options. Specify a single auth module if your application requires authentication before allowing the\nuser to use the platform.",
+            "description": "InitOptions Provider Options. This is a list of modules that will be loaded and used to handle init params (similar\nto query strings). The module data setting needs to specify \"supportedActions\" and this should be an array of strings\nof the actions this module supports. The init params used must specify action (which would map onto the action\nsupported) by your module and optionally payload if your module supports being passed a payload (this should be a\nbase64 encoded object when passed via init params).",
             "properties": {
                 "modules": {
                     "description": "The list of modules.",
@@ -2741,7 +2755,7 @@
         },
         "ModuleList_1": {
             "additionalProperties": false,
-            "description": "InitOptions Provider Options. This is a list of modules that will be loaded and used to handle init params (similar\nto query strings). The module data setting needs to specify \"supportedActions\" and this should be an array of strings\nof the actions this module supports. The init params used must specify action (which would map onto the action\nsupported) by your module and optionally payload if your module supports being passed a payload (this should be a\nbase64 encoded object when passed via init params).",
+            "description": "Logger Provider Options - A list of modules that will act as loggers that can receive logging information sent by the\nplatform",
             "properties": {
                 "modules": {
                     "description": "The list of modules.",
@@ -2755,7 +2769,7 @@
         },
         "ModuleList_2": {
             "additionalProperties": false,
-            "description": "Logger Provider Options - A list of modules that will act as loggers that can receive logging information sent by the\nplatform",
+            "description": "A list of modules that provide actions that can be used by the platform.",
             "properties": {
                 "modules": {
                     "description": "The list of modules.",
@@ -2769,20 +2783,6 @@
         },
         "ModuleList_3": {
             "additionalProperties": false,
-            "description": "A list of modules that provide actions that can be used by the platform.",
-            "properties": {
-                "modules": {
-                    "description": "The list of modules.",
-                    "items": {
-                        "$ref": "#/definitions/ModuleDefinition<unknown>"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "ModuleList_4": {
-            "additionalProperties": false,
             "description": "A list of modules that provide a set of conditions. The function for this condition will return true or false to\nindicate if the condition is met. Conditions are used in a number of places (for example menu options)",
             "properties": {
                 "modules": {
@@ -2795,7 +2795,7 @@
             },
             "type": "object"
         },
-        "ModuleList_5": {
+        "ModuleList_4": {
             "additionalProperties": false,
             "description": "This is a list of modules that allow you to hook into the lifecycle events exposed by the platform. A good example\nmight be you wish to register a module that is called when an authenticated session is expired",
             "properties": {


### PR DESCRIPTION
At the moment if a subscription the the `auth-logged-in` lifecycle event is made, but the auth process has already completed, you are never notified about the login happening.

This also adds the logged in user in the payload for the `auth-logged-in` event so that there is no need to access the auth provider from elsewhere.