### PR TITLE
Override popup menus

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -13,12 +13,12 @@
 - Added favorites support for Workspaces
 - Added favorites support for Pages
 - Change Favorites icons are theme aware
-- Change Favorites menu has option `menuType` to switch between `native` and `custom`
+- Change Favorites menu has option `menuStyle` to switch between `native` and `custom`
 - Fixed Pages and Workspace not appearing in home results as soon as they are created
 - Fixed Apps template not updating text color on theme-changed
 - Added module helpers `launchWorkspace` method
-- Added Native popup menus to support separators, icons
-- Added Custom popup menus to support separators, disabled, aria labelling and off-screen positioning
+- Added Native popup menus now support separators, icons
+- Added Custom popup menus now support separators, disabled, submenu, checkbox, aria labelling and off-screen positioning
 - BREAKING CHANGE The theming methods in module helpers have been encapsulated inside a class returned by the `getThemeClient` method, the old methods will still exist until the next release, but will log a warning about their removal
 - Added Dock re-ordering is now enabled by default (it can be disabled by setting `dockProvider.disableUserRearrangement` to true)
 - Added Dock provider entries now require an `id` field so that they can be identified when re-ordering is enabled
@@ -27,6 +27,9 @@
 - Added ability to specify whether the launched view/window should be autoCentered when launched via the launchPreference setting that can be added to an app definition.
 - Added ability to specify a custom Platform API window should be used for a view/inline-view instead of the default browser window through the options setting of launchPreference which can be added to an app definition. The ability to support Platform API Windows and Browser windows was added to v15 of the @openfin/workspace-platform package.
 - Updated [how-to-define-apps.md](./docs/how-to-define-apps.md), [how-to-define-apps-fdc3-1-2.md](./docs/how-to-define-apps-fdc3-1-2.md) and [how-to-define-apps-fdc3-2-0.md](./docs/how-to-define-apps-fdc3-2-0.md) to reflect the new launchPreference option.
+- Change Platform override for `openGlobalContextMenu` can be configured to use the custom popup menus by setting `browserProvider.menuOptions.style.globalMenu` to `native` or `custom`
+- Change Platform override for `openViewTabContextMenu` can be configured to use the custom popup menus by setting `browserProvider.menuOptions.style.viewMenu` to `native` or `custom`
+- Change Platform override for `openPageTabContextMenu` can be configured to use the custom popup menus by setting `browserProvider.menuOptions.style.pageMenu` to `native` or `custom`
 
 ## v14
 

--- a/how-to/workspace-platform-starter/client/src/framework/platform/platform.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/platform/platform.ts
@@ -177,6 +177,7 @@ async function setupPlatform(manifestSettings: CustomSettings): Promise<boolean>
 			overrideCallback(
 				platformConstructor,
 				customSettings?.platformProvider,
+				customSettings?.browserProvider,
 				await versionProvider.getVersionInfo()
 			),
 		integrations,

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/browser-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/browser-shapes.ts
@@ -5,7 +5,7 @@ import type {
 	ToolbarButton,
 	ViewTabMenuOptionType
 } from "@openfin/workspace-platform";
-import type { MenuEntry } from "./menu-shapes";
+import type { MenuEntry, PopupMenuStyles } from "./menu-shapes";
 
 /**
  * Browser Provider Options includes the default window/page and view options.
@@ -85,6 +85,24 @@ export type BrowserProviderOptions = Pick<
 			 * Should we include all the default options for the view menu? Default is true.
 			 */
 			viewMenu?: boolean;
+		};
+
+		/**
+		 * Style the menus, if no options are provided it will use the build in version.
+		 */
+		styles?: {
+			/**
+			 * Override the style for the global menu (top left icon)
+			 */
+			globalMenu?: PopupMenuStyles;
+			/**
+			 * Override the style for the page menu (right click on page tab)
+			 */
+			pageMenu?: PopupMenuStyles;
+			/**
+			 * Override the style for the view menu (right click on view tab)
+			 */
+			viewMenu?: PopupMenuStyles;
 		};
 	};
 

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/menu-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/menu-shapes.ts
@@ -23,6 +23,12 @@ export interface MenusProviderOptions extends ModuleList {
 	popupHtml?: string;
 
 	/**
+	 * The font size used in the custom popup menu.
+	 * defaults to 12
+	 */
+	menuFontSize?: number;
+
+	/**
 	 * The width to display the custom popup menu.
 	 * defaults to 200
 	 */
@@ -204,31 +210,11 @@ export type MenuOptionType<T> = T extends GlobalContextMenuItemTemplate
 	: TrayMenuOptionType;
 
 /**
- * Entry for a popup menu.
+ * The styles that can be used to display the popup menus.
  */
-export interface PopupMenuEntry<T = unknown> {
-	/**
-	 * Type of the menu entry.
-	 */
-	type?: "normal" | "separator";
+export type PopupMenuStyles = "native" | "custom";
 
-	/**
-	 * Label to show in the menu.
-	 */
-	label?: string;
-
-	/**
-	 * Icon to show in the menu.
-	 */
-	icon?: string;
-
-	/**
-	 * Custom data to associate with the entry.
-	 */
-	customData?: T;
-
-	/**
-	 * Is the menu entry enabled.
-	 */
-	enabled?: boolean;
-}
+/**
+ * Specialized version of the menu item template with generic data.
+ */
+export type PopupMenuEntry<T = unknown> = Omit<OpenFin.MenuItemTemplate, "data"> & { data?: T };

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/module-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/module-shapes.ts
@@ -4,7 +4,7 @@ import type { PlatformApp } from "./app-shapes";
 import type { FavoriteClient } from "./favorite-shapes";
 import type { LifecycleEvents, LifecycleHandler } from "./lifecycle-shapes";
 import type { Logger, LoggerCreator } from "./logger-shapes";
-import type { PopupMenuEntry } from "./menu-shapes";
+import type { PopupMenuEntry, PopupMenuStyles } from "./menu-shapes";
 import type { NotificationClient } from "./notification-shapes";
 import type { ColorSchemeMode, ThemeClient } from "./theme-shapes";
 import type { VersionInfo } from "./version-shapes";
@@ -213,7 +213,7 @@ export interface ModuleHelpers {
 	 * @param noEntryText The text to display if there are no entries.
 	 * @param menuEntries The menu entries to display.
 	 * @param options The options for displaying the menu.
-	 * @param options.mode Display as native menu or custom popup.
+	 * @param options.style Display as native menu or custom popup.
 	 * @returns The menu entry.
 	 */
 	showPopupMenu?<T = unknown>(
@@ -222,7 +222,7 @@ export interface ModuleHelpers {
 		noEntryText: string,
 		menuEntries: PopupMenuEntry<T>[],
 		options?: {
-			mode?: "native" | "custom";
+			style?: PopupMenuStyles;
 		}
 	): Promise<T | undefined>;
 }

--- a/how-to/workspace-platform-starter/client/src/modules/actions/custom-menu/actions.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/actions/custom-menu/actions.ts
@@ -67,11 +67,11 @@ export class DynamicMenuProvider implements Actions {
 					pages
 						.map((p) => ({
 							label: p.title,
-							customData: p.pageId
+							data: p.pageId
 						}))
 						.sort((a, b) => a.label.localeCompare(b.label)),
 					{
-						mode: "custom"
+						style: "custom"
 					}
 				);
 

--- a/how-to/workspace-platform-starter/client/src/modules/actions/favorites-menu/actions.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/actions/favorites-menu/actions.ts
@@ -4,15 +4,15 @@ import {
 	type CustomActionsMap,
 	type WorkspacePlatformModule
 } from "@openfin/workspace-platform";
+import type { Actions } from "workspace-platform-starter/shapes/actions-shapes";
 import {
 	FAVORITE_TYPE_NAME_APP,
 	FAVORITE_TYPE_NAME_PAGE,
 	FAVORITE_TYPE_NAME_WORKSPACE,
-	type FavoriteEntry,
-	type PopupMenuEntry
-} from "workspace-platform-starter/shapes";
-import type { Actions } from "workspace-platform-starter/shapes/actions-shapes";
+	type FavoriteEntry
+} from "workspace-platform-starter/shapes/favorite-shapes";
 import type { Logger, LoggerCreator } from "workspace-platform-starter/shapes/logger-shapes";
+import type { PopupMenuEntry } from "workspace-platform-starter/shapes/menu-shapes";
 import type { ModuleDefinition, ModuleHelpers } from "workspace-platform-starter/shapes/module-shapes";
 import { isEmpty } from "workspace-platform-starter/utils";
 import type { FavoritesMenuSettings } from "./shapes";
@@ -90,7 +90,7 @@ export class FavoritesMenuProvider implements Actions<FavoritesMenuSettings> {
 										menuEntries.push({
 											label: entry.label ?? "",
 											icon: entry.icon,
-											customData: entry
+											data: entry
 										});
 									}
 									hadEntries = true;
@@ -98,15 +98,15 @@ export class FavoritesMenuProvider implements Actions<FavoritesMenuSettings> {
 							}
 						}
 
-						const menuType = this._settings?.menuType ?? "native";
+						const menuStyle = this._settings?.menuStyle ?? "native";
 
 						const result = await this._helpers.showPopupMenu<FavoriteEntry>(
-							menuType === "custom" ? { x: payload.x - 16, y: 40 } : { x: payload.x, y: 48 },
+							menuStyle === "custom" ? { x: payload.x - 16, y: 40 } : { x: payload.x, y: 48 },
 							payload.windowIdentity,
 							"There are no favorites",
 							menuEntries,
 							{
-								mode: menuType
+								style: menuStyle
 							}
 						);
 

--- a/how-to/workspace-platform-starter/client/src/modules/actions/favorites-menu/shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/actions/favorites-menu/shapes.ts
@@ -1,3 +1,5 @@
+import type { PopupMenuStyles } from "workspace-platform-starter/shapes/menu-shapes";
+
 /**
  * Settings for favorites menu integration.
  */
@@ -5,5 +7,5 @@ export interface FavoritesMenuSettings {
 	/**
 	 * The type of menu to display, defaults to native.
 	 */
-	menuType?: "native" | "custom";
+	menuStyle?: PopupMenuStyles;
 }

--- a/how-to/workspace-platform-starter/client/types/module/shapes/browser-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/browser-shapes.d.ts
@@ -5,7 +5,7 @@ import type {
 	ToolbarButton,
 	ViewTabMenuOptionType
 } from "@openfin/workspace-platform";
-import type { MenuEntry } from "./menu-shapes";
+import type { MenuEntry, PopupMenuStyles } from "./menu-shapes";
 /**
  * Browser Provider Options includes the default window/page and view options.
  */
@@ -77,6 +77,23 @@ export type BrowserProviderOptions = Pick<
 			 * Should we include all the default options for the view menu? Default is true.
 			 */
 			viewMenu?: boolean;
+		};
+		/**
+		 * Style the menus, if no options are provided it will use the build in version.
+		 */
+		styles?: {
+			/**
+			 * Override the style for the global menu (top left icon)
+			 */
+			globalMenu?: PopupMenuStyles;
+			/**
+			 * Override the style for the page menu (right click on page tab)
+			 */
+			pageMenu?: PopupMenuStyles;
+			/**
+			 * Override the style for the view menu (right click on view tab)
+			 */
+			viewMenu?: PopupMenuStyles;
 		};
 	};
 	/**

--- a/how-to/workspace-platform-starter/client/types/module/shapes/menu-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/menu-shapes.d.ts
@@ -21,6 +21,11 @@ export interface MenusProviderOptions extends ModuleList {
 	 */
 	popupHtml?: string;
 	/**
+	 * The font size used in the custom popup menu.
+	 * defaults to 12
+	 */
+	menuFontSize?: number;
+	/**
 	 * The width to display the custom popup menu.
 	 * defaults to 200
 	 */
@@ -179,27 +184,12 @@ export type MenuOptionType<T> = T extends GlobalContextMenuItemTemplate
 	? ViewTabMenuOptionType
 	: TrayMenuOptionType;
 /**
- * Entry for a popup menu.
+ * The styles that can be used to display the popup menus.
  */
-export interface PopupMenuEntry<T = unknown> {
-	/**
-	 * Type of the menu entry.
-	 */
-	type?: "normal" | "separator";
-	/**
-	 * Label to show in the menu.
-	 */
-	label?: string;
-	/**
-	 * Icon to show in the menu.
-	 */
-	icon?: string;
-	/**
-	 * Custom data to associate with the entry.
-	 */
-	customData?: T;
-	/**
-	 * Is the menu entry enabled.
-	 */
-	enabled?: boolean;
-}
+export type PopupMenuStyles = "native" | "custom";
+/**
+ * Specialized version of the menu item template with generic data.
+ */
+export type PopupMenuEntry<T = unknown> = Omit<OpenFin.MenuItemTemplate, "data"> & {
+	data?: T;
+};

--- a/how-to/workspace-platform-starter/client/types/module/shapes/module-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/module-shapes.d.ts
@@ -4,7 +4,7 @@ import type { PlatformApp } from "./app-shapes";
 import type { FavoriteClient } from "./favorite-shapes";
 import type { LifecycleEvents, LifecycleHandler } from "./lifecycle-shapes";
 import type { Logger, LoggerCreator } from "./logger-shapes";
-import type { PopupMenuEntry } from "./menu-shapes";
+import type { PopupMenuEntry, PopupMenuStyles } from "./menu-shapes";
 import type { NotificationClient } from "./notification-shapes";
 import type { ColorSchemeMode, ThemeClient } from "./theme-shapes";
 import type { VersionInfo } from "./version-shapes";
@@ -186,7 +186,7 @@ export interface ModuleHelpers {
 	 * @param noEntryText The text to display if there are no entries.
 	 * @param menuEntries The menu entries to display.
 	 * @param options The options for displaying the menu.
-	 * @param options.mode Display as native menu or custom popup.
+	 * @param options.style Display as native menu or custom popup.
 	 * @returns The menu entry.
 	 */
 	showPopupMenu?<T = unknown>(
@@ -198,7 +198,7 @@ export interface ModuleHelpers {
 		noEntryText: string,
 		menuEntries: PopupMenuEntry<T>[],
 		options?: {
-			mode?: "native" | "custom";
+			style?: PopupMenuStyles;
 		}
 	): Promise<T | undefined>;
 }

--- a/how-to/workspace-platform-starter/public/common/popups/menu/index.html
+++ b/how-to/workspace-platform-starter/public/common/popups/menu/index.html
@@ -5,27 +5,48 @@
 		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Menu</title>
-		<link rel="stylesheet" href="../../style/app.css" />
 		<script src="./menu.js"></script>
 		<style>
+			* {
+				font-family: Inter, 'Sans Serif', sans-serif;
+				box-sizing: border-box;
+			}
+			html,
 			body {
-				background-color: var(--background-primary);
-				margin: 0;
+				width: 100%;
+				height: 100%;
 				padding: 0;
+				margin: 0;
+				background-color: var(--theme-background-primary);
+				display: flex;
+				justify-content: stretch;
+				align-items: stretch;
+			}
+			#menuContainer {
+				border: 1px solid var(--theme-background6);
+				margin-right: 1px;
+				margin-bottom: 1px;
+				padding-top: 6px;
+				padding-bottom: 6px;
+				display: flex;
+				flex-direction: column;
+				flex: 1;
+				overflow: hidden;
 			}
 			.menu-item {
-				background-color: var(--background-primary);
-				color: var(--text-default);
+				background-color: var(--theme-background);
+				color: var(--theme-text-default);
 				font-weight: normal;
 				display: flex;
 				flex-direction: row;
 				gap: 10px;
+				text-align: left;
 				align-items: center;
-				justify-content: flex-start;
-				padding: 10px 10px;
+				justify-content: stretch;
+				padding: 0px 10px;
 				border: 0;
 				border-radius: 0;
-				height: 32px;
+				height: 24px;
 				font-size: 12px;
 				cursor: pointer;
 			}
@@ -34,34 +55,45 @@
 				white-space: nowrap;
 				overflow: hidden;
 				text-overflow: ellipsis;
+				font-size: 11px;
+				flex: 1;
 			}
 
 			.menu-item:hover {
-				background-color: var(--input-background);
+				background-color: var(--theme-background5);
 			}
 
 			.menu-item-none {
 				display: flex;
-				background-color: var(--background-primary);
-				font-style: italic;
-				color: var(--text-default);
-				align-items: flex-start;
+				color: var(--theme-text-default);
+				align-items: center;
 				justify-content: flex-start;
-				padding: 10px 10px;
-				height: 32px;
+				padding: 0px 10px;
+				height: 24px;
 				font-size: 12px;
 			}
 
 			.menu-item-separator {
-				height: 16px;
+				height: 12px;
+			}
+
+			hr {
+				border-bottom-color: var(--theme-background6);
+				width: 90%;
+			}
+
+			svg {
+				fill: var(--theme-text-default);
 			}
 
 			.menu-item-disabled {
 				opacity: 0.5;
-				pointer-events: none;
+				cursor: hand;
 			}
 		</style>
 	</head>
 
-	<body class="col fill" id="menuContainer"></body>
+	<body>
+		<div class="col fill" id="menuContainer"></div>
+	</body>
 </html>

--- a/how-to/workspace-platform-starter/public/common/popups/menu/menu.js
+++ b/how-to/workspace-platform-starter/public/common/popups/menu/menu.js
@@ -1,32 +1,48 @@
 document.addEventListener('DOMContentLoaded', initDOM);
 
+let activeSubMenu;
+let activeSubMenuId;
+let mouseOverEntry;
+
 /**
  * Initialize the DOM components.
  */
 async function initDOM() {
 	const options = await fin.me.getOptions();
+	const menuData = options.customData;
 
-	const backgroundPrimary = options?.customData?.palette?.backgroundPrimary ?? '#1e1f23';
-	const textDefault = options?.customData?.palette?.textDefault ?? '#ffffff';
-	const inputBackground = options?.customData?.palette?.inputBackground ?? '#383a40';
+	window.addEventListener('blur', async () => {
+		// If we have an active submenu the blur was setting focus
+		// to the menu, otherwise we have lose focus so close without result
+		if (!activeSubMenu) {
+			// We delay this so that the blur event has time to complete
+			setTimeout(async () => {
+				await fin.me.dispatchPopupResult();
+			}, 100);
+		}
+	});
 
-	const root = document.querySelector(':root');
-	if (root) {
-		root.style.setProperty(`--background-primary`, backgroundPrimary);
-		root.style.setProperty(`--text-default`, textDefault);
-		root.style.setProperty(`--input-background`, inputBackground);
-	}
+	const colorScheme = menuData?.colorScheme ?? 'dark';
+
+	setColorScheme(colorScheme, 'theme-dark', 'theme-light');
+	convertPaletteToCss('theme', colorScheme, menuData?.palette);
 
 	const menuContainer = document.querySelector('#menuContainer');
+	// The menuContainer is initially hidden to allow for the palette to be set
+	menuContainer.style.display = 'flex';
 
 	if (menuContainer) {
-		if (Array.isArray(options.customData?.menuEntries) && options.customData.menuEntries.length > 0) {
-			for (const menuEntry of options.customData.menuEntries) {
+		if (Array.isArray(menuData?.menuEntries) && menuData.menuEntries.length > 0) {
+			for (const menuEntry of menuData.menuEntries) {
+				let menuEntryItem;
+				const hasSubMenu = menuEntry.type === 'submenu' || Array.isArray(menuEntry.submenu);
+				const isDisabled = !(menuEntry.enabled ?? true);
+
 				if (menuEntry.type === 'separator') {
-					const menuEntryItem = document.createElement('div');
+					menuEntryItem = document.createElement('div');
 
 					menuEntryItem.classList.add('menu-item-separator');
-					if (!(menuEntry.enabled ?? true)) {
+					if (isDisabled) {
 						menuEntryItem.classList.add('menu-item-disabled');
 					}
 
@@ -35,43 +51,248 @@ async function initDOM() {
 
 					menuContainer.append(menuEntryItem);
 				} else {
-					const menuEntryItem = document.createElement('button');
+					menuEntryItem = document.createElement('button');
 					menuEntryItem.ariaLabel = menuEntry.label;
 
 					menuEntryItem.classList.add('menu-item');
-					if (!(menuEntry.enabled ?? true)) {
+
+					if (isDisabled) {
 						menuEntryItem.classList.add('menu-item-disabled');
-					} else {
+					} else if (!hasSubMenu) {
 						menuEntryItem.addEventListener('click', async () => {
-							await fin.me.dispatchPopupResult(menuEntry.customData);
+							await fin.me.dispatchPopupResult(menuEntry.data);
 						});
 					}
 
 					let icon;
-					if (menuEntry.icon) {
+					if (menuEntry.checked) {
+						icon = createSVG(
+							'M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 0 0-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z'
+						);
+					} else if (menuEntry.icon) {
 						icon = document.createElement('img');
 						icon.src = menuEntry.icon;
-						icon.width = 16;
-						icon.height = 16;
+						icon.style.maxWidth = '16px';
+						icon.style.maxHeight = '16px';
 					}
 
 					const text = document.createElement('span');
 					text.textContent = menuEntry.label;
 
+					const iconContainer = document.createElement('div');
+					iconContainer.style.display = 'flex';
+					iconContainer.style.justifyContent = 'center';
+					iconContainer.style.alignItems = 'center';
+					iconContainer.style.width = '16px';
+					iconContainer.style.height = '16px';
 					if (icon) {
-						menuEntryItem.append(icon);
+						iconContainer.append(icon);
 					}
+
+					menuEntryItem.append(iconContainer);
 					menuEntryItem.append(text);
+					if (hasSubMenu) {
+						menuEntryItem.append(
+							createSVG(
+								'M715.8 493.5L335 165.1c-14.2-12.2-35-1.2-35 18.5v656.8c0 19.7 20.8 30.7 35 18.5l380.8-328.4c10.9-9.4 10.9-27.6 0-37z'
+							)
+						);
+					}
 					menuContainer.append(menuEntryItem);
 				}
+
+				menuEntryItem.addEventListener('mouseover', async (event) => {
+					mouseOverEntry = menuEntry;
+
+					// If there is an active sub menu and it's different from the
+					// current hovered menu entry, close it
+					if (activeSubMenu && activeSubMenu !== mouseOverEntry) {
+						await closeSubMenu();
+					}
+
+					// For the current hovered entry if it has a sub menu and it's not
+					// disabled, and there is no open menu then display the menu
+					if (!isDisabled && hasSubMenu && !activeSubMenu) {
+						// Debounce
+						setTimeout(async () => {
+							if (menuEntry === mouseOverEntry) {
+								await createSubMenu(options?.customData, menuEntry);
+							}
+						}, 200);
+					}
+				});
 			}
 		} else {
 			const noEntries = document.createElement('div');
-			const content = options.customData?.noEntryText ?? 'No entries';
+			const content = menuData?.noEntryText ?? 'No entries';
 			noEntries.textContent = content;
 			noEntries.ariaLabel = content;
 			noEntries.classList.add('menu-item-none');
 			menuContainer.append(noEntries);
 		}
 	}
+}
+
+/**
+ * Create a sub menu.
+ * @param menuData The menu data passed to the window.
+ * @param menuEntry The menu entry to create the submenu for.
+ */
+async function createSubMenu(menuData, menuEntry) {
+	if (activeSubMenu !== menuEntry) {
+		activeSubMenu = menuEntry;
+		activeSubMenuId = randomUUID();
+
+		let x = menuData.bounds.width - 20;
+		let y = menuEntry.y;
+		const width = menuEntry.submenuDimensions.width;
+		const height = menuEntry.submenuDimensions.height;
+
+		if (x + menuData.bounds.x + width > menuData.monitorRect.right) {
+			x = menuData.monitorRect.right - menuData.bounds.x - width - 20;
+		}
+		if (y + menuData.bounds.y + height > menuData.monitorRect.bottom) {
+			y = menuData.monitorRect.bottom - menuData.bounds.y - height - 20;
+		}
+
+		const bounds = { x, y, width, height };
+
+		const parentWindow = fin.Window.wrapSync(fin.me.identity);
+		const result = await parentWindow.showPopupWindow({
+			name: activeSubMenuId,
+			initialOptions: {
+				showTaskbarIcon: false,
+				smallWindow: true,
+				contextMenu: false,
+				backgroundColor: menuData.currentPalette?.backgroundPrimary,
+				customData: {
+					...menuData,
+					menuEntries: menuEntry.submenu,
+					bounds
+				}
+			},
+			url: menuData?.popupUrl,
+			...bounds,
+			blurBehavior: 'modal'
+		});
+		if (result.result === 'clicked' && result.identity.name === activeSubMenuId) {
+			setTimeout(async () => {
+				await fin.me.dispatchPopupResult(result.data);
+			}, 200);
+		}
+	}
+}
+
+/**
+ * Close the current submenu.
+ */
+async function closeSubMenu() {
+	if (activeSubMenu !== undefined) {
+		const win = fin.Window.wrapSync({
+			uuid: fin.me.identity.uuid,
+			name: activeSubMenuId
+		});
+		activeSubMenuId = undefined;
+		activeSubMenu = undefined;
+		try {
+			await win.close();
+		} catch {}
+	}
+}
+
+/**
+ * Create an SVG using just its path data.
+ * @param pathData The data to use in the path.
+ * @returns The created SVG
+ */
+function createSVG(pathData) {
+	const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+	svg.setAttribute('width', '12px');
+	svg.setAttribute('height', '12px');
+	svg.setAttribute('viewBox', '0 0 1024 1024');
+
+	const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+	path.setAttribute('d', pathData);
+	svg.append(path);
+	return svg;
+}
+
+/**
+ * Set the color scheme class on the document body.
+ * @param schemeType The type of the scheme dark or light.
+ * @param darkScheme The class name to add for dark scheme.
+ * @param lightScheme The class name to add for light scheme.
+ */
+function setColorScheme(schemeType, darkScheme, lightScheme) {
+	if (schemeType === 'light') {
+		document.body.classList.remove(darkScheme);
+		document.body.classList.add(lightScheme);
+	} else {
+		document.body.classList.remove(lightScheme);
+		document.body.classList.add(darkScheme);
+	}
+}
+
+/**
+ * Convert a camel case property name to kebab case for the css properties.
+ * @param input The input name to convert.
+ * @returns The name in kebab case.
+ */
+function kebabCase(input) {
+	if (typeof input === 'string' && input.length > 0) {
+		return (
+			input
+				.replace(/([A-Z])/g, ' $1')
+				.trim()
+				.match(/[^\u0000-\u002F\u003A-\u0040\u005B-\u0060\u007B-\u007F]+/g) ?? []
+		)
+			.join('-')
+			.toLowerCase();
+	}
+	return '';
+}
+
+/**
+ * Create all the css vars from the palette properties.
+ * @param prefix The prefix to add to the property names.
+ * @param scheme The scheme dark or light.
+ * @param palette The palette to convert to properties.
+ */
+function convertPaletteToCss(prefix, scheme, palette) {
+	const root = document.querySelector(':root');
+	if (root) {
+		root.style.setProperty(`--${prefix}-scheme`, scheme);
+		const keys = Object.keys(palette);
+		for (const key of keys) {
+			root.style.setProperty(`--${prefix}-${kebabCase(key)}`, palette[key]);
+		}
+	}
+}
+
+/**
+ * Polyfills randomUUID if running in a non-secure context.
+ * @returns The random UUID.
+ */
+function randomUUID() {
+	if ('randomUUID' in window.crypto) {
+		// eslint-disable-next-line no-restricted-syntax
+		return window.crypto.randomUUID();
+	}
+	// Polyfill the window.crypto.randomUUID if we are running in a non secure context that doesn't have it
+	// we are still using window.crypto.getRandomValues which is always available
+	// https://stackoverflow.com/a/2117523/2800218
+	/**
+	 * Get random hex value.
+	 * @param c The number to base the random value on.
+	 * @returns The random value.
+	 */
+	function getRandomHex(c) {
+		// eslint-disable-next-line no-bitwise
+		const rnd = window.crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (Number(c) / 4));
+		return (
+			// eslint-disable-next-line no-bitwise
+			(Number(c) ^ rnd).toString(16)
+		);
+	}
+	return '10000000-1000-4000-8000-100000000000'.replace(/[018]/g, getRandomHex);
 }

--- a/how-to/workspace-platform-starter/public/common/popups/menu/menu.js
+++ b/how-to/workspace-platform-starter/public/common/popups/menu/menu.js
@@ -18,7 +18,7 @@ async function initDOM() {
 			// We delay this so that the blur event has time to complete
 			setTimeout(async () => {
 				await fin.me.dispatchPopupResult();
-			}, 100);
+			}, 200);
 		}
 	});
 

--- a/how-to/workspace-platform-starter/public/manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/manifest.fin.json
@@ -568,7 +568,14 @@
 						"type": "SaveMenu"
 					}
 				}
-			]
+			],
+			"menuOptions": {
+				"styles": {
+					"globalMenu": "custom",
+					"pageMenu": "custom",
+					"viewMenu": "custom"
+				}
+			}
 		},
 		"themeProvider": {
 			"themes": [
@@ -609,34 +616,15 @@
 							"linkHover": "#0A76D3"
 						},
 						"dark": {
-							"brandPrimary": "#0A76D3",
-							"brandSecondary": "#383A40",
-							"backgroundPrimary": "#1E1F23",
-							"background1": "#111214",
-							"background2": "#1E1F23",
-							"background3": "#24262B",
-							"background4": "#2F3136",
-							"background5": "#383A40",
-							"background6": "#53565F",
-							"statusSuccess": "#35C759",
-							"statusWarning": "#F48F00",
-							"statusCritical": "#BE1D1F",
-							"statusActive": "#0498FB",
-							"inputBackground": "#53565F",
-							"inputColor": "#FFFFFF",
-							"inputPlaceholder": "#C9CBD2",
-							"inputDisabled": "#7D808A",
-							"inputFocused": "#C9CBD2",
-							"textDefault": "#FFFFFF",
-							"textHelp": "#C9CBD2",
-							"textInactive": "#7D808A",
-							"contentBackground1": "#0A76D3",
-							"contentBackground2": "#000000",
-							"contentBackground3": "#000000",
-							"contentBackground4": "#000000",
-							"contentBackground5": "#000000",
-							"linkDefault": "#6CADE5",
-							"linkHover": "#0A76D3"
+							"brandPrimary": "#0070D2",
+							"brandSecondary": "#0070D2",
+							"backgroundPrimary": "#265A78",
+							"background1": "#0C4362",
+							"background2": "#105998",
+							"background3": "#265A78",
+							"background4": "#0070D2",
+							"background5": "#0070D2",
+							"background6": "#0070D2"
 						}
 					}
 				}
@@ -1171,10 +1159,10 @@
 					"icon": "http://localhost:8080/favicon.ico",
 					"title": "Favorites Menu",
 					"description": "Favorites Menu",
-					"enabled": false,
+					"enabled": true,
 					"url": "http://localhost:8080/js/modules/actions/favorites-menu.bundle.js",
 					"data": {
-						"menuType": "native"
+						"menuStyle": "custom"
 					}
 				},
 				{
@@ -1294,8 +1282,6 @@
 		},
 		"menusProvider": {
 			"popupHtml": "http://localhost:8080/common/popups/menu/index.html",
-			"menuWidth": 200,
-			"menuItemHeight": 32,
 			"modules": [
 				{
 					"enabled": true,
@@ -1407,7 +1393,7 @@
 			]
 		},
 		"favoriteProvider": {
-			"enabled": false,
+			"enabled": true,
 			"favoriteIcon": "http://localhost:8080/icons/{scheme}/favorite.svg",
 			"unfavoriteIcon": "http://localhost:8080/icons/{scheme}/unfavorite.svg",
 			"favoriteCommand": "/fav",

--- a/how-to/workspace-platform-starter/public/manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/manifest.fin.json
@@ -568,14 +568,7 @@
 						"type": "SaveMenu"
 					}
 				}
-			],
-			"menuOptions": {
-				"styles": {
-					"globalMenu": "custom",
-					"pageMenu": "custom",
-					"viewMenu": "custom"
-				}
-			}
+			]
 		},
 		"themeProvider": {
 			"themes": [
@@ -616,15 +609,34 @@
 							"linkHover": "#0A76D3"
 						},
 						"dark": {
-							"brandPrimary": "#0070D2",
-							"brandSecondary": "#0070D2",
-							"backgroundPrimary": "#265A78",
-							"background1": "#0C4362",
-							"background2": "#105998",
-							"background3": "#265A78",
-							"background4": "#0070D2",
-							"background5": "#0070D2",
-							"background6": "#0070D2"
+							"brandPrimary": "#0A76D3",
+							"brandSecondary": "#383A40",
+							"backgroundPrimary": "#1E1F23",
+							"background1": "#111214",
+							"background2": "#1E1F23",
+							"background3": "#24262B",
+							"background4": "#2F3136",
+							"background5": "#383A40",
+							"background6": "#53565F",
+							"statusSuccess": "#35C759",
+							"statusWarning": "#F48F00",
+							"statusCritical": "#BE1D1F",
+							"statusActive": "#0498FB",
+							"inputBackground": "#53565F",
+							"inputColor": "#FFFFFF",
+							"inputPlaceholder": "#C9CBD2",
+							"inputDisabled": "#7D808A",
+							"inputFocused": "#C9CBD2",
+							"textDefault": "#FFFFFF",
+							"textHelp": "#C9CBD2",
+							"textInactive": "#7D808A",
+							"contentBackground1": "#0A76D3",
+							"contentBackground2": "#000000",
+							"contentBackground3": "#000000",
+							"contentBackground4": "#000000",
+							"contentBackground5": "#000000",
+							"linkDefault": "#6CADE5",
+							"linkHover": "#0A76D3"
 						}
 					}
 				}
@@ -1159,7 +1171,7 @@
 					"icon": "http://localhost:8080/favicon.ico",
 					"title": "Favorites Menu",
 					"description": "Favorites Menu",
-					"enabled": true,
+					"enabled": false,
 					"url": "http://localhost:8080/js/modules/actions/favorites-menu.bundle.js",
 					"data": {
 						"menuStyle": "custom"
@@ -1393,7 +1405,7 @@
 			]
 		},
 		"favoriteProvider": {
-			"enabled": true,
+			"enabled": false,
 			"favoriteIcon": "http://localhost:8080/icons/{scheme}/favorite.svg",
 			"unfavoriteIcon": "http://localhost:8080/icons/{scheme}/unfavorite.svg",
 			"favoriteCommand": "/fav",

--- a/how-to/workspace-platform-starter/public/manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/manifest.fin.json
@@ -1174,7 +1174,7 @@
 					"enabled": false,
 					"url": "http://localhost:8080/js/modules/actions/favorites-menu.bundle.js",
 					"data": {
-						"menuStyle": "custom"
+						"menuStyle": "native"
 					}
 				},
 				{

--- a/how-to/workspace-platform-starter/public/platform/provider.html
+++ b/how-to/workspace-platform-starter/public/platform/provider.html
@@ -7,6 +7,7 @@
 		<link rel="icon" type="image/x-icon" href="../favicon.ico" />
 		<meta name="description" content="" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<link rel="stylesheet" href="../common/style/app.css" />
 	</head>
 	<body>
 		<div>Custom Provider...</div>

--- a/how-to/workspace-platform-starter/public/schemas/settings.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/settings.schema.json
@@ -504,6 +504,25 @@
                                 }
                             },
                             "type": "object"
+                        },
+                        "styles": {
+                            "additionalProperties": false,
+                            "description": "Style the menus, if no options are provided it will use the build in version.",
+                            "properties": {
+                                "globalMenu": {
+                                    "$ref": "#/definitions/PopupMenuStyles",
+                                    "description": "Override the style for the global menu (top left icon)"
+                                },
+                                "pageMenu": {
+                                    "$ref": "#/definitions/PopupMenuStyles",
+                                    "description": "Override the style for the page menu (right click on page tab)"
+                                },
+                                "viewMenu": {
+                                    "$ref": "#/definitions/PopupMenuStyles",
+                                    "description": "Override the style for the view menu (right click on view tab)"
+                                }
+                            },
+                            "type": "object"
                         }
                     },
                     "type": "object"
@@ -2635,6 +2654,10 @@
             "additionalProperties": false,
             "description": "A list of modules that provide menu for different locations.",
             "properties": {
+                "menuFontSize": {
+                    "description": "The font size used in the custom popup menu.\ndefaults to 12",
+                    "type": "number"
+                },
                 "menuItemHeight": {
                     "description": "The height of an item in the custom popup menu.\ndefaults to 32.",
                     "type": "number"
@@ -3652,6 +3675,14 @@
         },
         "Point": {
             "$ref": "#/definitions/__type_35"
+        },
+        "PopupMenuStyles": {
+            "description": "The styles that can be used to display the popup menus.",
+            "enum": [
+                "custom",
+                "native"
+            ],
+            "type": "string"
         },
         "PreDefinedButtonConfig": {
             "additionalProperties": false,


### PR DESCRIPTION
- Change Platform override for `openGlobalContextMenu` can be configured to use the custom popup menus by setting `browserProvider.menuOptions.style.globalMenu` to `native` or `custom`
- Change Platform override for `openViewTabContextMenu` can be configured to use the custom popup menus by setting `browserProvider.menuOptions.style.viewMenu` to `native` or `custom`
- Change Platform override for `openPageTabContextMenu` can be configured to use the custom popup menus by setting `browserProvider.menuOptions.style.pageMenu` to `native` or `custom`
- Added Custom popup menus now support separators, disabled, submenu, checkbox, aria labelling and off-screen positioning
![image](https://github.com/built-on-openfin/workspace-starter/assets/5030334/21448141-cdbc-43b8-90b5-4f9802d67377)

![image](https://github.com/built-on-openfin/workspace-starter/assets/5030334/9f74a2cf-b4f4-4bc0-9c3d-a7edc156557a)
