### PR TITLE
Add url and channel support

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -52,6 +52,8 @@
   - Added example of how to enable/disable console logging of built in interop broker messages to manifests.
   - Added extra check of view/window title when building a list of intent handler instances.
 - Encourage the use of the initOptionsProvider for loading content into the platform.
+- Added url property to splashScreenProvider so you can provide your own custom location for the html content
+- Change splash screen progress updates are sent using channels so they work cross domain
 
 ## v14
 

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/splash-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/splash-shapes.ts
@@ -8,6 +8,11 @@ export interface SplashScreenProviderOptions {
 	disabled?: boolean;
 
 	/**
+	 * This url to provide a custom html file to load.
+	 */
+	url?: string;
+
+	/**
 	 * This defaults to manifest.shortcut.name if not provided.
 	 */
 	title?: string;

--- a/how-to/workspace-platform-starter/client/types/module/shapes/splash-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/splash-shapes.d.ts
@@ -7,6 +7,10 @@ export interface SplashScreenProviderOptions {
 	 */
 	disabled?: boolean;
 	/**
+	 * This url to provide a custom html file to load.
+	 */
+	url?: string;
+	/**
 	 * This defaults to manifest.shortcut.name if not provided.
 	 */
 	title?: string;

--- a/how-to/workspace-platform-starter/public/platform/splash.html
+++ b/how-to/workspace-platform-starter/public/platform/splash.html
@@ -45,5 +45,26 @@
 				</svg>
 			</div>
 		</main>
+		<script>
+			if (window.fin) {
+				(async () => {
+					try {
+						const options = await fin.me.getOptions();
+						const channelName = options.customData?.channelName;
+						if (channelName) {
+							const channel = await fin.InterApplicationBus.Channel.create(channelName);
+							await channel.register('progress', (payload) => {
+								const progress = document.querySelector('#progress');
+								if (progress) {
+									progress.textContent = `Initializing ${payload.progress}...`;
+								}
+							});
+						}
+					} catch (err) {
+						console.error(err);
+					}
+				})();
+			}
+		</script>
 	</body>
 </html>

--- a/how-to/workspace-platform-starter/public/schemas/settings.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/settings.schema.json
@@ -3928,6 +3928,10 @@
                     "description": "This defaults to manifest.shortcut.name if not provided.",
                     "type": "string"
                 },
+                "url": {
+                    "description": "This url to provide a custom html file to load.",
+                    "type": "string"
+                },
                 "width": {
                     "description": "The width for the splash screen, defaults to 400.",
                     "type": "number"


### PR DESCRIPTION
- Add `url` property to splash config
- Update the progress on the splash screen using channel, so that it will work cross domain