### PR TITLE
Add support for reshow for when a desktop shortcut is used

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v16
 
+- Added support for reshow. If you click on the application icon/shortcut it will show you the components that have been configured to autoShow (see [how to customize the bootstrapping process](./docs/how-to-customize-the-bootstrapping-process.md)) if the application is already running.
 - Docs - Added a document showing [How To Add A Service](./docs/how-to-add-a-service.md)
 - Improved launchPreference so that now args for a native app (app asset or external) can be specified via launchPreference. Launch preference can also be configured to allow args to be specified dynamically when the launch request is made. Please see [how to define app launch preference](./docs/how-to-define-app-launch-preference.md).
 - Improved launchPreference so additional options such as url, interop, customData can be specified. Modules can now pass a launchPreference when launching an app by appId. They can see if the app supports being updated by getting the app by id and checking for the updatable setting under launchPreference.options. Only inline-view/view and inline-window/window support updatable launch preferences. Please see [how to define app launch preference](./docs/how-to-define-app-launch-preference.md).

--- a/how-to/workspace-platform-starter/client/src/framework/init-options.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/init-options.ts
@@ -18,6 +18,7 @@ import { isEmpty, randomUUID } from "./utils";
 
 const ACTION_PARAM_NAME = "action";
 const ACTION_PAYLOAD_PARAM_NAME = "payload";
+const NO_PARAM_NAME = "-----default-if-no-param-----";
 
 const logger = createLogger("InitOptions");
 
@@ -138,14 +139,17 @@ export function registerActionListener(
 
 /**
  * Manually register a listener.
- * @param paramName The param name to look for in the init option.
  * @param handler The handler to call when a match on the param name occurs.
+ * @param paramName The param name to look for in the init option. If not specified then it is a function to be called if no params are passed.
  * @returns The subscription id that can be used to remove the listener.
  */
-export function registerListener(paramName: string, handler: InitOptionsListener): string | undefined {
+export function registerListener(handler: InitOptionsListener, paramName?: string): string | undefined {
 	if (paramName === ACTION_PARAM_NAME) {
 		logger.warn("Please use registerActionListener if you wish to listen for an action");
 		return;
+	}
+	if (isEmpty(paramName)) {
+		paramName = NO_PARAM_NAME;
 	}
 	const subscriptionId = randomUUID();
 	if (!listeners[paramName]) {
@@ -268,6 +272,11 @@ async function notifyListeners(initOptions: UserAppConfigArgs, context: ActionHa
 		}
 	}
 
+	if (isEmpty(listenerId) && (isEmpty(initOptions) || Object.keys(initOptions).length === 0)) {
+		logger.info("No init options passed, calling default listeners");
+		listenerId = NO_PARAM_NAME;
+	}
+
 	if (!isEmpty(listenerId)) {
 		logger.info(
 			`Init param has been passed and it has a matching listener (${listenerId}). Passing on init options to listeners`
@@ -308,5 +317,7 @@ async function queryWhileRunning(event: { userAppConfigArgs?: UserAppConfigArgs 
 		} else {
 			await notifyListeners(event.userAppConfigArgs, "running");
 		}
+	} else {
+		logger.info("Received while platform is running but no init options were passed");
 	}
 }

--- a/how-to/workspace-platform-starter/client/src/framework/platform/platform-override.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/platform/platform-override.ts
@@ -112,8 +112,8 @@ export function overrideCallback(
 		 * @returns nothing.
 		 */
 		public async launchIntoPlatform(payload: OpenFin.LaunchIntoPlatformPayload): Promise<void> {
-			logger.warn(
-				"launchIntoPlatform called. Please use the initOptionsProvider for loading content into the platform.",
+			logger.debug(
+				"launchIntoPlatform called. Please use the initOptionsProvider for loading content into the platform. If triggered by clicking on the application icon then autoShow options from the bootstrapper are applied.",
 				payload
 			);
 		}

--- a/how-to/workspace-platform-starter/client/src/framework/share.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/share.ts
@@ -34,14 +34,14 @@ export async function init(options: { enabled: boolean } | undefined): Promise<v
 		if (shareEnabled) {
 			if (!shareRegistered) {
 				shareRegistered = true;
-				initOptionsListenerId = registerListener("shareId", async (initOptions, context) => {
+				initOptionsListenerId = registerListener(async (initOptions, context) => {
 					logger.info("Received share request.");
 					if (typeof initOptions.shareId === "string") {
 						await loadSharedEntry(initOptions.shareId);
 					} else {
 						logger.warn("shareId passed but it wasn't a string");
 					}
-				});
+				}, "shareId");
 			} else {
 				logger.warn("Share cannot be registered more than once.");
 			}

--- a/how-to/workspace-platform-starter/docs/how-to-customize-the-bootstrapping-process.md
+++ b/how-to/workspace-platform-starter/docs/how-to-customize-the-bootstrapping-process.md
@@ -34,6 +34,8 @@ A provider can be initialized without being displayed, so to automatically show 
 
 If you do not provide and `autoShow` property the first registered component in the order listed above will be used.
 
+If the platform is already running and the user double clicks the desktop shortcut or shortcut in program files (or clicks on the platform icon in the dock if on a mac) then the components configured in "autoShow" will be shown.
+
 ## Lifecycle
 
 [Lifecycle events](./how-to-use-lifecycle-events.md) are raised during the bootstrapping process.

--- a/how-to/workspace-platform-starter/public/empty.manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/empty.manifest.fin.json
@@ -29,5 +29,8 @@
 		"product": "Workspace Starter - Workspace Platform Starter - Client",
 		"email": "support@openfin.co",
 		"forwardErrorReports": true
+	},
+	"snapshot": {
+		"windows": []
 	}
 }

--- a/how-to/workspace-platform-starter/public/fourth.manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/fourth.manifest.fin.json
@@ -67,6 +67,9 @@
 		"email": "support@openfin.co",
 		"forwardErrorReports": true
 	},
+	"snapshot": {
+		"windows": []
+	},
 	"customSettings": {
 		"platformProvider": {
 			"rootUrl": "http://localhost:8080",

--- a/how-to/workspace-platform-starter/public/manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/manifest.fin.json
@@ -82,6 +82,9 @@
 		"email": "support@openfin.co",
 		"forwardErrorReports": true
 	},
+	"snapshot": {
+		"windows": []
+	},
 	"customSettings": {
 		"bootstrap": {
 			"home": true,

--- a/how-to/workspace-platform-starter/public/second.manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/second.manifest.fin.json
@@ -64,6 +64,9 @@
 		"email": "support@openfin.co",
 		"forwardErrorReports": true
 	},
+	"snapshot": {
+		"windows": []
+	},
 	"customSettings": {
 		"authProvider": {
 			"modules": [

--- a/how-to/workspace-platform-starter/public/third.manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/third.manifest.fin.json
@@ -72,6 +72,9 @@
 		"email": "support@openfin.co",
 		"forwardErrorReports": true
 	},
+	"snapshot": {
+		"windows": []
+	},
 	"customSettings": {
 		"bootstrap": {
 			"home": true,


### PR DESCRIPTION
Add support for reshow and update documentation. Also add a snapshot to the manifest even if it is empty so that container logic can perform related checks and not error on a mac.