### PR TITLE
Updated manifests and added title check.

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -88,6 +88,7 @@
 - Change Lifecycle events can now be lazy subscribed so a late subscriber will get called with the last payload
 - Change Auth `logged-in` events can now be lazy subscribed so a late subscriber when you are already logged in will still receive the current user
 - Change Splash screen will now not show if `platform.preventQuitOnLastWindowClosed` is not set as closing the splash screen will exit the platform, a warning will be logged in this scenario
+- Added extra check of view/window title when building a list of intent handler instances.
 
 ## v13.1
 

--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -48,6 +48,8 @@
   - Is there a app specific endpoint available? E.g. if a view app has an id of `my-view-app` then we check for `manifest-get-my-view-app`. If the endpoint exists then we will call the request/response function against that endpoint and pass { url: string; appId: string} as the request. If you are using a fetch endpoint type instead of a custom module and the url is not specified we use the passed manifest url.
   - Is there a platform specific endpoint available - `manifest-get` is specified. This gives platform owners the option of providing a hook where they want to manage the fetching of manifests for their platform. If you are using a fetch endpoint type instead of a custom module and the url is not specified we use the passed manifest url.
   - If none of the above endpoints exist we fall back to the default `await fetch(manifestUrl)` behavior.
+  - Added example of how to enable/disable console logging of built in interop broker messages to manifests.
+  - Added extra check of view/window title when building a list of intent handler instances.
 
 ## v14
 

--- a/how-to/workspace-platform-starter/client/src/framework/platform/interopbroker.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/platform/interopbroker.ts
@@ -30,7 +30,7 @@ import type {
 	IntentTargetMetaData,
 	ProcessedContext
 } from "../shapes/interopbroker-shapes";
-import { formatError, isEmpty, isString, isStringValue } from "../utils";
+import { formatError, isEmpty, isString, isStringValue, sanitizeString } from "../utils";
 import { AppIntentHelper } from "./broker/app-intent-helper";
 import { ClientRegistrationHelper } from "./broker/client-registration-helper";
 import { IntentResolverHelper } from "./broker/intent-resolver-helper";
@@ -669,7 +669,7 @@ export function interopOverride(
 							// ensure no element tags are provided in the title
 							// we don't know how this information will be used
 							// and title hasn't come from the app directory
-							title = title.replace(/<[^>]*>?/gm, "");
+							title = sanitizeString(title);
 						}
 						const instanceAppMeta: AppMetadata = {
 							...appMetaData,

--- a/how-to/workspace-platform-starter/client/src/framework/platform/interopbroker.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/platform/interopbroker.ts
@@ -665,6 +665,12 @@ export function interopOverride(
 								error
 							);
 						}
+						if (!isEmpty(title)) {
+							// ensure no element tags are provided in the title
+							// we don't know how this information will be used
+							// and title hasn't come from the app directory
+							title = title.replace(/<[^>]*>?/gm, "");
+						}
 						const instanceAppMeta: AppMetadata = {
 							...appMetaData,
 							instanceId: app.instanceId,

--- a/how-to/workspace-platform-starter/client/src/framework/utils.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/utils.ts
@@ -117,3 +117,15 @@ export function formatError(err: unknown): string {
 	}
 	return JSON.stringify(err);
 }
+
+/**
+ * A basic string sanitize function that removes angle brackets <> from a string.
+ * @param content the content to sanitize
+ * @returns a string without angle brackets <>
+ */
+export function sanitizeString(content: string): string {
+	if (isString(content)) {
+		return content.replace(/<[^>]*>?/gm, "");
+	}
+	return content;
+}

--- a/how-to/workspace-platform-starter/public/fourth.manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/fourth.manifest.fin.json
@@ -48,7 +48,17 @@
 				}
 			}
 		},
-		"defaultViewOptions": {}
+		"defaultViewOptions": {},
+		"interopBrokerConfiguration": {
+			"logging": {
+				"beforeAction": {
+					"enabled": true
+				},
+				"afterAction": {
+					"enabled": true
+				}
+			}
+		}
 	},
 	"appAssets": [],
 	"supportInformation": {

--- a/how-to/workspace-platform-starter/public/manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/manifest.fin.json
@@ -57,6 +57,16 @@
 					}
 				}
 			}
+		},
+		"interopBrokerConfiguration": {
+			"logging": {
+				"beforeAction": {
+					"enabled": true
+				},
+				"afterAction": {
+					"enabled": true
+				}
+			}
 		}
 	},
 	"shortcut": {

--- a/how-to/workspace-platform-starter/public/second.manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/second.manifest.fin.json
@@ -46,6 +46,16 @@
 					}
 				}
 			}
+		},
+		"interopBrokerConfiguration": {
+			"logging": {
+				"beforeAction": {
+					"enabled": true
+				},
+				"afterAction": {
+					"enabled": true
+				}
+			}
 		}
 	},
 	"supportInformation": {

--- a/how-to/workspace-platform-starter/public/third.manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/third.manifest.fin.json
@@ -47,6 +47,16 @@
 		},
 		"defaultViewOptions": {
 			"fdc3InteropApi": "2.0"
+		},
+		"interopBrokerConfiguration": {
+			"logging": {
+				"beforeAction": {
+					"enabled": true
+				},
+				"afterAction": {
+					"enabled": true
+				}
+			}
 		}
 	},
 	"shortcut": {


### PR DESCRIPTION
The manifests now show how you can reduce the noise of the default interop broker console logs through interop broker configuration settings.

Added a validation step when returning information about instances of intent handlers.