### PR TITLE
Fixed and improvements

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,5 @@ package-lock.json
 *.bundle.js
 settings.schema.json
 reports
+*.exe
+*.zip

--- a/how-to/integrate-with-ms365/client/src/ms365-integration.ts
+++ b/how-to/integrate-with-ms365/client/src/ms365-integration.ts
@@ -1144,11 +1144,11 @@ export class Microsoft365Integration {
 			[
 				await templateHelpers.createContainer(
 					"row",
-					[await templateHelpers.createText("title", 14, { fontWeight: "bold" })],
+					[await templateHelpers.createText("title", 12, { fontWeight: "bold" })],
 					{
-						paddingBottom: "10px",
 						borderBottom: `1px solid ${palette.background6}`,
-						gap: "10px"
+						paddingBottom: "5px",
+						gap: "5px"
 					}
 				),
 				await templateHelpers.createText("description", 12),
@@ -1535,19 +1535,24 @@ export class Microsoft365Integration {
 									border: "2px solid white",
 									padding: "2px",
 									position: "relative",
-									left: "-12px",
-									top: "32px"
+									left: "-14px",
+									top: "28px"
 								}),
-								await templateHelpers.createContainer("column", [
-									await templateHelpers.createText("displayName", 14, {
-										fontWeight: "bold"
-									}),
-									await templateHelpers.createText("availability", 12, {})
-								])
+								await templateHelpers.createContainer(
+									"column",
+									[
+										await templateHelpers.createTitle("displayName"),
+										await templateHelpers.createText("availability", 10, {})
+									],
+									{
+										overflow: "hidden"
+									}
+								)
 							],
 							{
-								paddingBottom: "10px",
-								borderBottom: `1px solid ${palette.background6}`
+								borderBottom: `1px solid ${palette.background6}`,
+								paddingBottom: "5px",
+								gap: "5px"
 							}
 						),
 						await this.createPairsLayout(templateHelpers, palette, pairs),
@@ -1738,17 +1743,21 @@ export class Microsoft365Integration {
 									objectFit: "cover",
 									borderRadius: "50%"
 								}),
-								await templateHelpers.createContainer("column", [
-									await templateHelpers.createText("displayName", 14, {
-										fontWeight: "bold"
-									}),
-									await templateHelpers.createText("company", 12, {})
-								])
+								await templateHelpers.createContainer(
+									"column",
+									[
+										await templateHelpers.createTitle("displayName"),
+										await templateHelpers.createText("company", 10, {})
+									],
+									{
+										overflow: "hidden"
+									}
+								)
 							],
 							{
-								paddingBottom: "10px",
 								borderBottom: `1px solid ${palette.background6}`,
-								gap: "10px"
+								paddingBottom: "5px",
+								gap: "5px"
 							}
 						),
 						await this.createPairsLayout(templateHelpers, palette, pairs),
@@ -1806,7 +1815,7 @@ export class Microsoft365Integration {
 		if (message.bodyPreview) {
 			pairs.push({
 				label: "Preview",
-				value: message.bodyPreview,
+				value: this.sanitizeString(message.bodyPreview),
 				wide: true
 			});
 		}
@@ -1848,19 +1857,12 @@ export class Microsoft365Integration {
 				layout: await templateHelpers.createContainer(
 					"column",
 					[
-						await templateHelpers.createContainer(
-							"row",
-							[
-								await templateHelpers.createText("subject", 14, {
-									fontWeight: "bold"
-								})
-							],
-							{
-								paddingBottom: "10px",
-								borderBottom: `1px solid ${palette.background6}`,
-								gap: "10px"
-							}
-						),
+						await templateHelpers.createContainer("row", [await templateHelpers.createTitle("subject")], {
+							borderBottom: `1px solid ${palette.background6}`,
+							paddingBottom: "5px",
+							gap: "5px",
+							overflow: "hidden"
+						}),
 						await this.createPairsLayout(templateHelpers, palette, pairs),
 						await this.createButtonsLayout(templateHelpers, palette, buttons)
 					],
@@ -1945,7 +1947,7 @@ export class Microsoft365Integration {
 		if (event.bodyPreview) {
 			pairs.push({
 				label: "Preview",
-				value: event.bodyPreview,
+				value: this.sanitizeString(event.bodyPreview),
 				wide: true
 			});
 		}
@@ -1987,19 +1989,12 @@ export class Microsoft365Integration {
 				layout: await templateHelpers.createContainer(
 					"column",
 					[
-						await templateHelpers.createContainer(
-							"row",
-							[
-								await templateHelpers.createText("subject", 14, {
-									fontWeight: "bold"
-								})
-							],
-							{
-								paddingBottom: "10px",
-								borderBottom: `1px solid ${palette.background6}`,
-								gap: "10px"
-							}
-						),
+						await templateHelpers.createContainer("row", [await templateHelpers.createTitle("subject")], {
+							borderBottom: `1px solid ${palette.background6}`,
+							paddingBottom: "5px",
+							gap: "5px",
+							overflow: "hidden"
+						}),
 						await this.createPairsLayout(templateHelpers, palette, pairs),
 						await this.createButtonsLayout(templateHelpers, palette, buttons)
 					],
@@ -2086,12 +2081,10 @@ export class Microsoft365Integration {
 			});
 		}
 
-		// Strip any HTML tags
-		const body = chatMessage.body?.content?.replace(/<[^>]*>/g, "");
-		if (body) {
+		if (chatMessage.body?.content) {
 			pairs.push({
 				label: "Preview",
-				value: body,
+				value: this.sanitizeString(chatMessage.body?.content),
 				wide: true
 			});
 		}
@@ -2135,19 +2128,12 @@ export class Microsoft365Integration {
 				layout: await templateHelpers.createContainer(
 					"column",
 					[
-						await templateHelpers.createContainer(
-							"row",
-							[
-								await templateHelpers.createText("summary", 14, {
-									fontWeight: "bold"
-								})
-							],
-							{
-								paddingBottom: "10px",
-								borderBottom: `1px solid ${palette.background6}`,
-								gap: "10px"
-							}
-						),
+						await templateHelpers.createContainer("row", [await templateHelpers.createTitle("summary")], {
+							borderBottom: `1px solid ${palette.background6}`,
+							paddingBottom: "5px",
+							gap: "5px",
+							overflow: "hidden"
+						}),
 						await this.createPairsLayout(templateHelpers, palette, pairs),
 						await this.createButtonsLayout(templateHelpers, palette, buttons)
 					],
@@ -2269,19 +2255,12 @@ export class Microsoft365Integration {
 				layout: await templateHelpers.createContainer(
 					"column",
 					[
-						await templateHelpers.createContainer(
-							"row",
-							[
-								await templateHelpers.createText("displayName", 14, {
-									fontWeight: "bold"
-								})
-							],
-							{
-								paddingBottom: "10px",
-								borderBottom: `1px solid ${palette.background6}`,
-								gap: "10px"
-							}
-						),
+						await templateHelpers.createContainer("row", [await templateHelpers.createTitle("displayName")], {
+							borderBottom: `1px solid ${palette.background6}`,
+							paddingBottom: "5px",
+							gap: "5px",
+							overflow: "hidden"
+						}),
 						await this.createPairsLayout(templateHelpers, palette, pairs),
 						await this.createButtonsLayout(templateHelpers, palette, buttons)
 					],
@@ -2405,19 +2384,12 @@ export class Microsoft365Integration {
 				layout: await templateHelpers.createContainer(
 					"column",
 					[
-						await templateHelpers.createContainer(
-							"row",
-							[
-								await templateHelpers.createText("displayName", 14, {
-									fontWeight: "bold"
-								})
-							],
-							{
-								paddingBottom: "10px",
-								borderBottom: `1px solid ${palette.background6}`,
-								gap: "10px"
-							}
-						),
+						await templateHelpers.createContainer("row", [await templateHelpers.createTitle("displayName")], {
+							borderBottom: `1px solid ${palette.background6}`,
+							paddingBottom: "5px",
+							gap: "5px",
+							overflow: "hidden"
+						}),
 						await this.createPairsLayout(templateHelpers, palette, pairs),
 						await this.createButtonsLayout(templateHelpers, palette, buttons)
 					],
@@ -2529,19 +2501,12 @@ export class Microsoft365Integration {
 				layout: await templateHelpers.createContainer(
 					"column",
 					[
-						await templateHelpers.createContainer(
-							"row",
-							[
-								await templateHelpers.createText("displayName", 14, {
-									fontWeight: "bold"
-								})
-							],
-							{
-								paddingBottom: "10px",
-								borderBottom: `1px solid ${palette.background6}`,
-								gap: "10px"
-							}
-						),
+						await templateHelpers.createContainer("row", [await templateHelpers.createTitle("displayName")], {
+							borderBottom: `1px solid ${palette.background6}`,
+							paddingBottom: "5px",
+							gap: "5px",
+							overflow: "hidden"
+						}),
 						await this.createPairsLayout(templateHelpers, palette, pairs),
 						await this.createButtonsLayout(templateHelpers, palette, buttons)
 					],
@@ -2690,7 +2655,7 @@ export class Microsoft365Integration {
 		for (const pair of pairs) {
 			pairData[`${pair.label}Title`] = pair.label;
 			if (pair.value) {
-				pairData[pair.label] = this.stripHtml(pair.value);
+				pairData[pair.label] = this.sanitizeString(pair.value);
 			}
 			if (pair.links) {
 				for (let i = 0; i < pair.links.length; i++) {
@@ -2887,12 +2852,21 @@ export class Microsoft365Integration {
 	}
 
 	/**
-	 * Strip any HTML content from a string.
-	 * @param input The string to strip the HTML from.
-	 * @returns The string with HTML removed.
+	 * A basic string sanitize function that removes angle brackets <> from a string.
+	 * @param content the content to sanitize
+	 * @returns a string without angle brackets <>
 	 */
-	private stripHtml(input: string): string {
-		return input.replace(/<[^>]+>/g, "");
+	private sanitizeString(content: string): string {
+		if (content !== undefined && content !== null && typeof content === "string") {
+			return content
+				.replace(/<[^>]*>?/gm, "")
+				.replace(/&gt;/g, ">")
+				.replace(/&lt;/g, "<")
+				.replace(/&amp;/g, "&")
+				.replace(/&nbsp;/g, " ")
+				.replace(/\n\s*\n/g, "\n");
+		}
+		return content;
 	}
 
 	/**

--- a/how-to/integrate-with-ms365/client/src/shapes.ts
+++ b/how-to/integrate-with-ms365/client/src/shapes.ts
@@ -370,6 +370,21 @@ export interface TemplateHelpers {
 		fontSize?: number,
 		style?: CSS.Properties
 	): Promise<TemplateFragment>;
+
+	/**
+	 * Create a title element.
+	 * @param dataKey The data key for the title text.
+	 * @param fontSize The font size.
+	 * @param fontWeight The font weight.
+	 * @param style Additional CSS properties to use.
+	 * @returns The title element.
+	 */
+	createTitle(
+		dataKey: string,
+		fontSize?: number,
+		fontWeight?: string,
+		style?: CSS.Properties
+	): Promise<TextTemplateFragment>;
 }
 
 /**

--- a/how-to/integrate-with-salesforce/client/src/salesforce-integration.ts
+++ b/how-to/integrate-with-salesforce/client/src/salesforce-integration.ts
@@ -852,8 +852,8 @@ export class SalesforceIntegration {
 				if (fieldValue !== null && fieldValue !== undefined && fieldValue.length > 0) {
 					if (fieldMapping.displayMode === "icon") {
 						headerParts.image = await templateHelpers.createImage("image", "Profile", {
-							width: "44px",
-							height: "44px",
+							width: "38px",
+							height: "38px",
 							objectFit: "cover",
 							borderRadius: "50%"
 						});
@@ -868,9 +868,9 @@ export class SalesforceIntegration {
 							initials += values[values.length - 1][0];
 						}
 
-						headerParts.image = await templateHelpers.createText("initials", 18, {
-							width: "44px",
-							height: "44px",
+						headerParts.image = await templateHelpers.createText("initials", 16, {
+							width: "38px",
+							height: "38px",
 							objectFit: "cover",
 							borderRadius: "50%",
 							backgroundColor: palette.background2,
@@ -881,10 +881,10 @@ export class SalesforceIntegration {
 						});
 						data.initials = initials.toUpperCase();
 					} else if (fieldMapping.displayMode === "header") {
-						headerParts.header = await templateHelpers.createTitle("header", 14);
+						headerParts.header = await templateHelpers.createTitle("header");
 						data.header = fieldValue;
 					} else if (fieldMapping.displayMode === "sub-header") {
-						headerParts.subHeader = await templateHelpers.createText("subHeader", 12);
+						headerParts.subHeader = await templateHelpers.createText("subHeader", 10);
 						data.subHeader = fieldValue;
 					} else if (fieldMapping.displayMode === "field") {
 						if (fieldMapping.fieldContent === "link") {
@@ -924,12 +924,16 @@ export class SalesforceIntegration {
 			if (headerParts.subHeader) {
 				headerTitleParts.push(headerParts.subHeader);
 			}
-			headerChildren.push(await templateHelpers.createContainer("column", headerTitleParts));
+			headerChildren.push(
+				await templateHelpers.createContainer("column", headerTitleParts, {
+					overflow: "hidden"
+				})
+			);
 		}
 
 		const headerRow = await templateHelpers.createContainer("row", headerChildren, {
-			paddingBottom: "10px",
-			borderBottom: `1px solid ${palette.textDefault}`,
+			borderBottom: `1px solid ${palette.background6}`,
+			paddingBottom: "5px",
 			gap: "10px"
 		});
 

--- a/how-to/workspace-platform-starter/client/src/framework/favorite.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/favorite.ts
@@ -236,7 +236,6 @@ export async function deleteSavedFavorite(id: string): Promise<boolean> {
  */
 export function getInfo(): FavoriteInfo {
 	if (isEmpty(favoriteOptions)) {
-		logger.warn("The options for favorites has not been set yet.");
 		return {
 			isEnabled: false
 		};

--- a/how-to/workspace-platform-starter/client/src/framework/platform/interopbroker.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/platform/interopbroker.ts
@@ -74,7 +74,7 @@ export function interopOverride(
 			);
 			getSettings()
 				.then((customSettings) => {
-					if (!isEmpty(customSettings?.platformProvider)) {
+					if (!isEmpty(customSettings) && !isEmpty(customSettings?.platformProvider)) {
 						if (
 							isEmpty(customSettings?.platformProvider?.interop?.intentResolver) &&
 							!isEmpty(customSettings?.platformProvider?.intentPicker)

--- a/how-to/workspace-platform-starter/client/src/framework/platform/platform-override.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/platform/platform-override.ts
@@ -739,15 +739,15 @@ export function overrideCallback(
 						const platformManifest: OpenFin.Manifest = await app.getManifest();
 						logger.info("Platform Default Window Options", platformManifest?.platform?.defaultWindowOptions);
 						windowDefaultLeft =
-							settings.browserProvider?.defaultWindowOptions?.defaultLeft ??
+							settings?.browserProvider?.defaultWindowOptions?.defaultLeft ??
 							platformManifest?.platform?.defaultWindowOptions?.defaultLeft ??
 							0;
 						windowDefaultTop =
-							settings.browserProvider?.defaultWindowOptions?.defaultTop ??
+							settings?.browserProvider?.defaultWindowOptions?.defaultTop ??
 							platformManifest?.platform?.defaultWindowOptions?.defaultTop ??
 							0;
 
-						windowPositioningStrategy = settings.browserProvider?.windowPositioningStrategy;
+						windowPositioningStrategy = settings?.browserProvider?.windowPositioningStrategy;
 					}
 				}
 

--- a/how-to/workspace-platform-starter/client/src/framework/platform/platform-splash.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/platform/platform-splash.ts
@@ -27,14 +27,14 @@ export async function open(): Promise<void> {
 
 	if (!disabled) {
 		try {
-			const title = customSettings.splashScreenProvider?.title ?? manifest.shortcut?.name ?? "OpenFin";
+			const title = customSettings?.splashScreenProvider?.title ?? manifest.shortcut?.name ?? "OpenFin";
 			const icon =
-				customSettings.splashScreenProvider?.icon ??
+				customSettings?.splashScreenProvider?.icon ??
 				manifest.platform?.icon ??
 				"../common/images/icon-blue.png";
-			let backgroundColor: string | undefined = customSettings.splashScreenProvider?.backgroundColor;
-			let textColor: string | undefined = customSettings.splashScreenProvider?.textColor;
-			let borderColor: string | undefined = customSettings.splashScreenProvider?.borderColor;
+			let backgroundColor: string | undefined = customSettings?.splashScreenProvider?.backgroundColor;
+			let textColor: string | undefined = customSettings?.splashScreenProvider?.textColor;
+			let borderColor: string | undefined = customSettings?.splashScreenProvider?.borderColor;
 
 			const hasBackground = isStringValue(backgroundColor);
 			const hasText = isStringValue(textColor);

--- a/how-to/workspace-platform-starter/client/src/framework/platform/platform.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/platform/platform.ts
@@ -46,7 +46,7 @@ export async function init(): Promise<boolean> {
 	const customSettings = await getManifestCustomSettings();
 
 	const isValid = await authFlow.init(
-		customSettings.authProvider,
+		customSettings?.authProvider,
 		async () => setupPlatform(customSettings),
 		logger,
 		true
@@ -66,7 +66,7 @@ export async function init(): Promise<boolean> {
  * @param manifestSettings The custom setting to use for setting up the platform.
  * @returns True if the platform setup was successful.
  */
-async function setupPlatform(manifestSettings: CustomSettings): Promise<boolean> {
+async function setupPlatform(manifestSettings: CustomSettings | undefined): Promise<boolean> {
 	// Load the init options from the initial manifest
 	// and notify any actions with the after auth lifecycle
 	await modules.init(randomUUID());
@@ -78,7 +78,7 @@ async function setupPlatform(manifestSettings: CustomSettings): Promise<boolean>
 	await initOptionsProvider.init(manifestSettings?.initOptionsProvider, helpers, "after-auth");
 
 	// We reload the settings now that endpoints have been configured.
-	const customSettings: CustomSettings = await getSettings();
+	const customSettings: CustomSettings | undefined = await getSettings();
 
 	await platformSplashProvider.updateProgress("Logger");
 
@@ -129,7 +129,7 @@ async function setupPlatform(manifestSettings: CustomSettings): Promise<boolean>
 	await platformSplashProvider.updateProgress("Lifecycles");
 	await lifecycleProvider.init(customSettings?.lifecycleProvider, helpers);
 
-	const sharingEnabled = customSettings.platformProvider?.sharing ?? true;
+	const sharingEnabled = customSettings?.platformProvider?.sharing ?? true;
 	if (sharingEnabled) {
 		await platformSplashProvider.updateProgress("Sharing");
 		await shareProvider.init({ enabled: sharingEnabled });
@@ -148,13 +148,13 @@ async function setupPlatform(manifestSettings: CustomSettings): Promise<boolean>
 	const browser: BrowserInitConfig = {};
 
 	if (!isEmpty(customSettings?.browserProvider)) {
-		browser.defaultWindowOptions = await getDefaultWindowOptions(customSettings.browserProvider);
+		browser.defaultWindowOptions = await getDefaultWindowOptions(customSettings?.browserProvider);
 	}
 	if (!isEmpty(customSettings?.browserProvider?.defaultPageOptions)) {
-		browser.defaultPageOptions = customSettings.browserProvider?.defaultPageOptions;
+		browser.defaultPageOptions = customSettings?.browserProvider?.defaultPageOptions;
 	}
 	if (!isEmpty(customSettings?.browserProvider?.defaultViewOptions)) {
-		browser.defaultViewOptions = customSettings.browserProvider?.defaultViewOptions;
+		browser.defaultViewOptions = customSettings?.browserProvider?.defaultViewOptions;
 	}
 
 	logger.info("Specifying following browser options", browser);
@@ -168,7 +168,7 @@ async function setupPlatform(manifestSettings: CustomSettings): Promise<boolean>
 	await snapProvider.init(customSettings?.snapProvider);
 	conditionsProvider.registerCondition("snap", async () => snapProvider.isEnabled(), false);
 
-	await contentCreationProvider.init(customSettings.contentCreationProvider, helpers);
+	await contentCreationProvider.init(customSettings?.contentCreationProvider, helpers);
 
 	if (contentCreationProvider.isEnabled()) {
 		browser.defaultViewOptions = browser.defaultViewOptions ?? ({} as OpenFin.ViewOptions);

--- a/how-to/workspace-platform-starter/client/src/framework/settings.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/settings.ts
@@ -15,7 +15,7 @@ const PLATFORM_SETTINGS_ENDPOINT_GET = "platform-settings";
  * Load the customSettings section from the application manifest.
  * @returns The custom settings from the manifest.
  */
-export async function getManifestCustomSettings(): Promise<CustomSettings> {
+export async function getManifestCustomSettings(): Promise<CustomSettings | undefined> {
 	const app = await fin.Application.getCurrent();
 	const manifest: OpenFin.Manifest & { customSettings?: CustomSettings } = await app.getManifest();
 	return manifest.customSettings ?? {};
@@ -25,16 +25,17 @@ export async function getManifestCustomSettings(): Promise<CustomSettings> {
  * Get the settings for the application, either from manifest or settings endpoint.
  * @returns The custom settings for the application.
  */
-export async function getSettings(): Promise<CustomSettings> {
+export async function getSettings(): Promise<CustomSettings | undefined> {
 	if (isEmpty(customSettings)) {
 		// Get the settings from the manifest
 		customSettings = await getManifestCustomSettings();
 
 		// If the manifest has endpoint support then see if there is a settings endpoint
 		// that we can load additional settings from
-		if (customSettings.endpointProvider) {
+		const endpointProviderOptions = customSettings?.endpointProvider;
+		if (!isEmpty(endpointProviderOptions)) {
 			const moduleHelpers: ModuleHelpers = getDefaultHelpers();
-			await endpointProvider.init(customSettings.endpointProvider, moduleHelpers);
+			await endpointProvider.init(endpointProviderOptions, moduleHelpers);
 
 			if (endpointProvider.hasEndpoint(PLATFORM_SETTINGS_ENDPOINT_GET)) {
 				logger.info(`${PLATFORM_SETTINGS_ENDPOINT_GET} endpoint specified. Fetching platform settings.`);

--- a/how-to/workspace-platform-starter/client/src/framework/share.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/share.ts
@@ -177,7 +177,7 @@ async function notifyOfSuccessfulLoad(): Promise<void> {
 			appId: fin.me.identity.uuid
 		},
 		priority: 1,
-		icon: settings.browserProvider?.defaultWindowOptions?.icon,
+		icon: settings?.browserProvider?.defaultWindowOptions?.icon,
 		indicator: {
 			color: IndicatorColor.GREEN,
 			text: "Share Request Applied"
@@ -217,7 +217,7 @@ async function notifyOfSuccess(url: string, expiryInHours: number): Promise<void
 			appId: fin.me.identity.uuid
 		},
 		priority: 1,
-		icon: settings.browserProvider?.defaultWindowOptions?.icon,
+		icon: settings?.browserProvider?.defaultWindowOptions?.icon,
 		indicator: {
 			color: IndicatorColor.BLUE,
 			text: "Share Request Raised"
@@ -256,7 +256,7 @@ async function notifyOfFailure(body: string): Promise<void> {
 			appId: fin.me.identity.uuid
 		},
 		priority: 1,
-		icon: settings.browserProvider?.defaultWindowOptions?.icon,
+		icon: settings?.browserProvider?.defaultWindowOptions?.icon,
 		indicator: {
 			color: IndicatorColor.RED,
 			text: "Share Request Failed"
@@ -294,7 +294,7 @@ async function notifyOfExpiry(): Promise<void> {
 			appId: fin.me.identity.uuid
 		},
 		priority: 1,
-		icon: settings.browserProvider?.defaultWindowOptions?.icon,
+		icon: settings?.browserProvider?.defaultWindowOptions?.icon,
 		indicator: {
 			color: IndicatorColor.RED,
 			text: "Share Request Expired"

--- a/how-to/workspace-platform-starter/client/src/framework/utils.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/utils.ts
@@ -125,7 +125,13 @@ export function formatError(err: unknown): string {
  */
 export function sanitizeString(content: string): string {
 	if (isString(content)) {
-		return content.replace(/<[^>]*>?/gm, "");
+		return content
+			.replace(/<[^>]*>?/gm, "")
+			.replace(/&gt;/g, ">")
+			.replace(/&lt;/g, "<")
+			.replace(/&amp;/g, "&")
+			.replace(/&nbsp;/g, " ")
+			.replace(/\n\s*\n/g, "\n");
 	}
 	return content;
 }

--- a/how-to/workspace-platform-starter/client/src/framework/workspace/dock.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/workspace/dock.ts
@@ -5,7 +5,8 @@ import {
 	type CustomButtonConfig,
 	type DockButton,
 	type DockProvider,
-	type DockProviderRegistration
+	type DockProviderRegistration,
+	type WorkspaceButton
 } from "@openfin/workspace";
 import { getCurrentSync, type WorkspacePlatformModule } from "@openfin/workspace-platform";
 import type {
@@ -139,20 +140,43 @@ async function buildDockProvider(buttons: DockButton[]): Promise<DockProvider | 
 			id: dockProviderOptions.id,
 			title: dockProviderOptions.title,
 			icon: dockProviderOptions.icon,
-			workspaceComponents: {
-				hideWorkspacesButton: dockProviderOptions.workspaceComponents?.hideWorkspacesButton,
-				hideHomeButton:
-					!registeredBootstrapOptions?.home || dockProviderOptions.workspaceComponents?.hideHomeButton,
-				hideStorefrontButton:
-					!registeredBootstrapOptions?.store || dockProviderOptions.workspaceComponents?.hideStorefrontButton,
-				hideNotificationsButton:
-					!registeredBootstrapOptions?.notifications ||
-					dockProviderOptions.workspaceComponents?.hideNotificationsButton
-			},
+			workspaceComponents: buildWorkspaceButtons(),
 			disableUserRearrangement: dockProviderOptions?.disableUserRearrangement ?? false,
 			buttons: objectClone(registeredButtons)
 		};
 	}
+}
+
+/**
+ * Build the workspace buttons based on config.
+ * @returns The list of workspace buttons.
+ */
+function buildWorkspaceButtons(): WorkspaceButton[] {
+	const workspaceButtons: WorkspaceButton[] = [];
+
+	if (!(dockProviderOptions?.workspaceComponents?.hideWorkspacesButton ?? false)) {
+		workspaceButtons.push("switchWorkspace");
+	}
+	if (
+		!(dockProviderOptions?.workspaceComponents?.hideHomeButton ?? false) &&
+		(registeredBootstrapOptions?.home ?? false)
+	) {
+		workspaceButtons.push("home");
+	}
+	if (
+		!(dockProviderOptions?.workspaceComponents?.hideNotificationsButton ?? false) &&
+		(registeredBootstrapOptions?.notifications ?? false)
+	) {
+		workspaceButtons.push("notifications");
+	}
+	if (
+		!(dockProviderOptions?.workspaceComponents?.hideStorefrontButton ?? false) &&
+		(registeredBootstrapOptions?.store ?? false)
+	) {
+		workspaceButtons.push("store");
+	}
+
+	return workspaceButtons;
 }
 
 /**
@@ -554,6 +578,13 @@ export async function loadConfig(
 		}
 	}
 
+	if (!isEmpty(config)) {
+		// Always build the workspace buttons based on the config,
+		// otherwise loaded config can show buttons that it is
+		// not supposed to
+		config.workspaceComponents = buildWorkspaceButtons();
+	}
+
 	return config;
 }
 
@@ -602,16 +633,7 @@ async function refreshDock(): Promise<void> {
 		if (JSON.stringify(newButtons) !== JSON.stringify(registeredButtons)) {
 			const dockProvider = await buildDockProvider(newButtons);
 			if (dockProvider) {
-				// updateDockProviderConfig was added in v13, fallback if it doesn't exist
-				if (registrationInfo?.updateDockProviderConfig) {
-					await registrationInfo.updateDockProviderConfig(dockProvider);
-				} else {
-					await deregister();
-					await Dock.register(dockProvider);
-					if (registeredBootstrapOptions?.autoShow?.includes("dock")) {
-						await show();
-					}
-				}
+				await registrationInfo.updateDockProviderConfig(dockProvider);
 			}
 		}
 	}

--- a/how-to/workspace-platform-starter/client/src/framework/workspace/home.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/workspace/home.ts
@@ -1,14 +1,13 @@
 import {
+	CLITemplate,
 	Home,
-	type HomeProvider,
 	type CLIFilter,
 	type HomeDispatchedSearchResult,
+	type HomeProvider,
 	type HomeRegistration,
 	type HomeSearchListenerRequest,
 	type HomeSearchListenerResponse,
-	type HomeSearchResponse,
-	CLITemplate,
-	CLIFilterOptionType
+	type HomeSearchResponse
 } from "@openfin/workspace";
 import { getHelpSearchEntries, getSearchResults, itemSelection } from "../integrations";
 import { createLogger } from "../logger-provider";
@@ -206,7 +205,7 @@ async function onUserInput(
 				}
 			}
 			searchResults.context ??= {};
-			searchResults.context.filters = finalFilters.length > 0 ? finalFilters : [createDummyFilter()];
+			searchResults.context.filters = finalFilters.length > 0 ? finalFilters : [createEmptySourceFilter()];
 			if (!Array.isArray(searchResults?.results)) {
 				logger.info("No results array returned.");
 			} else {
@@ -237,7 +236,7 @@ async function onUserInput(
 			}
 		],
 		context: {
-			filters: [createDummyFilter()]
+			filters: [createEmptySourceFilter()]
 		}
 	};
 }
@@ -275,11 +274,10 @@ async function onSelection(result: HomeDispatchedSearchResult): Promise<void> {
  * bouncing as it adds and removes.
  * @returns A dummy filter.
  */
-function createDummyFilter(): CLIFilter {
+function createEmptySourceFilter(): CLIFilter {
 	return {
-		id: "app-searching",
-		title: "Tags",
-		type: CLIFilterOptionType.MultiSelect,
+		id: HOME_SOURCE_FILTERS,
+		title: homeProviderOptions?.sourceFilter?.label ?? HOME_SOURCE_DEFAULT_FILTER_LABEL,
 		options: [
 			{
 				value: "All",

--- a/how-to/workspace-platform-starter/client/src/framework/workspace/home.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/workspace/home.ts
@@ -6,7 +6,9 @@ import {
 	type HomeRegistration,
 	type HomeSearchListenerRequest,
 	type HomeSearchListenerResponse,
-	type HomeSearchResponse
+	type HomeSearchResponse,
+	CLITemplate,
+	CLIFilterOptionType
 } from "@openfin/workspace";
 import { getHelpSearchEntries, getSearchResults, itemSelection } from "../integrations";
 import { createLogger } from "../logger-provider";
@@ -21,6 +23,7 @@ const logger = createLogger("Home");
 let homeProviderOptions: HomeProviderOptions | undefined;
 let registrationInfo: HomeRegistration | undefined;
 let lastResponse: HomeSearchListenerResponse;
+let debounceTimerId: number | undefined;
 
 /**
  * Register the home component.
@@ -103,98 +106,140 @@ async function onUserInput(
 	request: HomeSearchListenerRequest,
 	response: HomeSearchListenerResponse
 ): Promise<HomeSearchResponse> {
-	try {
-		const filters: CLIFilter[] = request?.context?.selectedFilters ?? [];
-
-		if (!isEmpty(lastResponse)) {
-			lastResponse.close();
-		}
-		lastResponse = response;
-		lastResponse.open();
-
-		const queryLower = request.query.toLowerCase();
-
-		if (queryLower === "?") {
-			logger.info("Integration Help requested.");
-			const integrationHelpSearchEntries = await getHelpSearchEntries();
-			const searchResults = {
-				results: integrationHelpSearchEntries,
-				context: {
-					filters: []
-				}
-			};
-			return searchResults;
-		}
-
-		const enableSourceFilter = !(homeProviderOptions?.sourceFilter?.disabled ?? false);
-
-		let selectedSourceFilterOptions: string[] = [];
-		if (enableSourceFilter && filters) {
-			const sourceFilter = filters.find((f) => f.id === HOME_SOURCE_FILTERS);
-			if (sourceFilter) {
-				if (Array.isArray(sourceFilter.options)) {
-					selectedSourceFilterOptions = sourceFilter.options.filter((o) => o.isSelected).map((o) => o.value);
-				} else if (sourceFilter.options.isSelected) {
-					selectedSourceFilterOptions.push(sourceFilter.options.value);
-				}
-			}
-		}
-
-		let sourceFilterOptions: string[] = [];
-
-		logger.info("Search results requested.");
-		const searchResults = await getSearchResults(
-			request.query,
-			filters,
-			lastResponse,
-			selectedSourceFilterOptions,
-			{
-				queryMinLength: homeProviderOptions?.queryMinLength ?? 3,
-				queryAgainst: homeProviderOptions?.queryAgainst ?? ["title"],
-				isSuggestion: request.context?.isSuggestion ?? false
-			}
-		);
-
-		if (Array.isArray(searchResults.sourceFilters) && searchResults.sourceFilters.length > 0) {
-			sourceFilterOptions = sourceFilterOptions.concat(searchResults.sourceFilters);
-		}
-
-		if (enableSourceFilter && sourceFilterOptions.length > 0) {
-			searchResults.context = searchResults.context ?? {};
-			searchResults.context.filters = searchResults.context.filters ?? [];
-			searchResults.context.filters.push({
-				id: HOME_SOURCE_FILTERS,
-				title: homeProviderOptions?.sourceFilter?.label ?? HOME_SOURCE_DEFAULT_FILTER_LABEL,
-				options: sourceFilterOptions.map((c) => ({ value: c, isSelected: true }))
-			});
-		}
-
-		// Remove any empty filter lists as these can cause the UI to continually
-		// expand and collapse as you type
-		const finalFilters = [];
-		const contextFilters = searchResults.context?.filters;
-		if (Array.isArray(contextFilters)) {
-			for (const filter of contextFilters) {
-				if (Array.isArray(filter.options) && filter.options.length > 0) {
-					finalFilters.push(filter);
-				}
-			}
-		}
-		if (finalFilters.length > 0) {
-			searchResults.context = searchResults.context ?? {};
-			searchResults.context.filters = finalFilters;
-		}
-		if (!Array.isArray(searchResults?.results)) {
-			logger.info("No results array returned.");
-		} else {
-			logger.info(`${searchResults.results.length} results returned.`);
-		}
-		return searchResults;
-	} catch (err) {
-		logger.error("Exception while getting search list results", err);
+	if (debounceTimerId) {
+		window.clearTimeout(debounceTimerId);
+		debounceTimerId = undefined;
 	}
 
-	return { results: [] };
+	if (!isEmpty(lastResponse)) {
+		lastResponse.close();
+	}
+	lastResponse = response;
+	lastResponse.open();
+
+	// Debounce the keyboard input, this also means that the method returns
+	// immediately with a dummy filter, so the UI does not "bounce"
+	debounceTimerId = window.setTimeout(async () => {
+		try {
+			const filters: CLIFilter[] = request?.context?.selectedFilters ?? [];
+			const queryLower = request.query.toLowerCase();
+
+			if (queryLower === "?") {
+				logger.info("Integration Help requested.");
+				const integrationHelpSearchEntries = await getHelpSearchEntries();
+				const searchResults = {
+					results: integrationHelpSearchEntries,
+					context: {
+						filters: []
+					}
+				};
+				return searchResults;
+			}
+
+			const enableSourceFilter = !(homeProviderOptions?.sourceFilter?.disabled ?? false);
+
+			let selectedSourceFilterOptions: string[] = [];
+			if (enableSourceFilter && filters) {
+				const sourceFilter = filters.find((f) => f.id === HOME_SOURCE_FILTERS);
+				if (sourceFilter) {
+					if (Array.isArray(sourceFilter.options)) {
+						selectedSourceFilterOptions = sourceFilter.options
+							.filter((o) => o.isSelected)
+							.map((o) => o.value);
+					} else if (sourceFilter.options.isSelected) {
+						selectedSourceFilterOptions.push(sourceFilter.options.value);
+					}
+				}
+			}
+
+			let sourceFilterOptions: string[] = [];
+
+			logger.info("Search results requested.");
+			const finalFilters: CLIFilter[] = [];
+			const searchResults = await getSearchResults(
+				request.query,
+				filters,
+				{
+					...lastResponse,
+					updateContext: (context: HomeSearchResponse["context"]) => {
+						// We must provide an overloaded updateContext to the
+						// integrations so that we can intercept it, this was
+						// if they replace filters async it doesn't completely
+						// obliterate any that already exist
+						const finalContext = {
+							filters: finalFilters
+						};
+						if (context?.filters) {
+							finalContext.filters.push(...context.filters);
+						}
+						lastResponse.updateContext(finalContext);
+					}
+				},
+				selectedSourceFilterOptions,
+				{
+					queryMinLength: homeProviderOptions?.queryMinLength ?? 3,
+					queryAgainst: homeProviderOptions?.queryAgainst ?? ["title"],
+					isSuggestion: request.context?.isSuggestion ?? false
+				}
+			);
+
+			if (Array.isArray(searchResults.sourceFilters) && searchResults.sourceFilters.length > 0) {
+				sourceFilterOptions = sourceFilterOptions.concat(searchResults.sourceFilters);
+			}
+
+			if (enableSourceFilter && sourceFilterOptions.length > 0) {
+				searchResults.context = searchResults.context ?? {};
+				searchResults.context.filters = searchResults.context.filters ?? [];
+				searchResults.context.filters.push({
+					id: HOME_SOURCE_FILTERS,
+					title: homeProviderOptions?.sourceFilter?.label ?? HOME_SOURCE_DEFAULT_FILTER_LABEL,
+					options: sourceFilterOptions.map((c) => ({ value: c, isSelected: true }))
+				});
+			}
+
+			const contextFilters = searchResults.context?.filters;
+			if (Array.isArray(contextFilters)) {
+				for (const filter of contextFilters) {
+					if (Array.isArray(filter.options) && filter.options.length > 0) {
+						finalFilters.push(filter);
+					}
+				}
+			}
+			searchResults.context ??= {};
+			searchResults.context.filters = finalFilters.length > 0 ? finalFilters : [createDummyFilter()];
+			if (!Array.isArray(searchResults?.results)) {
+				logger.info("No results array returned.");
+			} else {
+				logger.info(`${searchResults.results.length} results returned.`);
+			}
+
+			// Return all the results and filters async so that the method
+			// returns quickly without the UI bouncing
+			lastResponse.revoke("home-searching");
+			lastResponse.respond(searchResults.results);
+			lastResponse.updateContext({
+				filters: searchResults.context?.filters
+			});
+		} catch (err) {
+			logger.error("Exception while getting search list results", err);
+		}
+	}, 200);
+
+	return {
+		results: [
+			{
+				key: "home-searching",
+				title: "Searching ...",
+				icon: homeProviderOptions?.icon,
+				actions: [],
+				template: CLITemplate.Loading,
+				templateContent: ""
+			}
+		],
+		context: {
+			filters: [createDummyFilter()]
+		}
+	};
 }
 
 /**
@@ -220,7 +265,26 @@ async function onSelection(result: HomeDispatchedSearchResult): Promise<void> {
 				);
 			}
 		}
-	} else {
+	} else if (result.action.trigger === "user-action") {
 		logger.warn("Unable to execute result without data being passed");
 	}
+}
+
+/**
+ * By creating a dummy filters the UI always shows the filter row, which stops it
+ * bouncing as it adds and removes.
+ * @returns A dummy filter.
+ */
+function createDummyFilter(): CLIFilter {
+	return {
+		id: "app-searching",
+		title: "Tags",
+		type: CLIFilterOptionType.MultiSelect,
+		options: [
+			{
+				value: "All",
+				isSelected: true
+			}
+		]
+	};
 }

--- a/how-to/workspace-platform-starter/client/src/framework/workspace/low-code-integrations.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/workspace/low-code-integrations.ts
@@ -11,6 +11,41 @@ let lowCodeIntegrations: { [key: string]: WorkflowIntegration };
 const requiresSearchInitialization: string[] = [];
 
 /**
+ * Initialize the Low Code Integration provider.
+ * @param options Options for the Low Code Integration Provider.
+ * @returns Nothing.
+ */
+export async function init(options: LowCodeIntegrationProviderOptions | undefined): Promise<void> {
+	if (!isEmpty(options)) {
+		logger.info("LowCodeIntegrationProvider initialized with options.");
+		lowCodeIntegrationProviderOptions = options;
+	}
+}
+
+/**
+ * This function initializes the low code integration instances if not already initialized and
+ * returns them as an array of instances.
+ * @returns An array of WorkflowIntegrations.
+ */
+export async function register(): Promise<WorkflowIntegration[]> {
+	if (isEmpty(lowCodeIntegrations)) {
+		await initializeLowCodeIntegrations();
+	}
+	if (isEmpty(lowCodeIntegrations)) {
+		return [];
+	}
+	return Object.values(lowCodeIntegrations);
+}
+
+/**
+ * Are there any low code integrations enabled.
+ * @returns True if there are enabled low code integrations.
+ */
+export function isEnabled(): boolean {
+	return !isEmpty(lowCodeIntegrations) && Object.keys(lowCodeIntegrations).length > 0;
+}
+
+/**
  * This function uses the passed configuration to create an instance of each required low code integration and
  * creates a list of low code integrations that still need their search integration initialized.
  */
@@ -60,33 +95,6 @@ async function initializeLowCodeIntegrations(): Promise<void> {
 			}
 		}
 	}
-}
-
-/**
- * Initialize the Low Code Integration provider.
- * @param options Options for the Low Code Integration Provider.
- * @returns Nothing.
- */
-export async function init(options: LowCodeIntegrationProviderOptions | undefined): Promise<void> {
-	if (!isEmpty(options)) {
-		logger.info("LowCodeIntegrationProvider initialized with options.");
-		lowCodeIntegrationProviderOptions = options;
-	}
-}
-
-/**
- * This function initializes the low code integration instances if not already initialized and
- * returns them as an array of instances.
- * @returns An array of WorkflowIntegrations.
- */
-export async function register(): Promise<WorkflowIntegration[]> {
-	if (isEmpty(lowCodeIntegrations)) {
-		await initializeLowCodeIntegrations();
-	}
-	if (isEmpty(lowCodeIntegrations)) {
-		return [];
-	}
-	return Object.values(lowCodeIntegrations);
 }
 
 /**

--- a/how-to/workspace-platform-starter/client/src/framework/workspace/notifications.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/workspace/notifications.ts
@@ -35,7 +35,7 @@ export async function register(
 
 		logger.info("Registering platform with Notification Center.");
 		const settings = await getSettings();
-		if (!isEmpty(settings?.notificationProvider)) {
+		if (!isEmpty(settings) && !isEmpty(settings?.notificationProvider)) {
 			const { notificationClients, ...notificationsPlatformOptions } = settings.notificationProvider;
 			notificationPlatformId = notificationsPlatformOptions?.id ?? fin.me.identity.uuid;
 			notificationsPlatformOptions.id = notificationPlatformId;

--- a/how-to/workspace-platform-starter/client/src/modules/endpoint/local-storage/platform-local-storage.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/endpoint/local-storage/platform-local-storage.ts
@@ -37,12 +37,7 @@ export class PlatformLocalStorage<T = unknown> implements PlatformStorage<T> {
 			return;
 		}
 		const store = this.getCompleteStore();
-		const savedEntry = store[id];
-		if (isEmpty(savedEntry)) {
-			this._logger?.warn(`No ${this._storageTypeName} entry was found for id ${id}`);
-			return;
-		}
-		return savedEntry;
+		return store[id];
 	}
 
 	/**

--- a/how-to/workspace-platform-starter/client/src/shell.ts
+++ b/how-to/workspace-platform-starter/client/src/shell.ts
@@ -17,7 +17,7 @@ export async function init(): Promise<boolean> {
 	const customSettings = await getManifestCustomSettings();
 	const isValid = await initAuthFlow(
 		customSettings?.authProvider,
-		async () => initProvider(customSettings.platformProvider),
+		async () => initProvider(customSettings?.platformProvider),
 		logger
 	);
 	if (!isValid) {

--- a/how-to/workspace-platform-starter/package.json
+++ b/how-to/workspace-platform-starter/package.json
@@ -19,6 +19,7 @@
 		"secondclient": "node ./scripts/launch.mjs http://localhost:8080/second.manifest.fin.json",
 		"thirdclient": "node ./scripts/launch.mjs http://localhost:8080/third.manifest.fin.json",
 		"fourthclient": "node ./scripts/launch.mjs http://localhost:8080/fourth.manifest.fin.json",
+		"emptyclient": "node ./scripts/launch.mjs http://localhost:8080/empty.manifest.fin.json",
 		"server": "node ./server/build/index.js",
 		"setup": "npm install && npm run build",
 		"generate-types": "tsc --project ./client/tsconfig.types.json && tsc --project ./client/tsconfig.types-module.json && npx rimraf ./client/types/framework",

--- a/how-to/workspace-platform-starter/public/empty.manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/empty.manifest.fin.json
@@ -1,0 +1,33 @@
+{
+	"$schema": "./schemas/manifest.schema.json",
+	"devtools_port": 9090,
+	"licenseKey": "openfin-demo-license-key",
+	"runtime": {
+		"arguments": "--v=1 --inspect",
+		"version": "33.116.77.11"
+	},
+	"startup_app": {
+		"name": "empty-workspace-starter-how-to-workspace-platform-starter"
+	},
+	"platform": {
+		"name": "empty-workspace-starter-how-to-workspace-platform-starter",
+		"uuid": "empty-workspace-platform-starter",
+		"icon": "http://localhost:8080/favicon.ico",
+		"autoShow": false,
+		"providerUrl": "http://localhost:8080/platform/provider.html",
+		"preventQuitOnLastWindowClosed": true
+	},
+	"shortcut": {
+		"company": "OpenFin",
+		"description": "A way of showing examples of what OpenFin can do.",
+		"icon": "http://localhost:8080/favicon.ico",
+		"name": "Workspace Platform Starter - v16.0.0",
+		"target": ["desktop", "start-menu"]
+	},
+	"supportInformation": {
+		"company": "OpenFin",
+		"product": "Workspace Starter - Workspace Platform Starter - Client",
+		"email": "support@openfin.co",
+		"forwardErrorReports": true
+	}
+}

--- a/how-to/workspace-platform-starter/public/schemas/manifest.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/manifest.schema.json
@@ -6,6 +6,5 @@
 			"$ref": "./settings.schema.json#/definitions/CustomSettings"
 		}
 	},
-	"required": ["customSettings"],
 	"additionalProperties": true
 }


### PR DESCRIPTION
- Prettier ignore .exe and .zip
- Salesforce and MS integration styling updated to match main platform
- MS Added string sanitization to result card content
- Custom settings is now marked optional in manifest schema
- Added additional `npm run emptyclient` with manifest containing no customSettings
- Fixed all providers that didn't behave when no customSettings were available
- When no bootstrap options were provided platform, default to showing home, if no home provider manifest settings used instead
- Favorites getInfo method no longer displays warning if not enabled
- Integration provider additional checks for option and initialized
- Sanitize string also replaces html components syntax
- Dock
   - Uses the updated workspaceComponents property instead individual flag for inbuilt buttons
   - Fix workspace buttons now reassigned on config load from storage to use those actually configured in the platform
   - Removed old deprecated code for updateDockProviderConfig
- Home 
    - Debounces all input
    - Results and filters populated using async method, which means the method can return immediately
    - Shows searching entry while waiting for results
    - Defaults to returning a single dummy filter, so the appearance and disappearance doesn't make the UI bounce
    - Fix lastResponse.updateContext is proxied so that we combine additional filters from plugins instead of replacing them
    - Only shows failed itemSelection warning if event was user-action
- Low code has additional isEnabled flag which is used to decide if to display splash progress
- Webpack build parallel script updated to fail fast when any of the sub builds has errors