### PR TITLE
Clone subscribers during firing to avoid skipping

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -33,7 +33,7 @@
 - Added conditions now support passing `callerType`and `context`
 - Added `include-in-snapshot` composite module which has both actions and conditions to display browser toolbar buttons which can control if a window is included in a snapshot, disabled by default
 - FUTURE BREAKING CHANGE `apps` and `buttons` in the dock config have been deprecated and replaced with `entries` which can contain the combined data from the old properties, the old properties will be read for now.
-- Change Auth `logged-in` event and lifecycle `auth-logged-in` events now contain the logged in user, if you don't want this to be passed set `authProvider.includeLoggedInUserInfo` to false
+- Change Auth `logged-in` and lifecycle `auth-logged-in` events are now passed the logged in user, if you don't want this to be passed set `authProvider.includeLoggedInUserInfo` to false
 - Change Lifecycle events can now be lazy subscribed so a late subscriber will get called with the last payload
 - Change Auth `logged-in` events can now be lazy subscribed so a late subscriber when you are already logged in will still receive the current user
 - Change Splash screen will now not show if `platform.preventQuitOnLastWindowClosed` is not set as closing the splash screen will exit the platform, a warning will be logged in this scenario

--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -33,6 +33,10 @@
 - Added conditions now support passing `callerType`and `context`
 - Added `include-in-snapshot` composite module which has both actions and conditions to display browser toolbar buttons which can control if a window is included in a snapshot, disabled by default
 - FUTURE BREAKING CHANGE `apps` and `buttons` in the dock config have been deprecated and replaced with `entries` which can contain the combined data from the old properties, the old properties will be read for now.
+- Change Auth `logged-in` event and lifecycle `auth-logged-in` events now contain the logged in user, if you don't want this to be passed set `authProvider.includeLoggedInUserInfo` to false
+- Change Lifecycle events can now be lazy subscribed so a late subscriber will get called with the last payload
+- Change Auth `logged-in` events can now be lazy subscribed so a late subscriber when you are already logged in will still receive the current user
+- Change Splash screen will now not show if `platform.preventQuitOnLastWindowClosed` is not set as the closing the splash screen will exit the platform, a warning will be logged in this scenario
 
 ## v13.1
 

--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Change Auth `logged-in` event and lifecycle `auth-logged-in` events now contain the logged in user, if you don't want this to be passed set `authProvider.includeLoggedInUserInfo` to false
 - Change Lifecycle events can now be lazy subscribed so a late subscriber will get called with the last payload
 - Change Auth `logged-in` events can now be lazy subscribed so a late subscriber when you are already logged in will still receive the current user
-- Change Splash screen will now not show if `platform.preventQuitOnLastWindowClosed` is not set as the closing the splash screen will exit the platform, a warning will be logged in this scenario
+- Change Splash screen will now not show if `platform.preventQuitOnLastWindowClosed` is not set as closing the splash screen will exit the platform, a warning will be logged in this scenario
 
 ## v13.1
 

--- a/how-to/workspace-platform-starter/client/src/framework/lifecycle.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/lifecycle.ts
@@ -69,7 +69,10 @@ export async function fireLifecycleEvent<T = unknown>(
 		logger.info(
 			`Notifying ${eventHandlers.subscribers.length} subscribers of lifecycle event ${lifecycleEvent}`
 		);
-		for (const idHandler of eventHandlers.subscribers) {
+		// Clone the subscribers, otherwise if calling the handler performs an unsubscribe
+		// the loop gets out of sync and items can be missed
+		const subscribers = [...eventHandlers.subscribers];
+		for (const idHandler of subscribers) {
 			logger.info(`Notifying subscriber ${idHandler.id} of event ${lifecycleEvent}`);
 			await idHandler.handler(platform, payload);
 		}


### PR DESCRIPTION
If during the firing of event handlers one of them unsubscribes this causes the iterator to get out of sync, so clone the array before firing the handlers.