### PR TITLE
Add new init options support to composite page module

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Change Platform override for `openViewTabContextMenu` can be configured to use the custom popup menus by setting `browserProvider.menuOptions.style.viewMenu` to `native` or `custom`
 - Change Platform override for `openPageTabContextMenu` can be configured to use the custom popup menus by setting `browserProvider.menuOptions.style.pageMenu` to `native` or `custom`
 - Updated launchPreferences to provide a wider range of host options for views. Updated example platform api page to read the title from workspace platform title.
+- Breaking Change: `ModuleHelpers launchPage` helper function now takes a pageId (and it has to be a valid pageId) instead of asking modules to get the platform, use the storage apis and then send a page. This reduces code and also ensures that only valid pages are launched.
 
 ## v14
 

--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Change Platform override for `openPageTabContextMenu` can be configured to use the custom popup menus by setting `browserProvider.menuOptions.style.pageMenu` to `native` or `custom`
 - Updated launchPreferences to provide a wider range of host options for views. Updated example platform api page to read the title from workspace platform title.
 - Breaking Change: `ModuleHelpers launchPage` helper function now takes a pageId (and it has to be a valid pageId) instead of asking modules to get the platform, use the storage apis and then send a page. This reduces code and also ensures that only valid pages are launched.
+- New Feature - Updated the page composite module so that you can enable an [init options](./client/src/modules/composite/pages/init-options.ts) module that lets you launch a specific page using init params. Example fins link: fin://localhost:8080/manifest.fin.json?$$action=show-page&$$payload=eyAicGFnZUlkIjogImIwY2UxNTg3LTM2ZDAtNGRlZC05ZGU3LTlmNmQyYjc1OGYyNyIgfQ== the payload is a base64 encoded string of { "pageId": "the-id-of-the-page" }
 
 ## v14
 

--- a/how-to/workspace-platform-starter/client/src/framework/integrations.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/integrations.ts
@@ -9,7 +9,6 @@ import {
 	type HomeSearchResult
 } from "@openfin/workspace";
 import { getCurrentSync } from "@openfin/workspace-platform";
-import { checkCondition } from "./conditions";
 import * as endpointProvider from "./endpoint";
 import { launch } from "./launch";
 import { createLogger } from "./logger-provider";
@@ -21,7 +20,7 @@ import {
 	initializeModules,
 	loadModules
 } from "./modules";
-import { launchPage, launchView } from "./platform/browser";
+import { launchView } from "./platform/browser";
 import * as platformSplashProvider from "./platform/platform-splash";
 import type {
 	EndpointIntegrationsPreferencesGetRequest,
@@ -73,7 +72,6 @@ export async function init(
 			...helpers,
 			templateHelpers,
 			launchView,
-			launchPage,
 			launchSnapshot: async (manifestUrl): Promise<OpenFin.Identity[]> => {
 				const identities = await launch({
 					manifestType: MANIFEST_TYPES.Snapshot.id,
@@ -87,10 +85,6 @@ export async function init(
 			},
 			openUrl: async (url) => fin.System.openUrlWithBrowser(url),
 			setSearchQuery,
-			condition: async (conditionId): Promise<boolean> => {
-				const platform = getCurrentSync();
-				return checkCondition(platform, conditionId);
-			},
 			share,
 			getPlatform: getCurrentSync
 		};

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/integrations-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/integrations-shapes.ts
@@ -53,13 +53,6 @@ export interface IntegrationHelpers extends ModuleHelpers {
 	setSearchQuery?(query: string): Promise<void>;
 
 	/**
-	 * Get the value of a condition.
-	 * @param conditionId The id of the condition.
-	 * @returns True if the condition is set.
-	 */
-	condition?(conditionId: string): Promise<boolean>;
-
-	/**
 	 * Share data.
 	 * @param options The sharing options.
 	 * @returns Nothing.

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/module-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/module-shapes.ts
@@ -1,6 +1,7 @@
 import type OpenFin from "@openfin/core";
-import type { BrowserWindowModule, CustomPaletteSet, Page } from "@openfin/workspace-platform";
+import type { BrowserWindowModule, CustomPaletteSet } from "@openfin/workspace-platform";
 import type { PlatformApp } from "./app-shapes";
+import type { ConditionContextTypes } from "./conditions-shapes";
 import type { FavoriteClient } from "./favorite-shapes";
 import type { LifecycleEvents, LifecycleHandler } from "./lifecycle-shapes";
 import type { Logger, LoggerCreator } from "./logger-shapes";
@@ -160,23 +161,23 @@ export interface ModuleHelpers {
 
 	/**
 	 * Launch a page in the workspace.
-	 * @param page The page to launch.
+	 * @param pageId The page to launch.
 	 * @param options The options for the launch.
 	 * @param options.bounds The optional bounds for the page.
 	 * @param options.targetWindowIdentity The optional target window for the page.
 	 * @param options.createCopyIfExists Create a copy of the page if it exists.
 	 * @param logger Log output from the operation.
-	 * @returns The window created.
+	 * @returns The window created or undefined if the page did not exist.
 	 */
 	launchPage?(
-		page: Page,
+		pageId: string,
 		options?: {
 			bounds?: OpenFin.Bounds;
 			targetWindowIdentity?: OpenFin.Identity;
 			createCopyIfExists?: boolean;
 		},
 		logger?: Logger
-	): Promise<BrowserWindowModule>;
+	): Promise<BrowserWindowModule | undefined>;
 
 	/**
 	 * Launch a workspace.
@@ -225,6 +226,14 @@ export interface ModuleHelpers {
 			style?: PopupMenuStyles;
 		}
 	): Promise<T | undefined>;
+
+	/**
+	 * Lets you check to see if a defined condition is true or false.
+	 * @param conditionId The condition to check for.
+	 * @param contextType What is the context for checking this condition.
+	 * @returns whether the condition is true or false
+	 */
+	condition(conditionId: string, contextType?: ConditionContextTypes): Promise<boolean>;
 }
 
 /**

--- a/how-to/workspace-platform-starter/client/src/modules/actions/custom-menu/actions.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/actions/custom-menu/actions.ts
@@ -79,8 +79,7 @@ export class DynamicMenuProvider implements Actions {
 					this._logger?.info("Menu dismissed");
 				} else if (this._helpers?.launchPage) {
 					this._logger?.info("Menu clicked", result);
-					const pageToLaunch = await platform.Storage.getPage(result);
-					await this._helpers.launchPage(pageToLaunch, undefined, this._logger);
+					await this._helpers.launchPage(result, undefined, this._logger);
 				}
 			}
 		};

--- a/how-to/workspace-platform-starter/client/src/modules/actions/favorites-menu/actions.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/actions/favorites-menu/actions.ts
@@ -121,7 +121,7 @@ export class FavoritesMenuProvider implements Actions<FavoritesMenuSettings> {
 								}
 							} else if (result.type === FAVORITE_TYPE_NAME_PAGE) {
 								if (!isEmpty(this._helpers?.launchPage)) {
-									await this._helpers?.launchPage(result.typeId);
+									await this._helpers?.launchPage(result.typeId, undefined, this._logger);
 								}
 							} else if (result.type === FAVORITE_TYPE_NAME_WORKSPACE) {
 								if (!isEmpty(this._helpers?.launchWorkspace)) {

--- a/how-to/workspace-platform-starter/client/src/modules/actions/favorites-menu/actions.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/actions/favorites-menu/actions.ts
@@ -121,8 +121,7 @@ export class FavoritesMenuProvider implements Actions<FavoritesMenuSettings> {
 								}
 							} else if (result.type === FAVORITE_TYPE_NAME_PAGE) {
 								if (!isEmpty(this._helpers?.launchPage)) {
-									const page = await platform.Storage.getPage(result.typeId);
-									await this._helpers?.launchPage(page);
+									await this._helpers?.launchPage(result.typeId);
 								}
 							} else if (result.type === FAVORITE_TYPE_NAME_WORKSPACE) {
 								if (!isEmpty(this._helpers?.launchWorkspace)) {

--- a/how-to/workspace-platform-starter/client/src/modules/composite/pages/actions.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/composite/pages/actions.ts
@@ -53,11 +53,9 @@ export class PageActions implements Actions {
 				const pageId: string = payload?.customData?.pageId;
 				const targetWindowIdentity: OpenFin.Identity = payload?.customData?.windowIdentity;
 				if (!isEmpty(pageId)) {
-					const page = await platform.Storage.getPage(pageId);
-
 					if (this._helpers?.launchPage) {
 						await this._helpers.launchPage(
-							page,
+							pageId,
 							{
 								targetWindowIdentity
 							},

--- a/how-to/workspace-platform-starter/client/src/modules/composite/pages/index.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/composite/pages/index.ts
@@ -1,8 +1,10 @@
 import type { ModuleImplementation, ModuleTypes } from "workspace-platform-starter/shapes/module-shapes";
 import { PageActions } from "./actions";
+import { InitOptionsShowPageHandler } from "./init-options";
 import { PageMenus } from "./menus";
 
 export const entryPoints: { [type in ModuleTypes]?: ModuleImplementation } = {
 	actions: new PageActions(),
-	menus: new PageMenus()
+	menus: new PageMenus(),
+	initOptions: new InitOptionsShowPageHandler()
 };

--- a/how-to/workspace-platform-starter/client/src/modules/composite/pages/init-options.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/composite/pages/init-options.ts
@@ -1,0 +1,75 @@
+import type { InitOptionsHandler } from "workspace-platform-starter/shapes/init-options-shapes";
+import type { Logger, LoggerCreator } from "workspace-platform-starter/shapes/logger-shapes";
+import type { ModuleDefinition, ModuleHelpers } from "workspace-platform-starter/shapes/module-shapes";
+import { isEmpty, isStringValue } from "workspace-platform-starter/utils";
+import type { LaunchPageOptions, LaunchPagePayload } from "./shapes";
+
+/**
+ * Init options launch handler.
+ */
+export class InitOptionsLaunchPageHandler implements InitOptionsHandler<LaunchPageOptions> {
+	private _logger?: Logger;
+
+	private _helpers?: ModuleHelpers;
+
+	private _definition?: ModuleDefinition<LaunchPageOptions>;
+
+	/**
+	 * Initialize the module.
+	 * @param definition The definition of the module from configuration include custom options.
+	 * @param loggerCreator For logging entries.
+	 * @param helpers Helper methods for the module to interact with the application core.
+	 * @returns Nothing.
+	 */
+	public async initialize(
+		definition: ModuleDefinition<LaunchPageOptions>,
+		loggerCreator: LoggerCreator,
+		helpers: ModuleHelpers
+	): Promise<void> {
+		this._logger = loggerCreator("InitOptionsLaunchPageHandler");
+		this._helpers = helpers;
+		this._definition = definition;
+		this._logger.info("The handler has been loaded");
+	}
+
+	/**
+	 * Handle the init options action.
+	 * @param requestedAction The requested action.
+	 * @param payload The payload for the action.
+	 */
+	public async action(requestedAction: string, payload?: LaunchPagePayload): Promise<void> {
+		if (isEmpty(payload)) {
+			this._logger?.warn(
+				`Actions passed to the module require a payload to be passed. Requested action: ${requestedAction} can not be fulfilled.`
+			);
+			return;
+		}
+		try {
+			if (requestedAction === "launch-page") {
+				const pageId = payload?.pageId;
+				this._logger?.info(`The following pageId was passed and requested to launch: ${pageId}`);
+
+				if (!isStringValue(pageId)) {
+					this._logger?.error(
+						"The init handler received an pageId in the wrong format and is unable to launch it"
+					);
+					return;
+				}
+
+				if (isEmpty(this._helpers?.launchPage) || isEmpty(this._helpers?.launchPage)) {
+					this._logger?.warn(
+						`Unable to launch page with pageId: ${pageId} as a launchPage function was not passed to this module via the module helpers.`
+					);
+					return;
+				}
+
+				const resultingWindow = await this._helpers?.launchPage(pageId);
+				if (isEmpty(resultingWindow)) {
+					this._logger?.error(`We have been unable to find and launch the provided pageId: ${pageId}`);
+				}
+			}
+		} catch (error) {
+			this._logger?.error(`Error trying to perform action ${requestedAction}.`, error);
+		}
+	}
+}

--- a/how-to/workspace-platform-starter/client/src/modules/composite/pages/init-options.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/composite/pages/init-options.ts
@@ -2,17 +2,17 @@ import type { InitOptionsHandler } from "workspace-platform-starter/shapes/init-
 import type { Logger, LoggerCreator } from "workspace-platform-starter/shapes/logger-shapes";
 import type { ModuleDefinition, ModuleHelpers } from "workspace-platform-starter/shapes/module-shapes";
 import { isEmpty, isStringValue } from "workspace-platform-starter/utils";
-import type { LaunchPageOptions, LaunchPagePayload } from "./shapes";
+import type { ShowPageOptions, ShowPagePayload } from "./shapes";
 
 /**
- * Init options launch handler.
+ * Init options show page handler.
  */
-export class InitOptionsLaunchPageHandler implements InitOptionsHandler<LaunchPageOptions> {
+export class InitOptionsShowPageHandler implements InitOptionsHandler<ShowPageOptions> {
 	private _logger?: Logger;
 
 	private _helpers?: ModuleHelpers;
 
-	private _definition?: ModuleDefinition<LaunchPageOptions>;
+	private _definition?: ModuleDefinition<ShowPageOptions>;
 
 	/**
 	 * Initialize the module.
@@ -22,11 +22,11 @@ export class InitOptionsLaunchPageHandler implements InitOptionsHandler<LaunchPa
 	 * @returns Nothing.
 	 */
 	public async initialize(
-		definition: ModuleDefinition<LaunchPageOptions>,
+		definition: ModuleDefinition<ShowPageOptions>,
 		loggerCreator: LoggerCreator,
 		helpers: ModuleHelpers
 	): Promise<void> {
-		this._logger = loggerCreator("InitOptionsLaunchPageHandler");
+		this._logger = loggerCreator("InitOptionsShowPageHandler");
 		this._helpers = helpers;
 		this._definition = definition;
 		this._logger.info("The handler has been loaded");
@@ -37,7 +37,7 @@ export class InitOptionsLaunchPageHandler implements InitOptionsHandler<LaunchPa
 	 * @param requestedAction The requested action.
 	 * @param payload The payload for the action.
 	 */
-	public async action(requestedAction: string, payload?: LaunchPagePayload): Promise<void> {
+	public async action(requestedAction: string, payload?: ShowPagePayload): Promise<void> {
 		if (isEmpty(payload)) {
 			this._logger?.warn(
 				`Actions passed to the module require a payload to be passed. Requested action: ${requestedAction} can not be fulfilled.`
@@ -45,27 +45,27 @@ export class InitOptionsLaunchPageHandler implements InitOptionsHandler<LaunchPa
 			return;
 		}
 		try {
-			if (requestedAction === "launch-page") {
+			if (requestedAction === "show-page") {
 				const pageId = payload?.pageId;
-				this._logger?.info(`The following pageId was passed and requested to launch: ${pageId}`);
+				this._logger?.info(`The following pageId was passed and requested to show: ${pageId}`);
 
 				if (!isStringValue(pageId)) {
 					this._logger?.error(
-						"The init handler received an pageId in the wrong format and is unable to launch it"
+						"The init handler received an pageId in the wrong format and is unable to show it"
 					);
 					return;
 				}
 
 				if (isEmpty(this._helpers?.launchPage) || isEmpty(this._helpers?.launchPage)) {
 					this._logger?.warn(
-						`Unable to launch page with pageId: ${pageId} as a launchPage function was not passed to this module via the module helpers.`
+						`Unable to show page with pageId: ${pageId} as a launchPage function was not passed to this module via the module helpers.`
 					);
 					return;
 				}
 
 				const resultingWindow = await this._helpers?.launchPage(pageId);
 				if (isEmpty(resultingWindow)) {
-					this._logger?.error(`We have been unable to find and launch the provided pageId: ${pageId}`);
+					this._logger?.error(`We have been unable to find and show the provided pageId: ${pageId}`);
 				}
 			}
 		} catch (error) {

--- a/how-to/workspace-platform-starter/client/src/modules/composite/pages/shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/composite/pages/shapes.ts
@@ -45,7 +45,7 @@ export interface PageMenuEntry {
 /**
  * The payload for launching a page.
  */
-export interface LaunchPagePayload {
+export interface ShowPagePayload {
 	/**
 	 * The page id.
 	 */
@@ -55,4 +55,4 @@ export interface LaunchPagePayload {
 /**
  * Options for the launch page init options.
  */
-export type LaunchPageOptions = InitOptionsHandlerOptions;
+export type ShowPageOptions = InitOptionsHandlerOptions;

--- a/how-to/workspace-platform-starter/client/src/modules/composite/pages/shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/composite/pages/shapes.ts
@@ -1,4 +1,4 @@
-import type { InitOptionsHandlerOptions } from "workspace-platform-starter/shapes";
+import type { InitOptionsHandlerOptions } from "workspace-platform-starter/shapes/init-options-shapes";
 import type { MenuPosition } from "workspace-platform-starter/shapes/menu-shapes";
 
 /**

--- a/how-to/workspace-platform-starter/client/src/modules/composite/pages/shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/composite/pages/shapes.ts
@@ -1,3 +1,4 @@
+import type { InitOptionsHandlerOptions } from "workspace-platform-starter/shapes";
 import type { MenuPosition } from "workspace-platform-starter/shapes/menu-shapes";
 
 /**
@@ -40,3 +41,18 @@ export interface PageMenuEntry {
 	 */
 	menuPosition?: MenuPosition;
 }
+
+/**
+ * The payload for launching a page.
+ */
+export interface LaunchPagePayload {
+	/**
+	 * The page id.
+	 */
+	pageId: string;
+}
+
+/**
+ * Options for the launch page init options.
+ */
+export type LaunchPageOptions = InitOptionsHandlerOptions;

--- a/how-to/workspace-platform-starter/client/src/modules/integrations/pages/integration.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/integrations/pages/integration.ts
@@ -316,9 +316,7 @@ export class PagesProvider implements IntegrationModule<PagesSettings> {
 
 					if (result.action.name === PagesProvider._ACTION_LAUNCH_PAGE) {
 						if (this._integrationHelpers?.getPlatform && this._integrationHelpers?.launchPage) {
-							const platform = this._integrationHelpers.getPlatform();
-							const pageToLaunch = await platform.Storage.getPage(data.pageId);
-							await this._integrationHelpers.launchPage(pageToLaunch, undefined, this._logger);
+							await this._integrationHelpers.launchPage(data.pageId, undefined, this._logger);
 						}
 					} else if (result.action.name === PagesProvider._ACTION_DELETE_PAGE) {
 						if (this._integrationHelpers?.getPlatform) {

--- a/how-to/workspace-platform-starter/client/types/module/shapes/integrations-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/integrations-shapes.d.ts
@@ -47,12 +47,6 @@ export interface IntegrationHelpers extends ModuleHelpers {
 	 */
 	setSearchQuery?(query: string): Promise<void>;
 	/**
-	 * Get the value of a condition.
-	 * @param conditionId The id of the condition.
-	 * @returns True if the condition is set.
-	 */
-	condition?(conditionId: string): Promise<boolean>;
-	/**
 	 * Share data.
 	 * @param options The sharing options.
 	 * @returns Nothing.

--- a/how-to/workspace-platform-starter/client/types/module/shapes/module-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/module-shapes.d.ts
@@ -1,5 +1,5 @@
 import type OpenFin from "@openfin/core";
-import type { BrowserWindowModule, CustomPaletteSet, Page } from "@openfin/workspace-platform";
+import type { BrowserWindowModule, CustomPaletteSet } from "@openfin/workspace-platform";
 import type { PlatformApp } from "./app-shapes";
 import type { FavoriteClient } from "./favorite-shapes";
 import type { LifecycleEvents, LifecycleHandler } from "./lifecycle-shapes";
@@ -8,6 +8,7 @@ import type { PopupMenuEntry, PopupMenuStyles } from "./menu-shapes";
 import type { NotificationClient } from "./notification-shapes";
 import type { ColorSchemeMode, ThemeClient } from "./theme-shapes";
 import type { VersionInfo } from "./version-shapes";
+import { ConditionContextTypes } from "./conditions-shapes";
 /**
  * List of modules.
  */
@@ -137,23 +138,23 @@ export interface ModuleHelpers {
 	launchApp?(appId: string): Promise<void>;
 	/**
 	 * Launch a page in the workspace.
-	 * @param page The page to launch.
+	 * @param pageId The page to launch.
 	 * @param options The options for the launch.
 	 * @param options.bounds The optional bounds for the page.
 	 * @param options.targetWindowIdentity The optional target window for the page.
 	 * @param options.createCopyIfExists Create a copy of the page if it exists.
 	 * @param logger Log output from the operation.
-	 * @returns The window created.
+	 * @returns The window created or undefined if the page did not exist.
 	 */
 	launchPage?(
-		page: Page,
+		pageId: string,
 		options?: {
 			bounds?: OpenFin.Bounds;
 			targetWindowIdentity?: OpenFin.Identity;
 			createCopyIfExists?: boolean;
 		},
 		logger?: Logger
-	): Promise<BrowserWindowModule>;
+	): Promise<BrowserWindowModule | undefined>;
 	/**
 	 * Launch a workspace.
 	 * @param workspaceId The id of the workspace to launch.
@@ -201,6 +202,13 @@ export interface ModuleHelpers {
 			style?: PopupMenuStyles;
 		}
 	): Promise<T | undefined>;
+	/**
+	 * Lets you check to see if a defined condition is true or false.
+	 * @param conditionId The condition to check for.
+	 * @param contextType What is the context for checking this condition.
+	 * @returns whether the condition is true or false
+	 */
+	condition(conditionId: string, contextType?: ConditionContextTypes): Promise<boolean>;
 }
 /**
  * The implementation of the module with generic options and helpers.

--- a/how-to/workspace-platform-starter/client/types/module/shapes/module-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/module-shapes.d.ts
@@ -1,6 +1,7 @@
 import type OpenFin from "@openfin/core";
 import type { BrowserWindowModule, CustomPaletteSet } from "@openfin/workspace-platform";
 import type { PlatformApp } from "./app-shapes";
+import type { ConditionContextTypes } from "./conditions-shapes";
 import type { FavoriteClient } from "./favorite-shapes";
 import type { LifecycleEvents, LifecycleHandler } from "./lifecycle-shapes";
 import type { Logger, LoggerCreator } from "./logger-shapes";
@@ -8,7 +9,6 @@ import type { PopupMenuEntry, PopupMenuStyles } from "./menu-shapes";
 import type { NotificationClient } from "./notification-shapes";
 import type { ColorSchemeMode, ThemeClient } from "./theme-shapes";
 import type { VersionInfo } from "./version-shapes";
-import { ConditionContextTypes } from "./conditions-shapes";
 /**
  * List of modules.
  */

--- a/how-to/workspace-platform-starter/public/manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/manifest.fin.json
@@ -1099,6 +1099,15 @@
 							"inline-snapshot"
 						]
 					}
+				},
+				{
+					"enabled": true,
+					"id": "show-page",
+					"title": "Init Options Show Page",
+					"url": "http://localhost:8080/js/modules/composite/pages.bundle.js",
+					"data": {
+						"supportedActions": ["show-page"]
+					}
 				}
 			]
 		},


### PR DESCRIPTION
The page composite module now supports launching/showing a page by specifying init params (similar to querystring params). This will either launch the page or bring it to front if it was already loaded.

It is launched using the following structure:
fins://domain/yourmanifest.fin.json?$$action=show-page&$$payload=eyAicGFnZUlkIjogImIwY2UxNTg3LTM2ZDAtNGRlZC05ZGU3LTlmNmQyYjc1OGYyNyIgfQ==

A localhost example:

fin://localhost:8080/manifest.fin.json?$$action=show-page&$$payload=eyAicGFnZUlkIjogImIwY2UxNTg3LTM2ZDAtNGRlZC05ZGU3LTlmNmQyYjc1OGYyNyIgfQ==

The payload is a base64 encoded string of a json object containing a pageId e.g.

{ "pageId": "b0ce1587-36d0-4ded-9de7-9f6d2b758f27" }

This pageId is unlikely to exist on your setup but it is just an example.

The module is enabled via the initProvider configuration in manifest.fin.json but the configuration can be disabled or removed if you don't want this support.

		"initOptionsProvider": {
			"modules": [
				{
					"enabled": true,
					"id": "show-page",
					"title": "Init Options Show Page",
					"url": "http://localhost:8080/js/modules/composite/pages.bundle.js",
					"data": {
						"supportedActions": ["show-page"]
					}
				}
			]
		},

The launchPage helper method passed to modules has been updated so that it now accepts a pageId instead of requiring modules to look up the page object and pass it.

the condition function (used to check to see if a certain condition is true) has also been moved from integration helpers to the base module helpers object to allow more modules to check for conditions.

Changelog has been updated to include the changes.