### PR TITLE
Add dock endpoints for config and enable rearrange

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -20,6 +20,9 @@
 - Added Native popup menus to support separators, icons
 - Added Custom popup menus to support separators, disabled, aria labelling and off-screen positioning
 - BREAKING CHANGE The theming methods in module helpers have been encapsulated inside a class returned by the `getThemeClient` method, the old methods will still exist until the next release, but will log a warning about their removal
+- Added Dock re-ordering is now enabled by default (it can be disabled by setting `dockProvider.disableUserRearrangement` to true)
+- Added Dock provider entries now require an `id` field so that they can be identified when re-ordering is enabled
+- Added Dock supports endpoints for storage of their config `dock-get` and `dock-set`, if you provide your own endpoints you must handle the adding/removing/ordering of buttons based on the available buttons
 
 ## v14
 

--- a/how-to/workspace-platform-starter/client/src/framework/platform/platform-override.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/platform/platform-override.ts
@@ -14,6 +14,7 @@ import {
 	type Workspace,
 	type WorkspacePlatformProvider
 } from "@openfin/workspace-platform";
+import type { DockProviderConfigWithIdentity } from "@openfin/workspace-platform/client-api/src";
 import * as analyticsProvider from "../analytics";
 import { getToolbarButtons, updateBrowserWindowButtonsColorScheme } from "../buttons";
 import * as endpointProvider from "../endpoint";
@@ -46,6 +47,7 @@ import type { VersionInfo } from "../shapes/version-shapes";
 import { applyClientSnapshot, decorateSnapshot } from "../snapshot-source";
 import { setCurrentColorSchemeMode } from "../themes";
 import { isEmpty } from "../utils";
+import { loadConfig, saveConfig } from "../workspace/dock";
 import { getAllVisibleWindows, getPageBounds } from "./browser";
 import { closedown as closedownPlatform } from "./platform";
 import { mapPlatformPageToStorage, mapPlatformWorkspaceToStorage } from "./platform-mapper";
@@ -763,6 +765,24 @@ export function overrideCallback(
 			}
 
 			return super.handleAnalytics(events);
+		}
+
+		/**
+		 * Implementation for getting the dock provider from persistent storage.
+		 * @param id The id of the dock provider to get.
+		 * @returns The loaded dock provider config.
+		 */
+		public async getDockProviderConfig(id: string): Promise<DockProviderConfigWithIdentity | undefined> {
+			return loadConfig(id, async (providerId) => super.getDockProviderConfig(providerId));
+		}
+
+		/**
+		 * Implementation for saving a dock provider config to persistent storage.
+		 * @param config The new dock config to save to persistent storage.
+		 * @returns Nothing.
+		 */
+		public async saveDockProviderConfig(config: DockProviderConfigWithIdentity): Promise<void> {
+			return saveConfig(config, async (providerConfig) => super.saveDockProviderConfig(providerConfig));
 		}
 	}
 	return new Override();

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/dock-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/dock-shapes.ts
@@ -28,6 +28,11 @@ export interface DockProviderOptions {
 	};
 
 	/**
+	 * Disallow rearrangement of dock icons by setting this flag.
+	 */
+	disableUserRearrangement?: boolean;
+
+	/**
 	 * What apps, actions or drop downs should be made available via the dock.
 	 */
 	entries?: DockButtonTypes[];
@@ -49,6 +54,11 @@ export interface DockProviderOptions {
  * Shared properties for dock buttons.
  */
 export interface DockButtonBase {
+	/**
+	 * The id for the dock entry.
+	 */
+	id: string;
+
 	/**
 	 * The tooltip to be shown for this button/entry
 	 */
@@ -122,7 +132,7 @@ export interface DockButtonDropdown extends DockButtonBase {
 	/**
 	 * List of button options
 	 */
-	options: (Omit<DockButtonApp, "iconUrl"> | Omit<DockButtonAction, "iconUrl">)[];
+	options: (Omit<DockButtonApp, "iconUrl" | "id"> | Omit<DockButtonAction, "iconUrl" | "id">)[];
 
 	/**
 	 * Text to display if there are no entries because conditions have excluded options.

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/platform-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/platform-shapes.ts
@@ -1,4 +1,6 @@
+import type { DockButton } from "@openfin/workspace";
 import type { Page, Workspace } from "@openfin/workspace-platform";
+import type { DockProviderConfigWithIdentity } from "@openfin/workspace-platform/client-api/src";
 import type { IntentResolverOptions, PlatformInteropBrokerOptions } from "./interopbroker-shapes";
 
 /**
@@ -233,4 +235,48 @@ export interface EndpointPageRemoveRequest {
 	 * The id of the page to remove.
 	 */
 	id: string;
+}
+
+/**
+ * A request type for the DockEndpoint that gets the config for an entry
+ */
+export interface EndpointDockGetRequest {
+	/**
+	 * The id of the platform making the request
+	 */
+	platform: string;
+	/**
+	 * The id of the config to get.
+	 */
+	id: string;
+
+	/**
+	 * The buttons that are available based on current configuration.
+	 */
+	availableButtons: DockButton[];
+}
+
+/**
+ * A response type for the DockEndpoint that gets the config for an entry
+ */
+export interface EndpointDockGetResponse {
+	/**
+	 * The config.
+	 */
+	config?: DockProviderConfigWithIdentity;
+}
+
+/**
+ * A request type for the DockEndpoint that sets the config for an entry
+ */
+export interface EndpointDockSetRequest {
+	/**
+	 * The id of the platform making the request
+	 */
+	platform: string;
+
+	/**
+	 * The config.
+	 */
+	config?: DockProviderConfigWithIdentity;
 }

--- a/how-to/workspace-platform-starter/client/types/module/shapes/dock-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/dock-shapes.d.ts
@@ -24,6 +24,10 @@ export interface DockProviderOptions {
 		hideStorefrontButton?: boolean;
 	};
 	/**
+	 * Disallow rearrangement of dock icons by setting this flag.
+	 */
+	disableUserRearrangement?: boolean;
+	/**
 	 * What apps, actions or drop downs should be made available via the dock.
 	 */
 	entries?: DockButtonTypes[];
@@ -42,6 +46,10 @@ export interface DockProviderOptions {
  * Shared properties for dock buttons.
  */
 export interface DockButtonBase {
+	/**
+	 * The id for the dock entry.
+	 */
+	id: string;
 	/**
 	 * The tooltip to be shown for this button/entry
 	 */
@@ -107,7 +115,7 @@ export interface DockButtonDropdown extends DockButtonBase {
 	/**
 	 * List of button options
 	 */
-	options: (Omit<DockButtonApp, "iconUrl"> | Omit<DockButtonAction, "iconUrl">)[];
+	options: (Omit<DockButtonApp, "iconUrl" | "id"> | Omit<DockButtonAction, "iconUrl" | "id">)[];
 	/**
 	 * Text to display if there are no entries because conditions have excluded options.
 	 */

--- a/how-to/workspace-platform-starter/client/types/module/shapes/platform-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/platform-shapes.d.ts
@@ -1,4 +1,6 @@
+import type { DockButton } from "@openfin/workspace";
 import type { Page, Workspace } from "@openfin/workspace-platform";
+import type { DockProviderConfigWithIdentity } from "@openfin/workspace-platform/client-api/src";
 import type { IntentResolverOptions, PlatformInteropBrokerOptions } from "./interopbroker-shapes";
 /**
  * Platform provider options.
@@ -214,4 +216,43 @@ export interface EndpointPageRemoveRequest {
 	 * The id of the page to remove.
 	 */
 	id: string;
+}
+/**
+ * A request type for the DockEndpoint that gets the config for an entry
+ */
+export interface EndpointDockGetRequest {
+	/**
+	 * The id of the platform making the request
+	 */
+	platform: string;
+	/**
+	 * The id of the config to get.
+	 */
+	id: string;
+	/**
+	 * The buttons that are available based on current configuration.
+	 */
+	availableButtons: DockButton[];
+}
+/**
+ * A response type for the DockEndpoint that gets the config for an entry
+ */
+export interface EndpointDockGetResponse {
+	/**
+	 * The config.
+	 */
+	config?: DockProviderConfigWithIdentity;
+}
+/**
+ * A request type for the DockEndpoint that sets the config for an entry
+ */
+export interface EndpointDockSetRequest {
+	/**
+	 * The id of the platform making the request
+	 */
+	platform: string;
+	/**
+	 * The config.
+	 */
+	config?: DockProviderConfigWithIdentity;
 }

--- a/how-to/workspace-platform-starter/public/manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/manifest.fin.json
@@ -802,25 +802,27 @@
 				"hideNotificationsButton": false,
 				"hideStorefrontButton": false
 			},
-			"apps": [
+			"entries": [
 				{
+					"id": "dock-apps",
 					"display": "individual",
 					"tags": ["dock"]
 				},
 				{
+					"id": "fdc3-apps",
 					"display": "group",
 					"tooltip": "FDC3",
 					"tags": ["fdc3"]
 				},
 				{
+					"id": "manager-apps",
 					"display": "group",
 					"tooltip": "Manager",
 					"iconUrl": "http://localhost:8080/common/images/icon-gradient.png",
 					"tags": ["manager"]
-				}
-			],
-			"buttons": [
+				},
 				{
+					"id": "favorites",
 					"tooltip": "Favorites",
 					"iconUrl": "http://localhost:8080/icons/{scheme}/favorite.svg",
 					"action": {
@@ -829,6 +831,7 @@
 					"conditions": ["favorites"]
 				},
 				{
+					"id": "pages",
 					"tooltip": "Pages",
 					"iconUrl": "http://localhost:8080/icons/{scheme}/page.svg",
 					"action": {
@@ -836,6 +839,7 @@
 					}
 				},
 				{
+					"id": "google",
 					"tooltip": "Google",
 					"iconUrl": "https://www.google.com/favicon.ico",
 					"action": {
@@ -846,6 +850,7 @@
 					}
 				},
 				{
+					"id": "social",
 					"tooltip": "Social",
 					"iconUrl": "http://localhost:8080/common/icons/{theme}/{scheme}/share.svg",
 					"options": [
@@ -870,6 +875,7 @@
 					]
 				},
 				{
+					"id": "windows",
 					"tooltip": "Window Visibility",
 					"iconUrl": "http://localhost:8080/common/icons/{theme}/{scheme}/windows.svg",
 					"options": [

--- a/how-to/workspace-platform-starter/public/schemas/settings.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/settings.schema.json
@@ -1135,13 +1135,18 @@
                     "description": "The icon to use to distinguish this entry from others",
                     "type": "string"
                 },
+                "id": {
+                    "description": "The id for the dock entry.",
+                    "type": "string"
+                },
                 "tooltip": {
                     "description": "The tooltip to be shown for this button/entry",
                     "type": "string"
                 }
             },
             "required": [
-                "action"
+                "action",
+                "id"
             ],
             "type": "object"
         },
@@ -1164,13 +1169,18 @@
                     "description": "The icon to use to distinguish this entry from others",
                     "type": "string"
                 },
+                "id": {
+                    "description": "The id for the dock entry.",
+                    "type": "string"
+                },
                 "tooltip": {
                     "description": "The tooltip to be shown for this button/entry",
                     "type": "string"
                 }
             },
             "required": [
-                "appId"
+                "appId",
+                "id"
             ],
             "type": "object"
         },
@@ -1197,6 +1207,10 @@
                     "description": "The icon to use to distinguish this entry from others",
                     "type": "string"
                 },
+                "id": {
+                    "description": "The id for the dock entry.",
+                    "type": "string"
+                },
                 "noEntries": {
                     "description": "Text to display if there are no entries because there are no tagged apps.",
                     "type": "string"
@@ -1214,7 +1228,8 @@
                 }
             },
             "required": [
-                "display"
+                "display",
+                "id"
             ],
             "type": "object"
         },
@@ -1231,6 +1246,10 @@
                 },
                 "iconUrl": {
                     "description": "The icon to use to distinguish this entry from others",
+                    "type": "string"
+                },
+                "id": {
+                    "description": "The id for the dock entry.",
                     "type": "string"
                 },
                 "noEntries": {
@@ -1257,6 +1276,7 @@
                 }
             },
             "required": [
+                "id",
                 "options"
             ],
             "type": "object"
@@ -1305,6 +1325,10 @@
                         ]
                     },
                     "type": "array"
+                },
+                "disableUserRearrangement": {
+                    "description": "Disallow rearrangement of dock icons by setting this flag.",
+                    "type": "boolean"
                 },
                 "entries": {
                     "description": "What apps, actions or drop downs should be made available via the dock.",

--- a/how-to/workspace-platform-starter/public/settings.json
+++ b/how-to/workspace-platform-starter/public/settings.json
@@ -780,25 +780,27 @@
 			"hideNotificationsButton": false,
 			"hideStorefrontButton": false
 		},
-		"apps": [
+		"entries": [
 			{
+				"id": "dock-apps",
 				"display": "individual",
 				"tags": ["dock"]
 			},
 			{
+				"id": "fdc3-apps",
 				"display": "group",
 				"tooltip": "FDC3",
 				"tags": ["fdc3"]
 			},
 			{
+				"id": "manager-apps",
 				"display": "group",
 				"tooltip": "Manager",
 				"iconUrl": "http://localhost:8080/common/images/icon-gradient.png",
 				"tags": ["manager"]
-			}
-		],
-		"buttons": [
+			},
 			{
+				"id": "google",
 				"tooltip": "Google",
 				"iconUrl": "https://www.google.com/favicon.ico",
 				"action": {
@@ -809,6 +811,7 @@
 				}
 			},
 			{
+				"id": "social",
 				"tooltip": "Social",
 				"iconUrl": "http://localhost:8080/common/icons/{theme}/{scheme}/share.svg",
 				"options": [
@@ -833,6 +836,7 @@
 				]
 			},
 			{
+				"id": "windows",
 				"tooltip": "Window Visibility",
 				"iconUrl": "http://localhost:8080/common/icons/{theme}/{scheme}/windows.svg",
 				"options": [


### PR DESCRIPTION
- Add support for dock endpoints for loading/saving config.
- Re-ordering is now enabled by default, if using the inbuilt storage the sorting will be re-applied for you based on the available buttons. If configuring your own endpoints you must do the sorting yourself
- Dock entries have added id field used to identify them during sorting
