### PR TITLE
Updated the default behaviour when applying snapshots

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v16
 
+- Update the applyWorkspace override so that the following applySnapshot options are applied: closeExistingWindows: false, closeSnapshotWindows: true
 - Updated logic to handle current launchExternalProcess and downloadAppAsset support in the Mac RVM. In apps.ts we filter out native or app asset applications and if Snap is enabled then we log a warning and do not try to enable the Snap SDK.
 - Updated endpoint types so that fetch endpoints keep mandatory options (it can't work without them) but module endpoints now have options marked as optional (as not all custom modules would need to pass settings). This ties in with the schema improvements below.
 - Added support for supporting intellisense for any manifest file called \*.manifest.fin.json or manifest.fin.json. The rules are any manifest in how-to/workspace-platform-starter will include the OpenFin manifest options as well as Workspace Platform Starter custom settings. Any manifest file in the other how-to examples will include the OpenFin manifest settings but not the custom settings that are specific to Workspace Platform Starter. The schema reference in the manifest has been dropped and schema settings are now picked up in the .vscode/settings.json file. Please open this repo at the root in VSCode so that you have access to all the how-tos and you have access to the settings for this repo.

--- a/how-to/workspace-platform-starter/client/src/framework/platform/platform-override.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/platform/platform-override.ts
@@ -364,7 +364,17 @@ export function overrideCallback(
 					}
 				}
 			}
-			const applied = await super.applyWorkspace(payload);
+			const applied = await super.applyWorkspace({
+				...payload,
+				options: {
+					...payload.options,
+					applySnapshotOptions: {
+						...payload.options?.applySnapshotOptions,
+						closeExistingWindows: false,
+						closeSnapshotWindows: true
+					}
+				}
+			});
 
 			if (applied && !workspaceApplied) {
 				workspaceApplied = true;

--- a/how-to/workspace-platform-starter/docs/how-to-add-a-service.md
+++ b/how-to/workspace-platform-starter/docs/how-to-add-a-service.md
@@ -63,4 +63,9 @@ If you are looking at building something that will handle intents -> Use a headl
 
 If you are looking at listening to notifications from a backend and push out notifications -> Use a lifecycle module that is fired after the bootstrap process and use the getNotificationClient helper method.
 
+## Source Reference
+
+- [Example hidden window definition: hidden.window.fin.json](../public/common/windows/hidden-window/hidden.window.fin.json)
+- [Example notification service using a lifecycle module: lifecycle.ts](../client/src/modules/lifecycle/example-notification-service/lifecycle.ts)
+
 [<- Back to Table Of Contents](../README.md)


### PR DESCRIPTION
It should not replace windows that have opted out of being included in the snapshot. This is how background services (windows) are intended to work otherwise they will be closed when switching workspaces.