### PR TITLE
Move actions to modules

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added support for Snap, enable by setting `customSettings.snapProvider.enabled` to true. Configure the `customSettings.snapProvider.serverAssetInfo` to point to the `SNAP_ASSET_URL`. Enable the Snap debugging window by setting `customSettings.snapProvider.showDebugWindow` to true.
 - Added new module type `content-creation`, these modules can be used to define content creation rules and handle the associated events. Modules are added in `customSettings.contentCreationProvider` section in manifest.
 - Added example content creation module which interrogates the `features` property from `window.open` to determine where to place a view in relation to where it was launched from. An example app `Content Creation Example` demonstrates this in use.
+- Change moved pin/unpin/move-view/move-window actions in to module
 
 ## v15
 

--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -5,7 +5,28 @@
 - Added support for Snap, enable by setting `customSettings.snapProvider.enabled` to true. Configure the `customSettings.snapProvider.serverAssetInfo` to point to the `SNAP_ASSET_URL`. Enable the Snap debugging window by setting `customSettings.snapProvider.showDebugWindow` to true.
 - Added new module type `content-creation`, these modules can be used to define content creation rules and handle the associated events. Modules are added in `customSettings.contentCreationProvider` section in manifest.
 - Added example content creation module which interrogates the `features` property from `window.open` to determine where to place a view in relation to where it was launched from. An example app `Content Creation Example` demonstrates this in use.
-- Change moved pin/unpin/move-view/move-window actions in to module
+- Added CustomActionCallerType enum to actions-shapes, use these in preference to the workspace-platform CustomActionCallerType type to avoid importing the whole npm package into your modules.
+- Change moved pin/unpin/move-view/move-window actions in to module, make sure the following config is in your manifest so this functionality is still available
+
+```json
+{
+   "customSettings": {
+      "actionsProvider": {
+         "modules": [
+            ...
+            {
+               "id": "window-platform",
+               "icon": "http://localhost:8080/favicon.ico",
+               "title": "Window Platform Actions",
+               "description": "Window Platform Actions",
+               "enabled": true,
+               "url": "http://localhost:8080/js/modules/actions/window-platform.bundle.js"
+            }
+         ]
+      }
+   }
+}
+```
 
 ## v15
 

--- a/how-to/workspace-platform-starter/client/src/framework/actions.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/actions.ts
@@ -1,30 +1,25 @@
-import type OpenFin from "@openfin/core";
 import {
 	CustomActionCallerType,
 	getCurrentSync,
-	type BrowserCreateWindowRequest,
 	type CustomActionPayload,
-	type CustomActionSpecifier,
 	type CustomActionsMap
 } from "@openfin/workspace-platform";
-import { toggleNotificationCenter } from "@openfin/workspace/notifications";
 import { getApp } from "./apps";
 import * as authProvider from "./auth";
 import { updateToolbarButtons } from "./buttons";
 import * as favoriteProvider from "./favorite";
 import { launch } from "./launch";
 import { createLogger } from "./logger-provider";
-import { showPopupMenu } from "./menu";
+import * as menuProvider from "./menu";
 import { closedownModules, initializeModules, loadModules } from "./modules";
 import { launchView } from "./platform/browser";
 import type { ActionHelpers, Actions, ActionsProviderOptions } from "./shapes/actions-shapes";
-import type { FavoriteEntry } from "./shapes/favorite-shapes";
-import type { PopupMenuEntry, PopupMenuStyles } from "./shapes/menu-shapes";
 import type { ModuleEntry, ModuleHelpers } from "./shapes/module-shapes";
-import { showShareOptions } from "./share";
-import { toggleScheme } from "./themes";
+import * as shareProvider from "./share";
+import * as themeProvider from "./themes";
 import { isEmpty, isStringValue } from "./utils";
-import { show } from "./workspace/home";
+import * as homeComponent from "./workspace/home";
+import * as notificationsComponent from "./workspace/notifications";
 
 const logger = createLogger("Actions");
 
@@ -37,21 +32,12 @@ let isInitialized: boolean = false;
  * These Ids are for actions built in to the platform.
  */
 export const PLATFORM_ACTION_IDS = {
-	moveViewToNewWindow: "move-view-to-new-window",
-	movePageToNewWindow: "move-page-to-new-window",
-	pinWindow: "pin-window",
-	unpinWindow: "unpin-window",
 	homeShow: "home-show",
 	notificationToggle: "notification-toggle",
-	share: "share",
 	quit: "quit",
 	logoutAndQuit: "logout-and-quit",
 	launchApp: "launch-app",
-	launchView: "launch-view",
-	toggleScheme: "toggle-scheme",
-	favoriteAdd: "favorite-add",
-	favoriteRemove: "favorite-remove",
-	popupMenu: "popup-menu"
+	launchView: "launch-view"
 };
 
 /**
@@ -118,8 +104,20 @@ async function buildActions(): Promise<void> {
 	// Get the platform actions
 	platformActionMap = await getPlatformActions();
 
+	const shareActions = await shareProvider.getPlatformActions();
+	const favoriteActions = await favoriteProvider.getPlatformActions();
+	const menuActions = await menuProvider.getPlatformActions();
+	const themeActions = await themeProvider.getPlatformActions();
+
 	// Merge in any custom actions registered with registerAction
-	platformActionMap = { ...platformActionMap, ...customActionMap };
+	platformActionMap = {
+		...platformActionMap,
+		...shareActions,
+		...favoriteActions,
+		...menuActions,
+		...themeActions,
+		...customActionMap
+	};
 
 	if (!isEmpty(modules)) {
 		// Merge the module actions
@@ -177,118 +175,12 @@ export function registerAction(actionName: string, action: () => Promise<void>):
 async function getPlatformActions(): Promise<CustomActionsMap> {
 	const actionMap: CustomActionsMap = {};
 
-	actionMap[PLATFORM_ACTION_IDS.moveViewToNewWindow] = async (
-		payload: CustomActionPayload
-	): Promise<void> => {
-		if (payload.callerType === CustomActionCallerType.ViewTabContextMenu) {
-			const platform = getCurrentSync();
-			const initialView = await platform.createView({
-				name: payload.selectedViews[0].name
-			} as OpenFin.PlatformViewCreationOptions);
-			if (payload.selectedViews.length > 1) {
-				const windowIdentity = await getViewWindowIdentity(initialView);
-				for (let i = 1; i < payload.selectedViews.length; i++) {
-					await platform.createView(
-						{
-							name: payload.selectedViews[i].name
-						} as OpenFin.PlatformViewCreationOptions,
-						windowIdentity,
-						initialView.identity
-					);
-				}
-			}
-		}
-	};
-
-	actionMap[PLATFORM_ACTION_IDS.movePageToNewWindow] = async (
-		payload: CustomActionPayload
-	): Promise<void> => {
-		if (payload.callerType === CustomActionCallerType.PageTabContextMenu) {
-			const platform = getCurrentSync();
-			const win = platform.Browser.wrapSync(payload.windowIdentity);
-			const page = await win.getPage(payload.pageId);
-			await platform.createWindow({
-				workspacePlatform: {
-					pages: [page]
-				}
-			});
-			await win.removePage(page.pageId);
-		}
-	};
-
-	actionMap[PLATFORM_ACTION_IDS.pinWindow] = async (payload: CustomActionPayload): Promise<void> => {
-		if (payload.callerType === CustomActionCallerType.CustomButton) {
-			const platform = getCurrentSync();
-			const browserWindow = platform.Browser.wrapSync(payload.windowIdentity);
-			const options = await browserWindow.openfinWindow.getOptions();
-			const createRequest: BrowserCreateWindowRequest = options as BrowserCreateWindowRequest;
-			if (createRequest.workspacePlatform.windowType !== "platform") {
-				const currentToolbarOptions = createRequest.workspacePlatform.toolbarOptions;
-				await browserWindow.openfinWindow.updateOptions({ alwaysOnTop: true });
-				if (currentToolbarOptions) {
-					const newButtons = await updateToolbarButtons(
-						currentToolbarOptions.buttons,
-						payload.customData.sourceId as string,
-						payload.customData.replacementId as string
-					);
-					await browserWindow.replaceToolbarOptions({ buttons: newButtons });
-				}
-			}
-		}
-
-		if (payload.callerType === CustomActionCallerType.ViewTabContextMenu) {
-			const platform = getCurrentSync();
-			const browserWindow = platform.Browser.wrapSync(payload.windowIdentity);
-			const options = await browserWindow.openfinWindow.getOptions();
-			const createRequest: BrowserCreateWindowRequest = options as BrowserCreateWindowRequest;
-			if (createRequest.workspacePlatform.windowType !== "platform") {
-				const currentToolbarOptions = createRequest.workspacePlatform.toolbarOptions;
-				await browserWindow.openfinWindow.updateOptions({ alwaysOnTop: true });
-				if (!isEmpty(currentToolbarOptions)) {
-					const newButtons = await updateToolbarButtons(
-						currentToolbarOptions.buttons,
-						payload.customData.sourceId as string,
-						payload.customData.replacementId as string
-					);
-					await browserWindow.replaceToolbarOptions({ buttons: newButtons });
-				}
-			}
-		}
-	};
-
-	actionMap[PLATFORM_ACTION_IDS.unpinWindow] = async (payload: CustomActionPayload): Promise<void> => {
-		if (payload.callerType === CustomActionCallerType.CustomButton) {
-			const platform = getCurrentSync();
-			const browserWindow = platform.Browser.wrapSync(payload.windowIdentity);
-			const options = await browserWindow.openfinWindow.getOptions();
-			const createRequest: BrowserCreateWindowRequest = options as BrowserCreateWindowRequest;
-			if (createRequest.workspacePlatform.windowType !== "platform") {
-				const currentToolbarOptions = createRequest.workspacePlatform.toolbarOptions;
-				await browserWindow.openfinWindow.updateOptions({ alwaysOnTop: false });
-				if (!isEmpty(currentToolbarOptions)) {
-					const newButtons = await updateToolbarButtons(
-						currentToolbarOptions.buttons,
-						payload.customData.sourceId as string,
-						payload.customData.replacementId as string
-					);
-					await browserWindow.replaceToolbarOptions({ buttons: newButtons });
-				}
-			}
-		}
-	};
-
 	actionMap[PLATFORM_ACTION_IDS.homeShow] = async (): Promise<void> => {
-		await show();
+		await homeComponent.show();
 	};
 
 	actionMap[PLATFORM_ACTION_IDS.notificationToggle] = async (): Promise<void> => {
-		await toggleNotificationCenter();
-	};
-
-	actionMap[PLATFORM_ACTION_IDS.share] = async (payload: CustomActionPayload): Promise<void> => {
-		if (payload.callerType === CustomActionCallerType.CustomButton) {
-			await showShareOptions(payload);
-		}
+		await notificationsComponent.toggle();
 	};
 
 	actionMap[PLATFORM_ACTION_IDS.quit] = async (): Promise<void> => {
@@ -335,94 +227,5 @@ async function getPlatformActions(): Promise<CustomActionsMap> {
 		}
 	};
 
-	actionMap[PLATFORM_ACTION_IDS.toggleScheme] = async (payload: CustomActionPayload): Promise<void> => {
-		if (
-			payload.callerType === CustomActionCallerType.CustomButton ||
-			payload.callerType === CustomActionCallerType.CustomDropdownItem
-		) {
-			await toggleScheme();
-		}
-	};
-
-	actionMap[PLATFORM_ACTION_IDS.favoriteAdd] = async (payload: CustomActionPayload): Promise<void> => {
-		if (
-			payload.callerType === CustomActionCallerType.CustomButton ||
-			payload.callerType === CustomActionCallerType.StoreCustomButton
-		) {
-			const favorite: FavoriteEntry = payload.customData;
-			if (isEmpty(favorite)) {
-				logger.error("Can only add to favorites if favorite data is provided in customData");
-			} else {
-				await favoriteProvider.setSavedFavorite(favorite);
-			}
-		}
-	};
-
-	actionMap[PLATFORM_ACTION_IDS.favoriteRemove] = async (payload: CustomActionPayload): Promise<void> => {
-		if (
-			payload.callerType === CustomActionCallerType.CustomButton ||
-			payload.callerType === CustomActionCallerType.StoreCustomButton
-		) {
-			const favorite: FavoriteEntry = payload.customData;
-			if (isEmpty(favorite)) {
-				logger.error("Can only remove from favorites if favorite data is provided in customData");
-			} else {
-				await favoriteProvider.deleteSavedFavorite(favorite.id);
-			}
-		}
-	};
-
-	actionMap[PLATFORM_ACTION_IDS.popupMenu] = async (payload: CustomActionPayload): Promise<void> => {
-		if (payload.callerType === CustomActionCallerType.CustomButton) {
-			const menuOptions: {
-				source: "dock";
-				noEntryText: string;
-				menuEntries: PopupMenuEntry<CustomActionSpecifier>[];
-				options?: {
-					popupMenuStyle?: PopupMenuStyles;
-				};
-			} = payload.customData;
-
-			const res = await showPopupMenu(
-				menuOptions.source === "dock" ? { x: payload.x, y: 48 } : { x: payload.x, y: payload.y },
-				payload.windowIdentity,
-				menuOptions.noEntryText,
-				menuOptions.menuEntries,
-				menuOptions.options
-			);
-
-			if (!isEmpty(res)) {
-				await callAction(res.id, {
-					...payload,
-					customData: res.customData
-				});
-			}
-		}
-	};
-
 	return actionMap;
-}
-
-/**
- * Get the identity of the window containing a view.
- * @param view The view to get the containing window identity.
- * @returns The identity of the containing window.
- */
-async function getViewWindowIdentity(view: OpenFin.View): Promise<OpenFin.Identity> {
-	const currentWindow = await view.getCurrentWindow();
-
-	// If the view does is not yet attached to a window, wait for the
-	// target-changed even which means it has been attached
-	if (isEmpty(currentWindow.identity.name) || currentWindow.identity.name === fin.me.identity.uuid) {
-		return new Promise<OpenFin.Identity>((resolve, reject) => {
-			view
-				.once("target-changed", async () => {
-					const hostWindow = await view.getCurrentWindow();
-					resolve(hostWindow.identity);
-				})
-				.catch(() => {});
-		});
-	}
-
-	return currentWindow.identity;
 }

--- a/how-to/workspace-platform-starter/client/src/framework/bootstrapper.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/bootstrapper.ts
@@ -4,7 +4,7 @@ import * as analyticsProvider from "./analytics";
 import { getApps } from "./apps";
 import * as authProvider from "./auth";
 import { isAuthenticationEnabled } from "./auth";
-import { registerAction } from "./connections";
+import * as connectionProvider from "./connections";
 import { init as registerInitOptionsListener } from "./init-options";
 import { closedown as deregisterIntegration, init as registerIntegration } from "./integrations";
 import { launch } from "./launch";
@@ -77,7 +77,7 @@ export async function init(): Promise<boolean> {
 				clientAPIVersion: homeRegistration.clientAPIVersion
 			};
 			registeredComponents.push("home");
-			registerHomeSupportedActions();
+			registerHomeConnectionActions();
 		}
 	}
 
@@ -90,7 +90,7 @@ export async function init(): Promise<boolean> {
 				workspaceMetaInfo = storeRegistration;
 			}
 			registeredComponents.push("store");
-			registerStoreSupportedActions();
+			registerStoreConnectionActions();
 		}
 	}
 
@@ -103,7 +103,7 @@ export async function init(): Promise<boolean> {
 				workspaceMetaInfo = dockRegistration;
 			}
 			registeredComponents.push("dock");
-			registerDockSupportedActions();
+			registerDockConnectionActions();
 		}
 	}
 
@@ -118,7 +118,7 @@ export async function init(): Promise<boolean> {
 		await platformSplashProvider.updateProgress("Notifications");
 
 		notificationMetaInfo = await notificationsComponent.register(customSettings.notificationProvider);
-		registerNotificationSupportedActions();
+		registerNotificationConnectionActions();
 	}
 
 	if (!isEmpty(notificationMetaInfo)) {
@@ -160,7 +160,7 @@ export async function init(): Promise<boolean> {
 	await lowCodeIntegrationProvider.initializeWorkflows();
 	if (lowCodeIntegrationProvider.hasRegisteredIntegrations() && !registeredComponents.includes("home")) {
 		registeredComponents.push("home");
-		registerHomeSupportedActions();
+		registerHomeConnectionActions();
 	}
 
 	logger.info("Validating auto show list:", bootstrapOptions.autoShow);
@@ -295,11 +295,11 @@ async function deregister(): Promise<void> {
 /**
  * Used to register home related actions.
  */
-function registerHomeSupportedActions(): void {
-	registerAction("show-home", async () => {
+function registerHomeConnectionActions(): void {
+	connectionProvider.registerAction("show-home", async () => {
 		await homeComponent.show();
 	});
-	registerAction("hide-home", async () => {
+	connectionProvider.registerAction("hide-home", async () => {
 		await homeComponent.hide();
 	});
 }
@@ -307,11 +307,11 @@ function registerHomeSupportedActions(): void {
 /**
  * Used to register store related actions.
  */
-function registerStoreSupportedActions(): void {
-	registerAction("show-store", async () => {
+function registerStoreConnectionActions(): void {
+	connectionProvider.registerAction("show-store", async () => {
 		await storeComponent.show();
 	});
-	registerAction("hide-store", async () => {
+	connectionProvider.registerAction("hide-store", async () => {
 		await storeComponent.hide();
 	});
 }
@@ -319,11 +319,11 @@ function registerStoreSupportedActions(): void {
 /**
  * Used to register dock related actions.
  */
-function registerDockSupportedActions(): void {
-	registerAction("show-dock", async () => {
+function registerDockConnectionActions(): void {
+	connectionProvider.registerAction("show-dock", async () => {
 		await dockComponent.show();
 	});
-	registerAction("minimize-dock", async () => {
+	connectionProvider.registerAction("minimize-dock", async () => {
 		await dockComponent.minimize();
 	});
 }
@@ -331,11 +331,11 @@ function registerDockSupportedActions(): void {
 /**
  * Used to register notification related actions.
  */
-function registerNotificationSupportedActions(): void {
-	registerAction("show-notifications", async () => {
+function registerNotificationConnectionActions(): void {
+	connectionProvider.registerAction("show-notifications", async () => {
 		await notificationsComponent.show();
 	});
-	registerAction("hide-notifications", async () => {
+	connectionProvider.registerAction("hide-notifications", async () => {
 		await notificationsComponent.hide();
 	});
 }

--- a/how-to/workspace-platform-starter/client/src/framework/favorite.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/favorite.ts
@@ -1,4 +1,9 @@
-import { getCurrentSync } from "@openfin/workspace-platform";
+import {
+	CustomActionCallerType,
+	getCurrentSync,
+	type CustomActionPayload,
+	type CustomActionsMap
+} from "@openfin/workspace-platform";
 import * as conditionsProvider from "./conditions";
 import { fireLifecycleEvent } from "./lifecycle";
 import { createLogger } from "./logger-provider";
@@ -243,4 +248,42 @@ export function getInfo(): FavoriteInfo {
 		command: favoriteOptions.favoriteCommand,
 		enabledTypes: favoriteOptions.supportedFavoriteTypes
 	};
+}
+
+/**
+ * Get the inbuilt actions for the platform.
+ * @returns The map of platform actions.
+ */
+export async function getPlatformActions(): Promise<CustomActionsMap> {
+	const actionMap: CustomActionsMap = {};
+
+	actionMap["favorite-add"] = async (payload: CustomActionPayload): Promise<void> => {
+		if (
+			payload.callerType === CustomActionCallerType.CustomButton ||
+			payload.callerType === CustomActionCallerType.StoreCustomButton
+		) {
+			const favorite: FavoriteEntry = payload.customData;
+			if (isEmpty(favorite)) {
+				logger.error("Can only add to favorites if favorite data is provided in customData");
+			} else {
+				await setSavedFavorite(favorite);
+			}
+		}
+	};
+
+	actionMap["favorite-remove"] = async (payload: CustomActionPayload): Promise<void> => {
+		if (
+			payload.callerType === CustomActionCallerType.CustomButton ||
+			payload.callerType === CustomActionCallerType.StoreCustomButton
+		) {
+			const favorite: FavoriteEntry = payload.customData;
+			if (isEmpty(favorite)) {
+				logger.error("Can only remove from favorites if favorite data is provided in customData");
+			} else {
+				await deleteSavedFavorite(favorite.id);
+			}
+		}
+	};
+
+	return actionMap;
 }

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/actions-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/actions-shapes.ts
@@ -35,3 +35,17 @@ export interface ActionHelpers extends ModuleHelpers {
 		replacementButtonId: string
 	) => Promise<ToolbarButton[]>;
 }
+
+/**
+ * Use this in preference to CustomActionCallerType from workspace-platform to avoid the import of the whole of workspace package in modules.
+ */
+export enum CustomActionCallerType {
+	CustomButton = "CustomButton",
+	StoreCustomButton = "StoreCustomButton",
+	CustomDropdownItem = "CustomDropdownItem",
+	GlobalContextMenu = "GlobalContextMenu",
+	ViewTabContextMenu = "ViewTabContextMenu",
+	PageTabContextMenu = "PageTabContextMenu",
+	SaveButtonContextMenu = "SaveButtonContextMenu",
+	API = "API"
+}

--- a/how-to/workspace-platform-starter/client/src/framework/themes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/themes.ts
@@ -1,6 +1,6 @@
 import type OpenFin from "@openfin/core";
-import type { CustomPaletteSet } from "@openfin/workspace-platform";
-import { ColorSchemeOptionType, getCurrentSync } from "@openfin/workspace-platform";
+import type { CustomActionPayload, CustomActionsMap, CustomPaletteSet } from "@openfin/workspace-platform";
+import { ColorSchemeOptionType, CustomActionCallerType, getCurrentSync } from "@openfin/workspace-platform";
 import { DEFAULT_PALETTES } from "./default-palettes";
 import { fireLifecycleEvent } from "./lifecycle";
 import { createLogger } from "./logger-provider";
@@ -373,4 +373,23 @@ export function themeUrl(
 	colorScheme: ColorSchemeMode
 ): string | undefined {
 	return url ? url.replace(/{theme}/g, iconFolder).replace(/{scheme}/g, colorScheme as string) : undefined;
+}
+
+/**
+ * Get the inbuilt actions for the platform.
+ * @returns The map of platform actions.
+ */
+export async function getPlatformActions(): Promise<CustomActionsMap> {
+	const actionMap: CustomActionsMap = {};
+
+	actionMap["toggle-scheme"] = async (payload: CustomActionPayload): Promise<void> => {
+		if (
+			payload.callerType === CustomActionCallerType.CustomButton ||
+			payload.callerType === CustomActionCallerType.CustomDropdownItem
+		) {
+			await toggleScheme();
+		}
+	};
+
+	return actionMap;
 }

--- a/how-to/workspace-platform-starter/client/src/framework/workspace/dock.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/workspace/dock.ts
@@ -663,7 +663,7 @@ async function addDropdownOrMenu(
 		tooltip,
 		iconUrl,
 		action: {
-			id: PLATFORM_ACTION_IDS.popupMenu,
+			id: "popup-menu",
 			customData: {
 				source: "dock",
 				noEntryText: "No Entries",

--- a/how-to/workspace-platform-starter/client/src/framework/workspace/notifications.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/workspace/notifications.ts
@@ -123,6 +123,15 @@ export async function hide(): Promise<void> {
 }
 
 /**
+ * Toggle the notification center.
+ * @returns Nothing.
+ */
+export async function toggle(): Promise<void> {
+	logger.info("Toggle Notifications called.");
+	return Notifications.toggleNotificationCenter();
+}
+
+/**
  * Returns a restricted notification client that helps isolate the notifications that
  * can be read, updated and cleared by a client inside of a platform.
  * @param options The options to help with the client restriction.

--- a/how-to/workspace-platform-starter/client/src/framework/workspace/store.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/workspace/store.ts
@@ -581,7 +581,7 @@ function calculateButtons(
 		appSecondaryButtons.push({
 			title: favoriteEntry ? "Remove Favorite" : "Add Favorite",
 			action: {
-				id: favoriteEntry ? PLATFORM_ACTION_IDS.favoriteRemove : PLATFORM_ACTION_IDS.favoriteAdd,
+				id: favoriteEntry ? "favorite-remove" : "favorite-add",
 				customData: favoriteEntry ?? {
 					id: randomUUID(),
 					type: FAVORITE_TYPE_NAME_APP,

--- a/how-to/workspace-platform-starter/client/src/modules/actions/custom-menu/actions.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/actions/custom-menu/actions.ts
@@ -1,12 +1,11 @@
-import {
-	CustomActionCallerType,
-	type CustomActionPayload,
-	type CustomActionsMap,
-	type Page,
-	type Workspace,
-	type WorkspacePlatformModule
+import type {
+	CustomActionPayload,
+	CustomActionsMap,
+	Page,
+	Workspace,
+	WorkspacePlatformModule
 } from "@openfin/workspace-platform";
-import type { Actions } from "workspace-platform-starter/shapes/actions-shapes";
+import { CustomActionCallerType, type Actions } from "workspace-platform-starter/shapes/actions-shapes";
 import type { Logger, LoggerCreator } from "workspace-platform-starter/shapes/logger-shapes";
 import type { ModuleDefinition, ModuleHelpers } from "workspace-platform-starter/shapes/module-shapes";
 import { isEmpty } from "workspace-platform-starter/utils";

--- a/how-to/workspace-platform-starter/client/src/modules/actions/favorites-menu/actions.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/actions/favorites-menu/actions.ts
@@ -1,10 +1,9 @@
-import {
-	CustomActionCallerType,
-	type CustomActionPayload,
-	type CustomActionsMap,
-	type WorkspacePlatformModule
+import type {
+	CustomActionPayload,
+	CustomActionsMap,
+	WorkspacePlatformModule
 } from "@openfin/workspace-platform";
-import type { Actions } from "workspace-platform-starter/shapes/actions-shapes";
+import { CustomActionCallerType, type Actions } from "workspace-platform-starter/shapes/actions-shapes";
 import {
 	FAVORITE_TYPE_NAME_APP,
 	FAVORITE_TYPE_NAME_PAGE,
@@ -72,7 +71,7 @@ export class FavoritesMenuProvider implements Actions<FavoritesMenuSettings> {
 				if (!isEmpty(getClient)) {
 					const client = await getClient();
 					if (!isEmpty(client)) {
-						const favInfo = await client.getInfo();
+						const favInfo = client.getInfo();
 						const menuEntries: PopupMenuEntry<FavoriteEntry>[] = [];
 
 						if (favInfo.enabledTypes) {
@@ -84,9 +83,9 @@ export class FavoritesMenuProvider implements Actions<FavoritesMenuSettings> {
 										menuEntries.push({ type: "separator" });
 									}
 
-									for (const entry of saved.sort((f1, f2) =>
-										(f1.label ?? "").localeCompare(f2.label ?? "")
-									)) {
+									saved.sort((f1, f2) => (f1.label ?? "").localeCompare(f2.label ?? ""));
+
+									for (const entry of saved) {
 										menuEntries.push({
 											label: entry.label ?? "",
 											icon: entry.icon,

--- a/how-to/workspace-platform-starter/client/src/modules/actions/opacity/actions.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/actions/opacity/actions.ts
@@ -1,11 +1,14 @@
+import type {
+	BrowserCreateWindowRequest,
+	CustomActionPayload,
+	CustomActionsMap,
+	WorkspacePlatformModule
+} from "@openfin/workspace-platform";
 import {
 	CustomActionCallerType,
-	type BrowserCreateWindowRequest,
-	type CustomActionPayload,
-	type CustomActionsMap,
-	type WorkspacePlatformModule
-} from "@openfin/workspace-platform";
-import type { ActionHelpers, Actions } from "workspace-platform-starter/shapes/actions-shapes";
+	type ActionHelpers,
+	type Actions
+} from "workspace-platform-starter/shapes/actions-shapes";
 import type { Logger, LoggerCreator } from "workspace-platform-starter/shapes/logger-shapes";
 import type { ModuleDefinition } from "workspace-platform-starter/shapes/module-shapes";
 import { isEmpty } from "workspace-platform-starter/utils";

--- a/how-to/workspace-platform-starter/client/src/modules/actions/window-actions/actions.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/actions/window-actions/actions.ts
@@ -1,0 +1,157 @@
+import type OpenFin from "@openfin/core";
+import {
+	CustomActionCallerType,
+	type BrowserCreateWindowRequest,
+	type CustomActionPayload,
+	type CustomActionsMap,
+	type WorkspacePlatformModule
+} from "@openfin/workspace-platform";
+import type { ActionHelpers, Actions } from "workspace-platform-starter/shapes/actions-shapes";
+import type { Logger, LoggerCreator } from "workspace-platform-starter/shapes/logger-shapes";
+import type { ModuleDefinition } from "workspace-platform-starter/shapes/module-shapes";
+import { isEmpty } from "workspace-platform-starter/utils";
+
+/**
+ * Implementation for the window actions provider.
+ */
+export class WindowActionsProvider implements Actions {
+	/**
+	 * The logger for displaying information from the module.
+	 * @internal
+	 */
+	private _logger?: Logger;
+
+	/**
+	 * Helper methods for the module.
+	 * @internal
+	 */
+	private _helpers: ActionHelpers | undefined;
+
+	/**
+	 * Initialize the module.
+	 * @param definition The definition of the module from configuration include custom options.
+	 * @param loggerCreator For logging entries.
+	 * @param helpers Helper methods for the module to interact with the application core.
+	 * @returns Nothing.
+	 */
+	public async initialize(
+		definition: ModuleDefinition,
+		loggerCreator: LoggerCreator,
+		helpers: ActionHelpers
+	): Promise<void> {
+		this._logger = loggerCreator("WindowActionsProvider");
+		this._helpers = helpers;
+
+		this._logger.info("Initializing");
+	}
+
+	/**
+	 * Get the actions from the module.
+	 * @param platform The platform module.
+	 * @returns The map of custom actions.
+	 */
+	public async get(platform: WorkspacePlatformModule): Promise<CustomActionsMap> {
+		const actionMap: CustomActionsMap = {};
+
+		actionMap["pin-window"] = async (payload: CustomActionPayload): Promise<void> => {
+			await this.pinUnpin(platform, payload, true);
+		};
+
+		actionMap["unpin-window"] = async (payload: CustomActionPayload): Promise<void> => {
+			await this.pinUnpin(platform, payload, false);
+		};
+
+		actionMap["move-view-to-new-window"] = async (payload: CustomActionPayload): Promise<void> => {
+			if (payload.callerType === CustomActionCallerType.ViewTabContextMenu) {
+				const initialView = await platform.createView({
+					name: payload.selectedViews[0].name
+				} as OpenFin.PlatformViewCreationOptions);
+				if (payload.selectedViews.length > 1) {
+					const windowIdentity = await this.getViewWindowIdentity(initialView);
+					for (let i = 1; i < payload.selectedViews.length; i++) {
+						await platform.createView(
+							{
+								name: payload.selectedViews[i].name
+							} as OpenFin.PlatformViewCreationOptions,
+							windowIdentity,
+							initialView.identity
+						);
+					}
+				}
+			}
+		};
+
+		actionMap["move-page-to-new-window"] = async (payload: CustomActionPayload): Promise<void> => {
+			if (payload.callerType === CustomActionCallerType.PageTabContextMenu) {
+				const win = platform.Browser.wrapSync(payload.windowIdentity);
+				const page = await win.getPage(payload.pageId);
+				await platform.createWindow({
+					workspacePlatform: {
+						pages: [page]
+					}
+				});
+				await win.removePage(page.pageId);
+			}
+		};
+
+		return actionMap;
+	}
+
+	/**
+	 * Pin or unpin the window.
+	 * @param platform The platform.
+	 * @param payload The payload for the action.
+	 * @param alwaysOnTop Should the window be always on top.
+	 */
+	private async pinUnpin(
+		platform: WorkspacePlatformModule,
+		payload: CustomActionPayload,
+		alwaysOnTop: boolean
+	): Promise<void> {
+		if (
+			!isEmpty(this._helpers) &&
+			(payload.callerType === CustomActionCallerType.CustomButton ||
+				payload.callerType === CustomActionCallerType.ViewTabContextMenu)
+		) {
+			const browserWindow = platform.Browser.wrapSync(payload.windowIdentity);
+			const options = await browserWindow.openfinWindow.getOptions();
+			const createRequest: BrowserCreateWindowRequest = options as BrowserCreateWindowRequest;
+			if (createRequest.workspacePlatform.windowType !== "platform") {
+				const currentToolbarOptions = createRequest.workspacePlatform.toolbarOptions;
+				await browserWindow.openfinWindow.updateOptions({ alwaysOnTop });
+				if (!isEmpty(currentToolbarOptions)) {
+					const newButtons = await this._helpers.updateToolbarButtons(
+						currentToolbarOptions.buttons,
+						payload.customData.sourceId as string,
+						payload.customData.replacementId as string
+					);
+					await browserWindow.replaceToolbarOptions({ buttons: newButtons });
+				}
+			}
+		}
+	}
+
+	/**
+	 * Get the identity of the window containing a view.
+	 * @param view The view to get the containing window identity.
+	 * @returns The identity of the containing window.
+	 */
+	private async getViewWindowIdentity(view: OpenFin.View): Promise<OpenFin.Identity> {
+		const currentWindow = await view.getCurrentWindow();
+
+		// If the view does is not yet attached to a window, wait for the
+		// target-changed even which means it has been attached
+		if (isEmpty(currentWindow.identity.name) || currentWindow.identity.name === fin.me.identity.uuid) {
+			return new Promise<OpenFin.Identity>((resolve, reject) => {
+				view
+					.once("target-changed", async () => {
+						const hostWindow = await view.getCurrentWindow();
+						resolve(hostWindow.identity);
+					})
+					.catch(() => {});
+			});
+		}
+
+		return currentWindow.identity;
+	}
+}

--- a/how-to/workspace-platform-starter/client/src/modules/actions/window-actions/index.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/actions/window-actions/index.ts
@@ -1,0 +1,9 @@
+import type { ModuleImplementation, ModuleTypes } from "workspace-platform-starter/shapes/module-shapes";
+import { WindowActionsProvider } from "./actions";
+
+/**
+ * Define the entry points for the module.
+ */
+export const entryPoints: { [type in ModuleTypes]?: ModuleImplementation } = {
+	actions: new WindowActionsProvider()
+};

--- a/how-to/workspace-platform-starter/client/src/modules/actions/window-platform/actions.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/actions/window-platform/actions.ts
@@ -1,20 +1,23 @@
 import type OpenFin from "@openfin/core";
+import type {
+	BrowserCreateWindowRequest,
+	CustomActionPayload,
+	CustomActionsMap,
+	WorkspacePlatformModule
+} from "@openfin/workspace-platform";
 import {
 	CustomActionCallerType,
-	type BrowserCreateWindowRequest,
-	type CustomActionPayload,
-	type CustomActionsMap,
-	type WorkspacePlatformModule
-} from "@openfin/workspace-platform";
-import type { ActionHelpers, Actions } from "workspace-platform-starter/shapes/actions-shapes";
+	type ActionHelpers,
+	type Actions
+} from "workspace-platform-starter/shapes/actions-shapes";
 import type { Logger, LoggerCreator } from "workspace-platform-starter/shapes/logger-shapes";
 import type { ModuleDefinition } from "workspace-platform-starter/shapes/module-shapes";
 import { isEmpty } from "workspace-platform-starter/utils";
 
 /**
- * Implementation for the window actions provider.
+ * Implementation for the window platform actions provider.
  */
-export class WindowActionsProvider implements Actions {
+export class WindowPlatformActionsProvider implements Actions {
 	/**
 	 * The logger for displaying information from the module.
 	 * @internal
@@ -39,7 +42,7 @@ export class WindowActionsProvider implements Actions {
 		loggerCreator: LoggerCreator,
 		helpers: ActionHelpers
 	): Promise<void> {
-		this._logger = loggerCreator("WindowActionsProvider");
+		this._logger = loggerCreator("WindowPlatformActionsProvider");
 		this._helpers = helpers;
 
 		this._logger.info("Initializing");

--- a/how-to/workspace-platform-starter/client/src/modules/actions/window-platform/index.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/actions/window-platform/index.ts
@@ -1,9 +1,9 @@
 import type { ModuleImplementation, ModuleTypes } from "workspace-platform-starter/shapes/module-shapes";
-import { WindowActionsProvider } from "./actions";
+import { WindowPlatformActionsProvider } from "./actions";
 
 /**
  * Define the entry points for the module.
  */
 export const entryPoints: { [type in ModuleTypes]?: ModuleImplementation } = {
-	actions: new WindowActionsProvider()
+	actions: new WindowPlatformActionsProvider()
 };

--- a/how-to/workspace-platform-starter/client/src/modules/composite/about/actions.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/composite/about/actions.ts
@@ -1,11 +1,14 @@
 import type OpenFin from "@openfin/core";
+import type {
+	CustomActionPayload,
+	CustomActionsMap,
+	WorkspacePlatformModule
+} from "@openfin/workspace-platform";
 import {
 	CustomActionCallerType,
-	type CustomActionPayload,
-	type CustomActionsMap,
-	type WorkspacePlatformModule
-} from "@openfin/workspace-platform";
-import type { ActionHelpers, Actions } from "workspace-platform-starter/shapes/actions-shapes";
+	type ActionHelpers,
+	type Actions
+} from "workspace-platform-starter/shapes/actions-shapes";
 import type { Logger, LoggerCreator } from "workspace-platform-starter/shapes/logger-shapes";
 import type { ModuleDefinition } from "workspace-platform-starter/shapes/module-shapes";
 import { isEmpty } from "workspace-platform-starter/utils";

--- a/how-to/workspace-platform-starter/client/src/modules/composite/default-workspace/actions.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/composite/default-workspace/actions.ts
@@ -1,10 +1,13 @@
+import type {
+	CustomActionPayload,
+	CustomActionsMap,
+	WorkspacePlatformModule
+} from "@openfin/workspace-platform";
 import {
 	CustomActionCallerType,
-	type CustomActionPayload,
-	type CustomActionsMap,
-	type WorkspacePlatformModule
-} from "@openfin/workspace-platform";
-import type { ActionHelpers, Actions } from "workspace-platform-starter/shapes/actions-shapes";
+	type ActionHelpers,
+	type Actions
+} from "workspace-platform-starter/shapes/actions-shapes";
 import type { Logger, LoggerCreator } from "workspace-platform-starter/shapes/logger-shapes";
 import type { ModuleDefinition } from "workspace-platform-starter/shapes/module-shapes";
 import { isEmpty } from "workspace-platform-starter/utils";

--- a/how-to/workspace-platform-starter/client/src/modules/composite/developer/actions.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/composite/developer/actions.ts
@@ -1,11 +1,14 @@
 import type OpenFin from "@openfin/core";
+import type {
+	CustomActionPayload,
+	CustomActionsMap,
+	WorkspacePlatformModule
+} from "@openfin/workspace-platform";
 import {
 	CustomActionCallerType,
-	type CustomActionPayload,
-	type CustomActionsMap,
-	type WorkspacePlatformModule
-} from "@openfin/workspace-platform";
-import type { ActionHelpers, Actions } from "workspace-platform-starter/shapes/actions-shapes";
+	type ActionHelpers,
+	type Actions
+} from "workspace-platform-starter/shapes/actions-shapes";
 import type { Logger, LoggerCreator } from "workspace-platform-starter/shapes/logger-shapes";
 import type { ModuleDefinition } from "workspace-platform-starter/shapes/module-shapes";
 import { isStringValue } from "workspace-platform-starter/utils";

--- a/how-to/workspace-platform-starter/client/src/modules/composite/include-in-snapshot/actions.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/composite/include-in-snapshot/actions.ts
@@ -1,11 +1,14 @@
+import type {
+	BrowserCreateWindowRequest,
+	CustomActionPayload,
+	CustomActionsMap,
+	WorkspacePlatformModule
+} from "@openfin/workspace-platform";
 import {
 	CustomActionCallerType,
-	type BrowserCreateWindowRequest,
-	type CustomActionPayload,
-	type CustomActionsMap,
-	type WorkspacePlatformModule
-} from "@openfin/workspace-platform";
-import type { ActionHelpers, Actions } from "workspace-platform-starter/shapes/actions-shapes";
+	type ActionHelpers,
+	type Actions
+} from "workspace-platform-starter/shapes/actions-shapes";
 import type { Logger, LoggerCreator } from "workspace-platform-starter/shapes/logger-shapes";
 import type { ModuleDefinition } from "workspace-platform-starter/shapes/module-shapes";
 import { isEmpty } from "workspace-platform-starter/utils";

--- a/how-to/workspace-platform-starter/client/src/modules/composite/pages/actions.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/composite/pages/actions.ts
@@ -1,11 +1,14 @@
 import type OpenFin from "@openfin/core";
+import type {
+	CustomActionPayload,
+	CustomActionsMap,
+	WorkspacePlatformModule
+} from "@openfin/workspace-platform";
 import {
 	CustomActionCallerType,
-	type CustomActionPayload,
-	type CustomActionsMap,
-	type WorkspacePlatformModule
-} from "@openfin/workspace-platform";
-import type { ActionHelpers, Actions } from "workspace-platform-starter/shapes/actions-shapes";
+	type ActionHelpers,
+	type Actions
+} from "workspace-platform-starter/shapes/actions-shapes";
 import type { Logger, LoggerCreator } from "workspace-platform-starter/shapes/logger-shapes";
 import type { ModuleDefinition } from "workspace-platform-starter/shapes/module-shapes";
 import { isEmpty } from "workspace-platform-starter/utils";

--- a/how-to/workspace-platform-starter/client/src/modules/composite/windows/actions.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/composite/windows/actions.ts
@@ -1,11 +1,14 @@
 import type OpenFin from "@openfin/core";
+import type {
+	CustomActionPayload,
+	CustomActionsMap,
+	WorkspacePlatformModule
+} from "@openfin/workspace-platform";
 import {
 	CustomActionCallerType,
-	type CustomActionPayload,
-	type CustomActionsMap,
-	type WorkspacePlatformModule
-} from "@openfin/workspace-platform";
-import type { ActionHelpers, Actions } from "workspace-platform-starter/shapes/actions-shapes";
+	type ActionHelpers,
+	type Actions
+} from "workspace-platform-starter/shapes/actions-shapes";
 import type { Logger, LoggerCreator } from "workspace-platform-starter/shapes/logger-shapes";
 import type { ModuleDefinition } from "workspace-platform-starter/shapes/module-shapes";
 import { isEmpty } from "workspace-platform-starter/utils";

--- a/how-to/workspace-platform-starter/client/src/modules/integrations/emoji/integration.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/integrations/emoji/integration.ts
@@ -11,7 +11,6 @@ import type {
 } from "@openfin/workspace";
 import type { CustomPaletteSet } from "@openfin/workspace-platform";
 import * as emoji from "node-emoji";
-import type { TemplateHelpers } from "workspace-platform-starter/shapes";
 import type {
 	IntegrationHelpers,
 	IntegrationModule,
@@ -19,6 +18,7 @@ import type {
 } from "workspace-platform-starter/shapes/integrations-shapes";
 import type { LoggerCreator } from "workspace-platform-starter/shapes/logger-shapes";
 import type { ModuleDefinition } from "workspace-platform-starter/shapes/module-shapes";
+import type { TemplateHelpers } from "workspace-platform-starter/shapes/template-shapes";
 
 /**
  * Implement the integration provider for Emojis.

--- a/how-to/workspace-platform-starter/client/src/modules/integrations/quote/integration.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/integrations/quote/integration.ts
@@ -20,7 +20,6 @@ import {
 	TimeScale
 } from "chart.js";
 import { DateTime } from "luxon";
-import type { TemplateHelpers } from "workspace-platform-starter/shapes";
 import type {
 	IntegrationHelpers,
 	IntegrationModule,
@@ -28,6 +27,7 @@ import type {
 } from "workspace-platform-starter/shapes/integrations-shapes";
 import type { LoggerCreator } from "workspace-platform-starter/shapes/logger-shapes";
 import type { ModuleDefinition } from "workspace-platform-starter/shapes/module-shapes";
+import type { TemplateHelpers } from "workspace-platform-starter/shapes/template-shapes";
 import { isEmpty } from "workspace-platform-starter/utils";
 import type { QuoteResult, QuoteSettings } from "./shapes";
 

--- a/how-to/workspace-platform-starter/client/types/module/shapes/actions-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/actions-shapes.d.ts
@@ -32,3 +32,16 @@ export interface ActionHelpers extends ModuleHelpers {
 		replacementButtonId: string
 	) => Promise<ToolbarButton[]>;
 }
+/**
+ * Use this in preference to CustomActionCallerType from workspace-platform to avoid the import of the whole of workspace package in modules.
+ */
+export declare enum CustomActionCallerType {
+	CustomButton = "CustomButton",
+	StoreCustomButton = "StoreCustomButton",
+	CustomDropdownItem = "CustomDropdownItem",
+	GlobalContextMenu = "GlobalContextMenu",
+	ViewTabContextMenu = "ViewTabContextMenu",
+	PageTabContextMenu = "PageTabContextMenu",
+	SaveButtonContextMenu = "SaveButtonContextMenu",
+	API = "API"
+}

--- a/how-to/workspace-platform-starter/client/webpack.config.js
+++ b/how-to/workspace-platform-starter/client/webpack.config.js
@@ -847,6 +847,34 @@ const configs = [
 		}
 	},
 	{
+		entry: './client/src/modules/composite/default-workspace/index.ts',
+		devtool: 'inline-source-map',
+		module: {
+			rules: [
+				{
+					test: /\.tsx?$/,
+					use: 'ts-loader',
+					exclude: /node_modules/
+				}
+			]
+		},
+		resolve: {
+			extensions: ['.tsx', '.ts', '.js'],
+			alias
+		},
+		externals: { fin: 'fin' },
+		output: {
+			filename: 'default-workspace.bundle.js',
+			library: {
+				type: 'module'
+			},
+			path: path.resolve(__dirname, '..', 'public', 'js', 'modules', 'composite')
+		},
+		experiments: {
+			outputModule: true
+		}
+	},
+	{
 		entry: './client/src/modules/content-creation/view-position/index.ts',
 		devtool: 'inline-source-map',
 		module: {
@@ -875,7 +903,7 @@ const configs = [
 		}
 	},
 	{
-		entry: './client/src/modules/actions/window-actions/index.ts',
+		entry: './client/src/modules/actions/window-platform/index.ts',
 		devtool: 'inline-source-map',
 		module: {
 			rules: [
@@ -892,7 +920,7 @@ const configs = [
 		},
 		externals: { fin: 'fin' },
 		output: {
-			filename: 'window-actions.bundle.js',
+			filename: 'window-platform.bundle.js',
 			library: {
 				type: 'module'
 			},

--- a/how-to/workspace-platform-starter/client/webpack.config.js
+++ b/how-to/workspace-platform-starter/client/webpack.config.js
@@ -873,6 +873,34 @@ const configs = [
 		experiments: {
 			outputModule: true
 		}
+	},
+	{
+		entry: './client/src/modules/actions/window-actions/index.ts',
+		devtool: 'inline-source-map',
+		module: {
+			rules: [
+				{
+					test: /\.tsx?$/,
+					use: 'ts-loader',
+					exclude: /node_modules/
+				}
+			]
+		},
+		resolve: {
+			extensions: ['.tsx', '.ts', '.js'],
+			alias
+		},
+		externals: { fin: 'fin' },
+		output: {
+			filename: 'window-actions.bundle.js',
+			library: {
+				type: 'module'
+			},
+			path: path.resolve(__dirname, '..', 'public', 'js', 'modules', 'actions')
+		},
+		experiments: {
+			outputModule: true
+		}
 	}
 ];
 

--- a/how-to/workspace-platform-starter/public/manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/manifest.fin.json
@@ -1295,6 +1295,14 @@
 					"description": "Allows the setting of a default workspace and whether or not it should be set when an active workspace is switched.",
 					"enabled": true,
 					"url": "http://localhost:8080/js/modules/composite/default-workspace.bundle.js"
+				},
+				{
+					"id": "window-actions",
+					"icon": "http://localhost:8080/favicon.ico",
+					"title": "Window Actions",
+					"description": "Window Actions",
+					"enabled": true,
+					"url": "http://localhost:8080/js/modules/actions/window-actions.bundle.js"
 				}
 			]
 		},

--- a/how-to/workspace-platform-starter/public/manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/manifest.fin.json
@@ -1297,12 +1297,12 @@
 					"url": "http://localhost:8080/js/modules/composite/default-workspace.bundle.js"
 				},
 				{
-					"id": "window-actions",
+					"id": "window-platform",
 					"icon": "http://localhost:8080/favicon.ico",
-					"title": "Window Actions",
-					"description": "Window Actions",
+					"title": "Window Platform Actions",
+					"description": "Window Platform Actions",
 					"enabled": true,
-					"url": "http://localhost:8080/js/modules/actions/window-actions.bundle.js"
+					"url": "http://localhost:8080/js/modules/actions/window-platform.bundle.js"
 				}
 			]
 		},


### PR DESCRIPTION
Improved the separation of actions from the platform

- Move pin/unpin/move-view/move-page actions to custom module
- Share action menu now uses central popup menu so can be shown in custom mode
- Favorites action logic moved to favorites source
- Menu action logic moved to menu source
- Theme action logic moved to themes source
- Methods in home for registerAction renamed to include Connection, as they are not core actions which causes confusion
- Added CustomActionCallerType to action shapes which reduces the size of the modules as they no longer need to include the whole of workspace-platform package