### PR TITLE
Fix duplicate entries in dock

### DIFF
--- a/how-to/workspace-platform-starter/client/src/framework/workspace/dock.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/workspace/dock.ts
@@ -132,7 +132,7 @@ async function buildButtons(): Promise<DockButton[]> {
 		const colorSchemeMode = await getCurrentColorSchemeMode();
 		const platform = getCurrentSync();
 
-		const entries = dockProviderOptions.entries ?? [];
+		const entries = Array.isArray(dockProviderOptions.entries) ? [...dockProviderOptions.entries] : [];
 		if (Array.isArray(dockProviderOptions.apps)) {
 			entries.push(...dockProviderOptions.apps);
 		}


### PR DESCRIPTION
The dock entries from the config were not copied, so if an update to the dock happened the array got added back to itself, continually expanding.