### PR TITLE
Add additional multi monitor awareness to WPS

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -4,7 +4,14 @@
 
 - Change storage mapper now removes additional defaults based on default window/page/view settings
 - Change storage mapper applies default settings when hydrating from storage
-- Added Example endpoint for page/workspace storage
+- Added Example endpoint for page/workspace storage to server (not production code)
+- Added Additional Monitor Awareness
+  - Initial set of updates to improve the multi-monitor experience.
+  - Extracted Window Positioning Strategy logic from Platform Override to the utils-position.ts file so that it can be used/called from more than one place.
+  - Improved launch preferences so that top and left can now be specified as part of the bounds.
+  - Improved launch preferences by extending appProvider so that you can specify default updatable preferences that should apply across applications (Caution. Preferences such as url should remain app specific).
+  - Dock now takes monitor into account when launching apps using the app entry type or launch-view action or favorites menu option (module). This only applies to views and windows (not snapshots or other types of app).
+  - Interop Broker now takes into account who raised the intent/fdc3.open request when launching a view/window in response (it will position it on the same monitor as the requesting app if possible using the window positioning strategy)
 
 ## v16
 

--- a/how-to/workspace-platform-starter/client/src/framework/launch.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/launch.ts
@@ -6,6 +6,7 @@ import {
 	type BrowserWorkspacePlatformWindowOptions,
 	type Page
 } from "@openfin/workspace-platform";
+import { isAppPreferenceUpdatable } from "./apps";
 import { launchConnectedApp } from "./connections";
 import * as endpointProvider from "./endpoint";
 import { createLogger } from "./logger-provider";
@@ -24,7 +25,8 @@ import type {
 	UpdatableLaunchPreference,
 	ViewLaunchOptions,
 	WindowLaunchOptions,
-	PreferenceConstraintUrl
+	PreferenceConstraintUrl,
+	HostLaunchOptions
 } from "./shapes/app-shapes";
 import * as snapProvider from "./snap";
 import { isEmpty, isStringValue, objectClone, randomUUID } from "./utils";
@@ -383,55 +385,49 @@ async function launchWindow(
 
 	if (!windowExists) {
 		try {
-			const appLaunchPreference = objectClone(windowApp.launchPreference);
-			const appLaunchPreferenceOptions = objectClone(
-				windowApp.launchPreference?.options
-			) as WindowLaunchOptions;
+			const appLaunchPreference = objectClone(windowApp.launchPreference) ?? {};
+			const appLaunchPreferenceOptions =
+				(objectClone(windowApp.launchPreference?.options) as WindowLaunchOptions) ??
+				({ type: "window" } as WindowLaunchOptions);
 
-			// validate passed launch preferences
-			if (
-				appLaunchPreference?.options?.type === "window" &&
-				Array.isArray(appLaunchPreferenceOptions?.updatable) &&
-				appLaunchPreferenceOptions.updatable.length > 0
-			) {
-				for (const option of appLaunchPreferenceOptions.updatable) {
-					if (option.name === "bounds") {
-						appLaunchPreference.bounds = launchPreference?.bounds;
-					} else if (option.name === "centered") {
-						appLaunchPreference.defaultCentered = launchPreference?.defaultCentered;
-					} else if (
-						option.name === "custom-data" &&
-						launchPreference?.options?.type === "window" &&
-						!isEmpty(launchPreference.options?.window?.customData)
-					) {
-						if (isEmpty(appLaunchPreferenceOptions.window)) {
-							appLaunchPreferenceOptions.window = {};
-						}
-						appLaunchPreferenceOptions.window.customData = {
-							...appLaunchPreferenceOptions.window?.customData,
-							...launchPreference.options?.window?.customData
-						};
-					} else if (
-						option.name === "interop" &&
-						launchPreference?.options?.type === "window" &&
-						!isEmpty(launchPreference.options?.window?.interop)
-					) {
-						if (isEmpty(appLaunchPreferenceOptions.window)) {
-							appLaunchPreferenceOptions.window = {};
-						}
-						appLaunchPreferenceOptions.window.interop = launchPreference?.options.window?.interop;
-					} else if (
-						option.name === "url" &&
-						launchPreference?.options?.type === "window" &&
-						!isEmpty(launchPreference.options?.window) &&
-						isStringValue(launchPreference.options?.window?.url)
-					) {
-						if (isEmpty(appLaunchPreferenceOptions.window)) {
-							appLaunchPreferenceOptions.window = {};
-						}
-						if (isValidUrl(manifest.url, launchPreference.options.window.url, option.constraint)) {
-							appLaunchPreferenceOptions.window.url = launchPreference.options.window.url;
-						}
+			const canUpdateBounds = isAppPreferenceUpdatable(windowApp, "bounds");
+			const canUpdateCentered = isAppPreferenceUpdatable(windowApp, "centered");
+			const canUpdateCustomData = isAppPreferenceUpdatable(windowApp, "custom-data");
+			const canUpdateInterop = isAppPreferenceUpdatable(windowApp, "interop");
+			const canUpdateUrl = isAppPreferenceUpdatable(windowApp, "url");
+
+			if (!isEmpty(canUpdateBounds) && !isEmpty(launchPreference?.bounds)) {
+				appLaunchPreference.bounds = { ...appLaunchPreference.bounds, ...launchPreference?.bounds };
+			}
+
+			if (!isEmpty(canUpdateCentered) && !isEmpty(launchPreference?.defaultCentered)) {
+				appLaunchPreference.defaultCentered = launchPreference?.defaultCentered;
+			}
+
+			if (appLaunchPreferenceOptions?.type === "window" && launchPreference?.options?.type === "window") {
+				if (!isEmpty(canUpdateCustomData) && !isEmpty(launchPreference?.options?.window?.customData)) {
+					if (isEmpty(appLaunchPreferenceOptions.window)) {
+						appLaunchPreferenceOptions.window = {};
+					}
+					appLaunchPreferenceOptions.window.customData = {
+						...appLaunchPreferenceOptions.window?.customData,
+						...launchPreference.options?.window?.customData
+					};
+				}
+
+				if (!isEmpty(canUpdateInterop) && !isEmpty(launchPreference?.options?.window?.interop)) {
+					if (isEmpty(appLaunchPreferenceOptions.window)) {
+						appLaunchPreferenceOptions.window = {};
+					}
+					appLaunchPreferenceOptions.window.interop = launchPreference?.options.window?.interop;
+				}
+
+				if (!isEmpty(canUpdateUrl) && !isEmpty(launchPreference?.options?.window?.url)) {
+					if (isEmpty(appLaunchPreferenceOptions.window)) {
+						appLaunchPreferenceOptions.window = {};
+					}
+					if (isValidUrl(manifest.url, launchPreference.options.window.url, canUpdateUrl.constraint)) {
+						appLaunchPreferenceOptions.window.url = launchPreference.options.window.url;
 					}
 				}
 			}
@@ -442,6 +438,10 @@ async function launchWindow(
 			manifest.defaultWidth = appLaunchPreference?.bounds?.width ?? manifest.defaultWidth;
 			manifest.width = appLaunchPreference?.bounds?.width ?? manifest.width;
 			manifest.defaultCentered = appLaunchPreference?.defaultCentered ?? manifest.defaultCentered;
+			manifest.x = appLaunchPreference.bounds?.left ?? manifest.x;
+			manifest.defaultLeft = appLaunchPreference.bounds?.left ?? manifest.defaultLeft;
+			manifest.y = appLaunchPreference.bounds?.top ?? manifest.y;
+			manifest.defaultTop = appLaunchPreference.bounds?.top ?? manifest.defaultTop;
 
 			if (
 				!isEmpty(appLaunchPreferenceOptions?.window) &&
@@ -552,75 +552,74 @@ async function launchView(
 	if (!viewExists) {
 		try {
 			const platform = getCurrentSync();
-			const appLaunchPreference = objectClone(viewApp.launchPreference);
-			const appLaunchPreferenceOptions = objectClone(viewApp.launchPreference?.options) as ViewLaunchOptions;
-			if (
-				appLaunchPreference?.options?.type === "view" &&
-				Array.isArray(appLaunchPreferenceOptions?.updatable) &&
-				appLaunchPreferenceOptions.updatable.length > 0
-			) {
-				for (const option of appLaunchPreferenceOptions.updatable) {
-					if (option.name === "bounds") {
-						appLaunchPreference.bounds = launchPreference?.bounds;
-					} else if (option.name === "centered") {
-						appLaunchPreference.defaultCentered = launchPreference?.defaultCentered;
-					} else if (
-						option.name === "host-options" &&
-						launchPreference?.options?.type === "view" &&
-						!isEmpty(launchPreference.options.host)
+			const appLaunchPreference = objectClone(viewApp.launchPreference) ?? {};
+			const appLaunchPreferenceOptions =
+				objectClone(viewApp.launchPreference?.options) ??
+				({
+					type: "view"
+				} as ViewLaunchOptions);
+
+			const canUpdateBounds = isAppPreferenceUpdatable(viewApp, "bounds");
+			const canUpdateCentered = isAppPreferenceUpdatable(viewApp, "centered");
+			const canUpdateHostOptions = isAppPreferenceUpdatable(viewApp, "host-options");
+			const canUpdateCustomData = isAppPreferenceUpdatable(viewApp, "custom-data");
+			const canUpdateInterop = isAppPreferenceUpdatable(viewApp, "interop");
+			const canUpdateUrl = isAppPreferenceUpdatable(viewApp, "url");
+
+			if (!isEmpty(canUpdateBounds) && !isEmpty(launchPreference?.bounds)) {
+				appLaunchPreference.bounds = { ...appLaunchPreference.bounds, ...launchPreference?.bounds };
+			}
+
+			if (!isEmpty(canUpdateCentered) && !isEmpty(launchPreference?.defaultCentered)) {
+				appLaunchPreference.defaultCentered = launchPreference?.defaultCentered;
+			}
+
+			if (appLaunchPreferenceOptions?.type === "view" && launchPreference?.options?.type === "view") {
+				if (isEmpty(appLaunchPreferenceOptions.host)) {
+					appLaunchPreferenceOptions.host = {};
+				}
+				if (!isEmpty(canUpdateHostOptions) && !isEmpty(launchPreference?.options?.host)) {
+					if (
+						isStringValue(appLaunchPreferenceOptions.host?.url) &&
+						isStringValue(launchPreference.options.host?.url) &&
+						!isValidUrl(
+							appLaunchPreferenceOptions.host.url,
+							launchPreference.options.host.url,
+							canUpdateHostOptions.constraint
+						)
 					) {
-						if (isEmpty(appLaunchPreferenceOptions.host)) {
-							appLaunchPreferenceOptions.host = {};
-						}
-						if (
-							isStringValue(appLaunchPreferenceOptions.host?.url) &&
-							isStringValue(launchPreference.options.host?.url) &&
-							!isValidUrl(
-								appLaunchPreferenceOptions.host.url,
-								launchPreference.options.host.url,
-								option.constraint
-							)
-						) {
-							// a url already exists and the suggested one does not match so reset it
-							launchPreference.options.host.url = undefined;
-						}
-						appLaunchPreferenceOptions.host = {
-							...appLaunchPreferenceOptions.host,
-							...launchPreference.options?.host
-						};
-					} else if (
-						option.name === "custom-data" &&
-						launchPreference?.options?.type === "view" &&
-						!isEmpty(launchPreference.options?.view?.customData)
-					) {
-						if (isEmpty(appLaunchPreferenceOptions.view)) {
-							appLaunchPreferenceOptions.view = {};
-						}
-						appLaunchPreferenceOptions.view.customData = {
-							...appLaunchPreferenceOptions.view?.customData,
-							...launchPreference.options?.view?.customData
-						};
-					} else if (
-						option.name === "interop" &&
-						launchPreference?.options?.type === "view" &&
-						!isEmpty(launchPreference.options?.view?.interop)
-					) {
-						if (isEmpty(appLaunchPreferenceOptions.view)) {
-							appLaunchPreferenceOptions.view = {};
-						}
-						appLaunchPreferenceOptions.view.interop = launchPreference?.options.view?.interop;
-					} else if (
-						option.name === "url" &&
-						launchPreference?.options?.type === "view" &&
-						!isEmpty(launchPreference.options.view) &&
-						isStringValue(launchPreference.options?.view?.url)
-					) {
-						if (isEmpty(appLaunchPreferenceOptions.view)) {
-							appLaunchPreferenceOptions.view = {};
-						}
-						if (isValidUrl(manifest.url, launchPreference.options.view.url, option.constraint)) {
-							appLaunchPreferenceOptions.view.url = launchPreference.options.view.url;
-						}
+						// a url already exists and the suggested one does not match so reset it
+						launchPreference.options.host.url = undefined;
+					}
+					appLaunchPreferenceOptions.host = {
+						...appLaunchPreferenceOptions.host,
+						...launchPreference.options?.host
+					};
+				}
+
+				if (!isEmpty(canUpdateCustomData) && !isEmpty(launchPreference?.options?.view?.customData)) {
+					if (isEmpty(appLaunchPreferenceOptions.view)) {
+						appLaunchPreferenceOptions.view = {};
+					}
+					appLaunchPreferenceOptions.view.customData = {
+						...appLaunchPreferenceOptions.view?.customData,
+						...launchPreference.options?.view?.customData
+					};
+				}
+
+				if (!isEmpty(canUpdateInterop) && !isEmpty(launchPreference?.options?.view?.interop)) {
+					if (isEmpty(appLaunchPreferenceOptions.view)) {
+						appLaunchPreferenceOptions.view = {};
+					}
+					appLaunchPreferenceOptions.view.interop = launchPreference?.options.view?.interop;
+				}
+
+				if (!isEmpty(canUpdateUrl) && !isEmpty(launchPreference?.options?.view?.url)) {
+					if (isEmpty(appLaunchPreferenceOptions.view)) {
+						appLaunchPreferenceOptions.view = {};
+					}
+					if (isValidUrl(manifest.url, launchPreference.options.view.url, canUpdateUrl.constraint)) {
+						appLaunchPreferenceOptions.view.url = launchPreference.options.view.url;
 					}
 				}
 			}
@@ -648,10 +647,13 @@ async function launchView(
 				}
 			}
 			const bounds = appLaunchPreference?.bounds;
-			if (
-				!isEmpty(bounds) ||
-				(!isEmpty(appLaunchPreferenceOptions) && appLaunchPreferenceOptions.type === "view")
-			) {
+			const host: HostLaunchOptions | undefined =
+				!isEmpty(appLaunchPreferenceOptions) && appLaunchPreferenceOptions.type === "view"
+					? appLaunchPreferenceOptions?.host
+					: undefined;
+			const defaultCentered = appLaunchPreference?.defaultCentered ?? false;
+
+			if (!isEmpty(bounds) || !isEmpty(host)) {
 				let workspacePlatform:
 					| Partial<BrowserWorkspacePlatformWindowOptions>
 					| { windowType: WindowType.Platform }
@@ -671,29 +673,26 @@ async function launchView(
 						}
 					],
 					settings: {
-						hasHeaders: appLaunchPreferenceOptions?.host?.hasHeaders
+						hasHeaders: host?.hasHeaders
 					}
 				};
 
 				workspacePlatform = {
-					windowType: !isEmpty(appLaunchPreferenceOptions?.host?.url) ? WindowType.Platform : undefined,
-					disableMultiplePages: appLaunchPreferenceOptions?.host?.disableMultiplePages,
-					title: appLaunchPreferenceOptions?.host?.title,
-					favicon: appLaunchPreferenceOptions?.host?.icon
+					windowType: !isEmpty(host?.url) ? WindowType.Platform : undefined,
+					disableMultiplePages: host?.disableMultiplePages,
+					title: host?.title,
+					favicon: host?.icon
 				};
-				if (
-					!isEmpty(appLaunchPreferenceOptions?.host?.pageTitle) ||
-					!isEmpty(appLaunchPreferenceOptions?.host?.pageIcon)
-				) {
+				if (!isEmpty(host?.pageTitle) || !isEmpty(host?.pageIcon)) {
 					const page: Page = {
 						pageId: `page-${randomUUID()}`,
-						iconUrl: appLaunchPreferenceOptions?.host?.pageIcon,
-						title: await platform.Browser.getUniquePageTitle(appLaunchPreferenceOptions?.host?.pageTitle),
+						iconUrl: host?.pageIcon,
+						title: await platform.Browser.getUniquePageTitle(host?.pageTitle),
 						layout
 					};
 					workspacePlatform.pages = [page];
 				}
-				if (appLaunchPreferenceOptions?.host?.disableToolbarOptions === true) {
+				if (host?.disableToolbarOptions === true) {
 					workspacePlatform.toolbarOptions = { buttons: [] };
 				}
 
@@ -703,12 +702,14 @@ async function launchView(
 
 				const preferenceWindow = await platform.createWindow({
 					workspacePlatform,
-					url: appLaunchPreferenceOptions?.host?.url,
+					url: host?.url,
 					height: bounds?.height,
 					defaultHeight: bounds?.height,
 					defaultWidth: bounds?.width,
+					defaultLeft: bounds?.left,
+					defaultTop: bounds?.top,
 					width: bounds?.width,
-					defaultCentered: appLaunchPreference?.defaultCentered,
+					defaultCentered,
 					layout
 				});
 
@@ -951,7 +952,10 @@ async function launchExternalProcess(
 	instanceId?: string,
 	launchPreference?: UpdatableLaunchPreference
 ): Promise<PlatformAppIdentifier> {
-	const nativeOptions = app.launchPreference?.options as NativeLaunchOptions;
+	const nativeOptions =
+		(objectClone(app.launchPreference?.options) as NativeLaunchOptions) ??
+		({ type: "native" } as NativeLaunchOptions);
+	const canUpdateArgs = isAppPreferenceUpdatable(app, "arguments");
 
 	const hasPath = isStringValue(options.path);
 
@@ -959,24 +963,20 @@ async function launchExternalProcess(
 
 	let args: string[] | undefined;
 
-	if (nativeOptions?.type === "native") {
-		if (
-			launchPreference?.options?.type === "native" &&
-			Array.isArray(nativeOptions?.updatable) &&
-			nativeOptions.updatable.length > 0
-		) {
-			for (const option of nativeOptions.updatable) {
-				if (option.name === "arguments" && Array.isArray(launchPreference.options.native?.arguments)) {
-					args = launchPreference.options.native?.arguments;
-					logger.debug(`Using passed launch preference for the args for app ${app.appId}`, args);
-				}
-			}
-		}
-		if (isEmpty(args) && Array.isArray(nativeOptions?.native?.arguments)) {
-			args = nativeOptions.native?.arguments;
-			logger.debug(`Using app definition based args for app ${app.appId}`, args);
-		}
+	if (
+		!isEmpty(canUpdateArgs) &&
+		launchPreference?.options?.type === "native" &&
+		Array.isArray(launchPreference?.options?.native?.arguments)
+	) {
+		args = launchPreference.options.native?.arguments;
+		logger.debug(`Using passed launch preference for the args for app ${app.appId}`, args);
 	}
+
+	if (isEmpty(args) && nativeOptions.type === "native" && Array.isArray(nativeOptions.native?.arguments)) {
+		args = nativeOptions.native?.arguments;
+		logger.debug(`Using app definition based args for app ${app.appId}`, args);
+	}
+
 	if (isEmpty(args) && isStringValue(options.arguments)) {
 		args = [options.arguments];
 	} else if (isEmpty(args)) {

--- a/how-to/workspace-platform-starter/client/src/framework/platform/browser.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/platform/browser.ts
@@ -497,25 +497,3 @@ export async function launchView(
 	}
 	return platform.createView(viewOptions, targetIdentity);
 }
-
-/**
- * Get a list of all the visible windows in the platform.
- * @returns The list of visible windows.
- */
-export async function getAllVisibleWindows(): Promise<OpenFin.Window[]> {
-	const platform = fin.Platform.getCurrentSync();
-	const windows = await platform.Application.getChildWindows();
-	const availableWindows: OpenFin.Window[] = [];
-	for (const currentWindow of windows) {
-		try {
-			const isShowing = await currentWindow.isShowing();
-			if (isShowing) {
-				availableWindows.push(currentWindow);
-			}
-		} catch {
-			// if the window is destroyed before determining if it is showing then
-			// we should move to the next window but not throw.
-		}
-	}
-	return availableWindows;
-}

--- a/how-to/workspace-platform-starter/client/src/framework/platform/platform-override.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/platform/platform-override.ts
@@ -767,11 +767,11 @@ export function overrideCallback(
 					if (!hasLeft || !hasTop) {
 						const position = await getWindowPositionUsingStrategy(windowPositioningOptions);
 
-						if (!hasLeft && !isEmpty(position?.x)) {
-							options.defaultLeft = position.x;
+						if (!hasLeft && !isEmpty(position?.left)) {
+							options.defaultLeft = position.left;
 						}
-						if (!hasTop && !isEmpty(position?.y)) {
-							options.defaultTop = position.y;
+						if (!hasTop && !isEmpty(position?.top)) {
+							options.defaultTop = position.top;
 						}
 					}
 				}

--- a/how-to/workspace-platform-starter/client/src/framework/platform/platform.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/platform/platform.ts
@@ -4,6 +4,7 @@ import {
 	init as workspacePlatformInit,
 	type BrowserInitConfig
 } from "@openfin/workspace-platform";
+import { getWindowPositionOptions } from "workspace-platform-starter/utils-position";
 import * as actionsProvider from "../actions";
 import * as analyticsProvider from "../analytics";
 import * as appProvider from "../apps";
@@ -163,8 +164,12 @@ async function setupPlatform(manifestSettings: CustomSettings | undefined): Prom
 	}
 
 	logger.info("Specifying following browser options", browser);
-
-	const customActions = await actionsProvider.init(customSettings?.actionsProvider, helpers);
+	const windowPositioningOptions = await getWindowPositionOptions(customSettings?.browserProvider);
+	const customActions = await actionsProvider.init(
+		customSettings?.actionsProvider,
+		helpers,
+		windowPositioningOptions
+	);
 	const theme = await getThemes();
 
 	await lowCodeIntegrationProvider.init(customSettings?.lowCodeIntegrationProvider);

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/app-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/app-shapes.ts
@@ -93,12 +93,9 @@ export type PlatformApp = App & {
  */
 export interface LaunchPreference {
 	/**
-	 * Do you wish to specify a custom height/width that should be used when this application is launched?
+	 * Do you wish to specify a custom height/width and/or x/y position that should be used when this application is launched?
 	 */
-	bounds?: {
-		width: number;
-		height: number;
-	};
+	bounds?: Partial<OpenFin.Bounds>;
 
 	/**
 	 * Should the launched UI be positioned in the center of the screen?
@@ -115,6 +112,16 @@ export interface LaunchPreference {
  *
  */
 export type UpdatableLaunchPreference = LaunchPreference;
+
+/**
+ * A type that contains the available updatable launch preferences
+ */
+export type UpdatableLaunchPreferenceDefinition =
+	| WindowPreference
+	| WindowPreferenceUrl
+	| ViewPreference
+	| ViewPreferenceUrl
+	| NativePreference;
 
 /**
  * The list of Launch Option Types
@@ -157,13 +164,18 @@ export interface ViewLaunchOptions extends LaunchOptions {
 }
 
 /**
+ * A list of all the names of possible preferences that can be updated.
+ */
+export type PreferenceName = ViewPreferenceName | WebPreferenceName | NativePreferenceName;
+
+/**
  * Which Launch Options are updatable and are there any constraints
  */
 export interface Preference<T = unknown> {
 	/**
 	 * What setting is updatable?
 	 */
-	name: ViewPreferenceName | WebPreferenceName | NativePreferenceName;
+	name: PreferenceName;
 
 	/**
 	 * Is there a constraint that the platform can apply?
@@ -517,6 +529,11 @@ export interface AppProviderOptions {
 	 * your platform to support (only the ones listed will be included in the end result).
 	 */
 	manifestTypes?: ManifestTypeId[];
+
+	/**
+	 * Do you wish to allow specific launchPreferences to be specified when launching an app by default?
+	 */
+	updatableLaunchPreference?: UpdatableLaunchPreferenceDefinition[];
 }
 
 /**

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/browser-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/browser-shapes.ts
@@ -93,6 +93,32 @@ export type BrowserProviderOptions = Pick<
 };
 
 /**
+ * Options for window positioning.
+ */
+export interface WindowPositioningOptions {
+	/**
+	 * The strategy for window positioning.
+	 */
+	windowPositioningStrategy?: CascadingWindowOffsetStrategy;
+
+	/**
+	 * By default we implement a Window Positioning Strategy that will try and position launched windows with an
+	 * offset. The way the windows are offset can be configured by specifying windowPositioningStrategy.
+	 * If you want to turn this off (e.g. automation tests that do not care about the layout of windows) then you
+	 * can set this value to true.
+	 */
+	disableWindowPositioningStrategy?: boolean;
+
+	/**
+	 * The default position for new windows.
+	 */
+	defaults?: {
+		top?: number;
+		left?: number;
+	};
+}
+
+/**
  * The cascading window strategy for positioning new windows.
  */
 export interface CascadingWindowOffsetStrategy {

--- a/how-to/workspace-platform-starter/client/src/framework/utils-position.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/utils-position.ts
@@ -202,9 +202,9 @@ export async function getWindowPositionOptions(
  * @returns The x and y coordinates of the window position.
  */
 export async function getWindowPositionUsingStrategy(
-	windowPositioningOptions: WindowPositioningOptions,
+	windowPositioningOptions?: WindowPositioningOptions,
 	relatedTo?: OpenFin.MonitorDetails | OpenFin.Identity | { x: number; y: number }
-): Promise<{ x: number; y: number } | undefined> {
+): Promise<{ left: number; top: number } | undefined> {
 	if (windowPositioningOptions?.disableWindowPositioningStrategy === true) {
 		return;
 	}
@@ -233,8 +233,8 @@ export async function getWindowPositionUsingStrategy(
 	// OS menus, task bar etc
 	const availableLeft = targetMonitor.availableRect.left;
 	const availableTop = targetMonitor.availableRect.top;
-	const windowOffsetsX: number = windowPositioningOptions.windowPositioningStrategy?.x ?? 30;
-	const windowOffsetsY: number = windowPositioningOptions.windowPositioningStrategy?.y ?? 30;
+	const windowOffsetsX: number = windowPositioningOptions?.windowPositioningStrategy?.x ?? 30;
+	const windowOffsetsY: number = windowPositioningOptions?.windowPositioningStrategy?.y ?? 30;
 	const windowOffsetsMaxIncrements: number =
 		windowPositioningOptions?.windowPositioningStrategy?.maxIncrements ?? 8;
 	const visibleWindows = await getAllVisibleWindows();
@@ -289,7 +289,7 @@ export async function getWindowPositionUsingStrategy(
 	const yOffset = minCountIndex * windowOffsetsY;
 	const y = windowDefaultTop + yOffset + availableTop;
 
-	return { x, y };
+	return { left: x, top: y };
 }
 
 /**

--- a/how-to/workspace-platform-starter/client/src/framework/utils-position.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/utils-position.ts
@@ -272,9 +272,9 @@ export async function getWindowPositionUsingStrategy(
 		const topPos = windowDefaultTop + yPos;
 		const foundWins = topLeftBounds.filter(
 			(topLeftWinBounds) =>
-				topLeftWinBounds.left >= leftPos &&
+				topLeftWinBounds.left >= leftPos + availableLeft &&
 				topLeftWinBounds.right <= leftPos + windowOffsetsX + availableLeft &&
-				topLeftWinBounds.top >= topPos &&
+				topLeftWinBounds.top >= topPos + availableTop &&
 				topLeftWinBounds.bottom <= topPos + windowOffsetsY + availableTop
 		);
 		// If this slot has less than the current minimum use this slot

--- a/how-to/workspace-platform-starter/client/src/modules/actions/favorites-menu/actions.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/actions/favorites-menu/actions.ts
@@ -4,6 +4,7 @@ import type {
 	WorkspacePlatformModule
 } from "@openfin/workspace-platform";
 import { CustomActionCallerType, type Actions } from "workspace-platform-starter/shapes/actions-shapes";
+import type { LaunchPreference } from "workspace-platform-starter/shapes/app-shapes";
 import {
 	FAVORITE_TYPE_NAME_APP,
 	FAVORITE_TYPE_NAME_PAGE,
@@ -14,6 +15,7 @@ import type { Logger, LoggerCreator } from "workspace-platform-starter/shapes/lo
 import type { PopupMenuEntry } from "workspace-platform-starter/shapes/menu-shapes";
 import type { ModuleDefinition, ModuleHelpers } from "workspace-platform-starter/shapes/module-shapes";
 import { isEmpty } from "workspace-platform-starter/utils";
+import { getWindowPositionUsingStrategy } from "workspace-platform-starter/utils-position";
 import type { FavoritesMenuSettings } from "./shapes";
 
 /**
@@ -117,7 +119,15 @@ export class FavoritesMenuProvider implements Actions<FavoritesMenuSettings> {
 
 							if (result.type === FAVORITE_TYPE_NAME_APP) {
 								if (!isEmpty(this._helpers?.launchApp)) {
-									await this._helpers?.launchApp(result.typeId);
+									let launchPreference: LaunchPreference | undefined;
+									const bounds = await getWindowPositionUsingStrategy(
+										undefined, // go with defaults
+										payload.windowIdentity
+									);
+									if (!isEmpty(bounds)) {
+										launchPreference = { bounds };
+									}
+									await this._helpers?.launchApp(result.typeId, launchPreference);
 								}
 							} else if (result.type === FAVORITE_TYPE_NAME_PAGE) {
 								if (!isEmpty(this._helpers?.launchPage)) {

--- a/how-to/workspace-platform-starter/client/types/module/shapes/app-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/app-shapes.d.ts
@@ -84,12 +84,9 @@ export type PlatformApp = App & {
  */
 export interface LaunchPreference {
 	/**
-	 * Do you wish to specify a custom height/width that should be used when this application is launched?
+	 * Do you wish to specify a custom height/width and/or x/y position that should be used when this application is launched?
 	 */
-	bounds?: {
-		width: number;
-		height: number;
-	};
+	bounds?: Partial<OpenFin.Bounds>;
 	/**
 	 * Should the launched UI be positioned in the center of the screen?
 	 */
@@ -103,6 +100,15 @@ export interface LaunchPreference {
  *
  */
 export type UpdatableLaunchPreference = LaunchPreference;
+/**
+ * A type that contains the available updatable launch preferences
+ */
+export type UpdatableLaunchPreferenceDefinition =
+	| WindowPreference
+	| WindowPreferenceUrl
+	| ViewPreference
+	| ViewPreferenceUrl
+	| NativePreference;
 /**
  * The list of Launch Option Types
  */
@@ -139,13 +145,17 @@ export interface ViewLaunchOptions extends LaunchOptions {
 	updatable?: (ViewPreference | ViewPreferenceUrl)[];
 }
 /**
+ * A list of all the names of possible preferences that can be updated.
+ */
+export type PreferenceName = ViewPreferenceName | WebPreferenceName | NativePreferenceName;
+/**
  * Which Launch Options are updatable and are there any constraints
  */
 export interface Preference<T = unknown> {
 	/**
 	 * What setting is updatable?
 	 */
-	name: ViewPreferenceName | WebPreferenceName | NativePreferenceName;
+	name: PreferenceName;
 	/**
 	 * Is there a constraint that the platform can apply?
 	 */
@@ -452,6 +462,10 @@ export interface AppProviderOptions {
 	 * your platform to support (only the ones listed will be included in the end result).
 	 */
 	manifestTypes?: ManifestTypeId[];
+	/**
+	 * Do you wish to allow specific launchPreferences to be specified when launching an app by default?
+	 */
+	updatableLaunchPreference?: UpdatableLaunchPreferenceDefinition[];
 }
 /**
  * Applications that support specific intent.

--- a/how-to/workspace-platform-starter/client/types/module/shapes/browser-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/browser-shapes.d.ts
@@ -82,6 +82,29 @@ export type BrowserProviderOptions = Pick<
 	disableWindowPositioningStrategy?: boolean;
 };
 /**
+ * Options for window positioning.
+ */
+export interface WindowPositioningOptions {
+	/**
+	 * The strategy for window positioning.
+	 */
+	windowPositioningStrategy?: CascadingWindowOffsetStrategy;
+	/**
+	 * By default we implement a Window Positioning Strategy that will try and position launched windows with an
+	 * offset. The way the windows are offset can be configured by specifying windowPositioningStrategy.
+	 * If you want to turn this off (e.g. automation tests that do not care about the layout of windows) then you
+	 * can set this value to true.
+	 */
+	disableWindowPositioningStrategy?: boolean;
+	/**
+	 * The default position for new windows.
+	 */
+	defaults?: {
+		top?: number;
+		left?: number;
+	};
+}
+/**
  * The cascading window strategy for positioning new windows.
  */
 export interface CascadingWindowOffsetStrategy {

--- a/how-to/workspace-platform-starter/docs/how-to-define-apps.md
+++ b/how-to/workspace-platform-starter/docs/how-to-define-apps.md
@@ -132,6 +132,7 @@ The app provider definition can either come from your manifest or from an extern
 | cacheDurationInMinutes           | How many minutes should we wait before refreshing the list from the server? Can be used on it's own or with cacheDurationInSeconds.                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | cacheDurationInSeconds           | How many seconds should we wait before refreshing the list from the server? Can be used on it's own or with cacheDurationInMinutes.                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | manifestTypes                    | An array of the manifestTypes the app should support from the apps.json feed                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| updatablePreference              | An array of the launch preferences that should be updatable for apps by default (e.g. you want bounds to be dynamic when launching an app)                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 
 ### An Example Of What These Settings Would Look Like (Taken From [manifest.fin.json](../public/manifest.fin.json))
 
@@ -154,6 +155,9 @@ The app provider definition can either come from your manifest or from an extern
              "manifest",
              "desktop-browser",
              "connection"
+           ],
+           "updatableLaunchPreference": [
+            { "name": "bounds" }
            ]
         },
 ```

--- a/how-to/workspace-platform-starter/public/manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/manifest.fin.json
@@ -198,7 +198,10 @@
 				"desktop-browser",
 				"connection",
 				"endpoint"
-			]
+			],
+			"updatableLaunchPreference": [{
+				"name": "bounds"
+			}]
 		},
 		"endpointProvider": {
 			"modules": [

--- a/how-to/workspace-platform-starter/public/manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/manifest.fin.json
@@ -199,9 +199,11 @@
 				"connection",
 				"endpoint"
 			],
-			"updatableLaunchPreference": [{
-				"name": "bounds"
-			}]
+			"updatableLaunchPreference": [
+				{
+					"name": "bounds"
+				}
+			]
 		},
 		"endpointProvider": {
 			"modules": [

--- a/how-to/workspace-platform-starter/public/schemas/fdc3v1.2-appd.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/fdc3v1.2-appd.schema.json
@@ -257,25 +257,15 @@
 			"type": "object"
 		},
 		"InteropConfig": {
-			"$ref": "#/definitions/__type_1"
+			"$ref": "#/definitions/__type_2"
 		},
 		"LaunchPreference": {
 			"additionalProperties": false,
 			"description": "Are there any preferences you would like to apply when launching this application?",
 			"properties": {
 				"bounds": {
-					"additionalProperties": false,
-					"description": "Do you wish to specify a custom height/width that should be used when this application is launched?",
-					"properties": {
-						"height": {
-							"type": "number"
-						},
-						"width": {
-							"type": "number"
-						}
-					},
-					"required": ["height", "width"],
-					"type": "object"
+					"$ref": "#/definitions/Partial",
+					"description": "Do you wish to specify a custom height/width and/or x/y position that should be used when this application is launched?"
 				},
 				"defaultCentered": {
 					"description": "Should the launched UI be positioned in the center of the screen?",
@@ -370,7 +360,10 @@
 			"$ref": "#/definitions/__type"
 		},
 		"Partial_1": {
-			"$ref": "#/definitions/__type_2"
+			"$ref": "#/definitions/__type_1"
+		},
+		"Partial_2": {
+			"$ref": "#/definitions/__type_3"
 		},
 		"Preference.T": {
 			"description": "A list of Web related constraints",
@@ -406,17 +399,17 @@
 					"items": {
 						"anyOf": [
 							{
-								"$ref": "#/definitions/ViewPreference<never>"
+								"$ref": "#/definitions/ViewPreferenceUrl"
 							},
 							{
-								"$ref": "#/definitions/ViewPreferenceUrl"
+								"$ref": "#/definitions/ViewPreference<never>"
 							}
 						]
 					},
 					"type": "array"
 				},
 				"view": {
-					"$ref": "#/definitions/Partial",
+					"$ref": "#/definitions/Partial_1",
 					"description": "The option to override a few settings that are specific to views."
 				}
 			},
@@ -516,17 +509,17 @@
 					"items": {
 						"anyOf": [
 							{
-								"$ref": "#/definitions/WindowPreference<never>"
+								"$ref": "#/definitions/WindowPreferenceUrl"
 							},
 							{
-								"$ref": "#/definitions/WindowPreferenceUrl"
+								"$ref": "#/definitions/WindowPreference<never>"
 							}
 						]
 					},
 					"type": "array"
 				},
 				"window": {
-					"$ref": "#/definitions/Partial_1",
+					"$ref": "#/definitions/Partial_2",
 					"description": "The option to override a few settings that are specific to windows."
 				}
 			},
@@ -565,6 +558,24 @@
 		"__type": {
 			"additionalProperties": false,
 			"properties": {
+				"height": {
+					"type": "number"
+				},
+				"left": {
+					"type": "number"
+				},
+				"top": {
+					"type": "number"
+				},
+				"width": {
+					"type": "number"
+				}
+			},
+			"type": "object"
+		},
+		"__type_1": {
+			"additionalProperties": false,
+			"properties": {
 				"customData": {
 					"description": "A field that the user can attach serializable data to be ferried around with the window options.\n_When omitted, _inherits_ from the parent application._"
 				},
@@ -577,7 +588,7 @@
 			},
 			"type": "object"
 		},
-		"__type_1": {
+		"__type_2": {
 			"additionalProperties": false,
 			"description": "Information relevant to the Interop Broker.",
 			"properties": {
@@ -592,7 +603,7 @@
 			},
 			"type": "object"
 		},
-		"__type_2": {
+		"__type_3": {
 			"additionalProperties": false,
 			"properties": {
 				"customData": {

--- a/how-to/workspace-platform-starter/public/schemas/fdc3v2.0-appd.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/fdc3v2.0-appd.schema.json
@@ -417,25 +417,15 @@
 			"type": "object"
 		},
 		"InteropConfig": {
-			"$ref": "#/definitions/__type_1"
+			"$ref": "#/definitions/__type_2"
 		},
 		"LaunchPreference": {
 			"additionalProperties": false,
 			"description": "Are there any preferences you would like to apply when launching this application?",
 			"properties": {
 				"bounds": {
-					"additionalProperties": false,
-					"description": "Do you wish to specify a custom height/width that should be used when this application is launched?",
-					"properties": {
-						"height": {
-							"type": "number"
-						},
-						"width": {
-							"type": "number"
-						}
-					},
-					"required": ["height", "width"],
-					"type": "object"
+					"$ref": "#/definitions/Partial",
+					"description": "Do you wish to specify a custom height/width and/or x/y position that should be used when this application is launched?"
 				},
 				"defaultCentered": {
 					"description": "Should the launched UI be positioned in the center of the screen?",
@@ -563,7 +553,10 @@
 			"$ref": "#/definitions/__type"
 		},
 		"Partial_1": {
-			"$ref": "#/definitions/__type_2"
+			"$ref": "#/definitions/__type_1"
+		},
+		"Partial_2": {
+			"$ref": "#/definitions/__type_3"
 		},
 		"Preference.T": {
 			"description": "A list of Web related constraints",
@@ -623,17 +616,17 @@
 					"items": {
 						"anyOf": [
 							{
-								"$ref": "#/definitions/ViewPreference<never>"
+								"$ref": "#/definitions/ViewPreferenceUrl"
 							},
 							{
-								"$ref": "#/definitions/ViewPreferenceUrl"
+								"$ref": "#/definitions/ViewPreference<never>"
 							}
 						]
 					},
 					"type": "array"
 				},
 				"view": {
-					"$ref": "#/definitions/Partial",
+					"$ref": "#/definitions/Partial_1",
 					"description": "The option to override a few settings that are specific to views."
 				}
 			},
@@ -745,17 +738,17 @@
 					"items": {
 						"anyOf": [
 							{
-								"$ref": "#/definitions/WindowPreference<never>"
+								"$ref": "#/definitions/WindowPreferenceUrl"
 							},
 							{
-								"$ref": "#/definitions/WindowPreferenceUrl"
+								"$ref": "#/definitions/WindowPreference<never>"
 							}
 						]
 					},
 					"type": "array"
 				},
 				"window": {
-					"$ref": "#/definitions/Partial_1",
+					"$ref": "#/definitions/Partial_2",
 					"description": "The option to override a few settings that are specific to windows."
 				}
 			},
@@ -794,6 +787,24 @@
 		"__type": {
 			"additionalProperties": false,
 			"properties": {
+				"height": {
+					"type": "number"
+				},
+				"left": {
+					"type": "number"
+				},
+				"top": {
+					"type": "number"
+				},
+				"width": {
+					"type": "number"
+				}
+			},
+			"type": "object"
+		},
+		"__type_1": {
+			"additionalProperties": false,
+			"properties": {
 				"customData": {
 					"description": "A field that the user can attach serializable data to be ferried around with the window options.\n_When omitted, _inherits_ from the parent application._"
 				},
@@ -806,7 +817,7 @@
 			},
 			"type": "object"
 		},
-		"__type_1": {
+		"__type_2": {
 			"additionalProperties": false,
 			"description": "Information relevant to the Interop Broker.",
 			"properties": {
@@ -821,7 +832,7 @@
 			},
 			"type": "object"
 		},
-		"__type_2": {
+		"__type_3": {
 			"additionalProperties": false,
 			"properties": {
 				"customData": {

--- a/how-to/workspace-platform-starter/public/schemas/platform-apps.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/platform-apps.schema.json
@@ -327,18 +327,8 @@
 			"description": "Are there any preferences you would like to apply when launching this application?",
 			"properties": {
 				"bounds": {
-					"additionalProperties": false,
-					"description": "Do you wish to specify a custom height/width that should be used when this application is launched?",
-					"properties": {
-						"height": {
-							"type": "number"
-						},
-						"width": {
-							"type": "number"
-						}
-					},
-					"required": ["height", "width"],
-					"type": "object"
+					"$ref": "#/definitions/Partial_11",
+					"description": "Do you wish to specify a custom height/width and/or x/y position that should be used when this application is launched?"
 				},
 				"defaultCentered": {
 					"description": "Should the launched UI be positioned in the center of the screen?",
@@ -449,6 +439,9 @@
 		},
 		"Partial_12": {
 			"$ref": "#/definitions/__type_34"
+		},
+		"Partial_13": {
+			"$ref": "#/definitions/__type_35"
 		},
 		"Partial_2": {
 			"$ref": "#/definitions/__type_7"
@@ -729,17 +722,17 @@
 					"items": {
 						"anyOf": [
 							{
-								"$ref": "#/definitions/ViewPreference<never>"
+								"$ref": "#/definitions/ViewPreferenceUrl"
 							},
 							{
-								"$ref": "#/definitions/ViewPreferenceUrl"
+								"$ref": "#/definitions/ViewPreference<never>"
 							}
 						]
 					},
 					"type": "array"
 				},
 				"view": {
-					"$ref": "#/definitions/Partial_11",
+					"$ref": "#/definitions/Partial_12",
 					"description": "The option to override a few settings that are specific to views."
 				}
 			},
@@ -872,17 +865,17 @@
 					"items": {
 						"anyOf": [
 							{
-								"$ref": "#/definitions/WindowPreference<never>"
+								"$ref": "#/definitions/WindowPreferenceUrl"
 							},
 							{
-								"$ref": "#/definitions/WindowPreferenceUrl"
+								"$ref": "#/definitions/WindowPreference<never>"
 							}
 						]
 					},
 					"type": "array"
 				},
 				"window": {
-					"$ref": "#/definitions/Partial_12",
+					"$ref": "#/definitions/Partial_13",
 					"description": "The option to override a few settings that are specific to windows."
 				}
 			},
@@ -2123,6 +2116,24 @@
 		"__type_33": {
 			"additionalProperties": false,
 			"properties": {
+				"height": {
+					"type": "number"
+				},
+				"left": {
+					"type": "number"
+				},
+				"top": {
+					"type": "number"
+				},
+				"width": {
+					"type": "number"
+				}
+			},
+			"type": "object"
+		},
+		"__type_34": {
+			"additionalProperties": false,
+			"properties": {
 				"customData": {
 					"description": "A field that the user can attach serializable data to be ferried around with the window options.\n_When omitted, _inherits_ from the parent application._"
 				},
@@ -2135,7 +2146,7 @@
 			},
 			"type": "object"
 		},
-		"__type_34": {
+		"__type_35": {
 			"additionalProperties": false,
 			"properties": {
 				"customData": {

--- a/how-to/workspace-platform-starter/public/schemas/settings.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/settings.schema.json
@@ -50,7 +50,7 @@
             "$ref": "#/definitions/__type_14"
         },
         "AppAssetInfo": {
-            "$ref": "#/definitions/__type_48"
+            "$ref": "#/definitions/__type_49"
         },
         "AppEndpointOptions": {
             "anyOf": [
@@ -269,6 +269,13 @@
                     "description": "The specified app sources may include apps of many different manifest types. Which manifest types do you want\nyour platform to support (only the ones listed will be included in the end result).",
                     "items": {
                         "$ref": "#/definitions/ManifestTypeId"
+                    },
+                    "type": "array"
+                },
+                "updatableLaunchPreference": {
+                    "description": "Do you wish to allow specific launchPreferences to be specified when launching an app by default?",
+                    "items": {
+                        "$ref": "#/definitions/UpdatableLaunchPreferenceDefinition"
                     },
                     "type": "array"
                 }
@@ -2024,21 +2031,8 @@
             "description": "Are there any preferences you would like to apply when launching this application?",
             "properties": {
                 "bounds": {
-                    "additionalProperties": false,
-                    "description": "Do you wish to specify a custom height/width that should be used when this application is launched?",
-                    "properties": {
-                        "height": {
-                            "type": "number"
-                        },
-                        "width": {
-                            "type": "number"
-                        }
-                    },
-                    "required": [
-                        "height",
-                        "width"
-                    ],
-                    "type": "object"
+                    "$ref": "#/definitions/Partial_13",
+                    "description": "Do you wish to specify a custom height/width and/or x/y position that should be used when this application is launched?"
                 },
                 "defaultCentered": {
                     "description": "Should the launched UI be positioned in the center of the screen?",
@@ -3130,7 +3124,7 @@
                 "updatable": {
                     "description": "What can be specified when launching a native app. This is an array of named types to reflect the properties you are happy to be specified.\nBy default nothing can be set outside of the app definition when launching the app.",
                     "items": {
-                        "$ref": "#/definitions/NativePreference<never>"
+                        "$ref": "#/definitions/NativePreference<never>_1"
                     },
                     "type": "array"
                 }
@@ -3141,6 +3135,20 @@
             "type": "object"
         },
         "NativePreference<never>": {
+            "additionalProperties": false,
+            "description": "Which Launch Options are updatable and are there any constraints",
+            "properties": {
+                "name": {
+                    "$ref": "#/definitions/NativePreferenceName",
+                    "description": "What setting is updatable?"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object"
+        },
+        "NativePreference<never>_1": {
             "additionalProperties": false,
             "description": "Which Launch Options are updatable and are there any constraints",
             "properties": {
@@ -3231,7 +3239,7 @@
             "type": "object"
         },
         "NotificationIndicatorColorsWithScheme": {
-            "$ref": "#/definitions/__type_47"
+            "$ref": "#/definitions/__type_48"
         },
         "NotificationProviderOptions": {
             "additionalProperties": false,
@@ -3549,6 +3557,9 @@
         },
         "Partial_14": {
             "$ref": "#/definitions/__type_45"
+        },
+        "Partial_15": {
+            "$ref": "#/definitions/__type_46"
         },
         "Partial_2": {
             "$ref": "#/definitions/__type_5"
@@ -3964,7 +3975,7 @@
             "$ref": "#/definitions/__type_18"
         },
         "Record": {
-            "$ref": "#/definitions/__type_46"
+            "$ref": "#/definitions/__type_47"
         },
         "RectangleByEdgePositions": {
             "$ref": "#/definitions/__type_37"
@@ -4574,6 +4585,26 @@
             },
             "type": "object"
         },
+        "UpdatableLaunchPreferenceDefinition": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/WindowPreference<never>"
+                },
+                {
+                    "$ref": "#/definitions/WindowPreferenceUrl"
+                },
+                {
+                    "$ref": "#/definitions/ViewPreference<never>"
+                },
+                {
+                    "$ref": "#/definitions/ViewPreferenceUrl"
+                },
+                {
+                    "$ref": "#/definitions/NativePreference<never>"
+                }
+            ],
+            "description": "A type that contains the available updatable launch preferences"
+        },
         "VersionInfo": {
             "additionalProperties": false,
             "description": "Information about the version of the platform and it's dependencies",
@@ -4662,17 +4693,17 @@
                     "items": {
                         "anyOf": [
                             {
-                                "$ref": "#/definitions/ViewPreference<never>"
+                                "$ref": "#/definitions/ViewPreferenceUrl"
                             },
                             {
-                                "$ref": "#/definitions/ViewPreferenceUrl"
+                                "$ref": "#/definitions/ViewPreference<never>_1"
                             }
                         ]
                     },
                     "type": "array"
                 },
                 "view": {
-                    "$ref": "#/definitions/Partial_13",
+                    "$ref": "#/definitions/Partial_14",
                     "description": "The option to override a few settings that are specific to views."
                 }
             },
@@ -4914,6 +4945,20 @@
             ],
             "type": "object"
         },
+        "ViewPreference<never>_1": {
+            "additionalProperties": false,
+            "description": "Which Launch Options are updatable and are there any constraints",
+            "properties": {
+                "name": {
+                    "$ref": "#/definitions/ViewPreferenceName",
+                    "description": "What setting is updatable?"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object"
+        },
         "ViewPreferenceName": {
             "description": "The different type of settings that might apply to a view",
             "enum": [
@@ -5086,17 +5131,17 @@
                     "items": {
                         "anyOf": [
                             {
-                                "$ref": "#/definitions/WindowPreference<never>"
+                                "$ref": "#/definitions/WindowPreferenceUrl"
                             },
                             {
-                                "$ref": "#/definitions/WindowPreferenceUrl"
+                                "$ref": "#/definitions/WindowPreference<never>_1"
                             }
                         ]
                     },
                     "type": "array"
                 },
                 "window": {
-                    "$ref": "#/definitions/Partial_14",
+                    "$ref": "#/definitions/Partial_15",
                     "description": "The option to override a few settings that are specific to windows."
                 }
             },
@@ -5106,6 +5151,20 @@
             "type": "object"
         },
         "WindowPreference<never>": {
+            "additionalProperties": false,
+            "description": "Which Launch Options are updatable and are there any constraints",
+            "properties": {
+                "name": {
+                    "$ref": "#/definitions/WebPreferenceName",
+                    "description": "What setting is updatable?"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object"
+        },
+        "WindowPreference<never>_1": {
             "additionalProperties": false,
             "description": "Which Launch Options are updatable and are there any constraints",
             "properties": {
@@ -7198,14 +7257,17 @@
         "__type_44": {
             "additionalProperties": false,
             "properties": {
-                "customData": {
-                    "description": "A field that the user can attach serializable data to be ferried around with the window options.\n_When omitted, _inherits_ from the parent application._"
+                "height": {
+                    "type": "number"
                 },
-                "interop": {
-                    "$ref": "#/definitions/InteropConfig"
+                "left": {
+                    "type": "number"
                 },
-                "url": {
-                    "type": "string"
+                "top": {
+                    "type": "number"
+                },
+                "width": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -7227,6 +7289,17 @@
         },
         "__type_46": {
             "additionalProperties": false,
+            "properties": {
+                "customData": {
+                    "description": "A field that the user can attach serializable data to be ferried around with the window options.\n_When omitted, _inherits_ from the parent application._"
+                },
+                "interop": {
+                    "$ref": "#/definitions/InteropConfig"
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "__type_47": {
@@ -7234,6 +7307,10 @@
             "type": "object"
         },
         "__type_48": {
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "__type_49": {
             "additionalProperties": false,
             "properties": {
                 "alias": {

--- a/how-to/workspace-platform-starter/public/schemas/wps.manifest.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/wps.manifest.schema.json
@@ -48,7 +48,7 @@
 			"$ref": "#/definitions/__type_14"
 		},
 		"AppAssetInfo": {
-			"$ref": "#/definitions/__type_48"
+			"$ref": "#/definitions/__type_49"
 		},
 		"AppEndpointOptions": {
 			"anyOf": [
@@ -250,6 +250,13 @@
 					"description": "The specified app sources may include apps of many different manifest types. Which manifest types do you want\nyour platform to support (only the ones listed will be included in the end result).",
 					"items": {
 						"$ref": "#/definitions/ManifestTypeId"
+					},
+					"type": "array"
+				},
+				"updatableLaunchPreference": {
+					"description": "Do you wish to allow specific launchPreferences to be specified when launching an app by default?",
+					"items": {
+						"$ref": "#/definitions/UpdatableLaunchPreferenceDefinition"
 					},
 					"type": "array"
 				}
@@ -709,7 +716,7 @@
 			"$ref": "#/definitions/__type_15"
 		},
 		"ContextGroupInfo": {
-			"$ref": "#/definitions/__type_52"
+			"$ref": "#/definitions/__type_53"
 		},
 		"ContextGroupStates": {
 			"$ref": "#/definitions/__type_39"
@@ -1034,7 +1041,7 @@
 			"$ref": "#/definitions/__type_31"
 		},
 		"DefaultDomainSettings": {
-			"$ref": "#/definitions/__type_55"
+			"$ref": "#/definitions/__type_56"
 		},
 		"DelayStrategy": {
 			"additionalProperties": false,
@@ -1088,7 +1095,7 @@
 			"$ref": "#/definitions/__type_36"
 		},
 		"DisplayMetadata": {
-			"$ref": "#/definitions/__type_53"
+			"$ref": "#/definitions/__type_54"
 		},
 		"DockButtonAction": {
 			"additionalProperties": false,
@@ -1586,7 +1593,7 @@
 			"type": "string"
 		},
 		"FileDownloadSettings": {
-			"$ref": "#/definitions/__type_56"
+			"$ref": "#/definitions/__type_57"
 		},
 		"GlobalContextMenuOptionType": {
 			"description": "Types of global context menu options, including pre-defined ones.\nUser-defined context menu items should use the value `Custom`",
@@ -1889,13 +1896,13 @@
 			"type": "object"
 		},
 		"InteropBrokerOptions": {
-			"$ref": "#/definitions/__type_51"
+			"$ref": "#/definitions/__type_52"
 		},
 		"InteropConfig": {
 			"$ref": "#/definitions/__type_16"
 		},
 		"InteropLoggingOptions": {
-			"$ref": "#/definitions/__type_54"
+			"$ref": "#/definitions/__type_55"
 		},
 		"LaunchExternalProcessListener": {
 			"$ref": "#/definitions/__type_41"
@@ -1905,18 +1912,8 @@
 			"description": "Are there any preferences you would like to apply when launching this application?",
 			"properties": {
 				"bounds": {
-					"additionalProperties": false,
-					"description": "Do you wish to specify a custom height/width that should be used when this application is launched?",
-					"properties": {
-						"height": {
-							"type": "number"
-						},
-						"width": {
-							"type": "number"
-						}
-					},
-					"required": ["height", "width"],
-					"type": "object"
+					"$ref": "#/definitions/Partial_13",
+					"description": "Do you wish to specify a custom height/width and/or x/y position that should be used when this application is launched?"
 				},
 				"defaultCentered": {
 					"description": "Should the launched UI be positioned in the center of the screen?",
@@ -2924,7 +2921,7 @@
 				"updatable": {
 					"description": "What can be specified when launching a native app. This is an array of named types to reflect the properties you are happy to be specified.\nBy default nothing can be set outside of the app definition when launching the app.",
 					"items": {
-						"$ref": "#/definitions/NativePreference<never>"
+						"$ref": "#/definitions/NativePreference<never>_1"
 					},
 					"type": "array"
 				}
@@ -2933,6 +2930,18 @@
 			"type": "object"
 		},
 		"NativePreference<never>": {
+			"additionalProperties": false,
+			"description": "Which Launch Options are updatable and are there any constraints",
+			"properties": {
+				"name": {
+					"$ref": "#/definitions/NativePreferenceName",
+					"description": "What setting is updatable?"
+				}
+			},
+			"required": ["name"],
+			"type": "object"
+		},
+		"NativePreference<never>_1": {
 			"additionalProperties": false,
 			"description": "Which Launch Options are updatable and are there any constraints",
 			"properties": {
@@ -3019,7 +3028,7 @@
 			"type": "object"
 		},
 		"NotificationIndicatorColorsWithScheme": {
-			"$ref": "#/definitions/__type_47"
+			"$ref": "#/definitions/__type_48"
 		},
 		"NotificationProviderOptions": {
 			"additionalProperties": false,
@@ -3305,7 +3314,10 @@
 			"$ref": "#/definitions/__type_45"
 		},
 		"Partial_15": {
-			"$ref": "#/definitions/__type_50"
+			"$ref": "#/definitions/__type_46"
+		},
+		"Partial_16": {
+			"$ref": "#/definitions/__type_51"
 		},
 		"Partial_2": {
 			"$ref": "#/definitions/__type_5"
@@ -3700,7 +3712,7 @@
 					"type": "number"
 				},
 				"defaultWindowOptions": {
-					"$ref": "#/definitions/Partial_15",
+					"$ref": "#/definitions/Partial_16",
 					"description": "**Platforms Only.** Default window options apply to all platform windows."
 				},
 				"disableDefaultCommands": {
@@ -3960,7 +3972,7 @@
 			"$ref": "#/definitions/__type_18"
 		},
 		"Record": {
-			"$ref": "#/definitions/__type_46"
+			"$ref": "#/definitions/__type_47"
 		},
 		"RectangleByEdgePositions": {
 			"$ref": "#/definitions/__type_37"
@@ -4073,7 +4085,7 @@
 			"type": "object"
 		},
 		"Snapshot": {
-			"$ref": "#/definitions/__type_49"
+			"$ref": "#/definitions/__type_50"
 		},
 		"SnapshotSourceConnection": {
 			"additionalProperties": false,
@@ -4518,6 +4530,26 @@
 			},
 			"type": "object"
 		},
+		"UpdatableLaunchPreferenceDefinition": {
+			"anyOf": [
+				{
+					"$ref": "#/definitions/WindowPreference<never>"
+				},
+				{
+					"$ref": "#/definitions/WindowPreferenceUrl"
+				},
+				{
+					"$ref": "#/definitions/ViewPreference<never>"
+				},
+				{
+					"$ref": "#/definitions/ViewPreferenceUrl"
+				},
+				{
+					"$ref": "#/definitions/NativePreference<never>"
+				}
+			],
+			"description": "A type that contains the available updatable launch preferences"
+		},
 		"VersionInfo": {
 			"additionalProperties": false,
 			"description": "Information about the version of the platform and it's dependencies",
@@ -4606,17 +4638,17 @@
 					"items": {
 						"anyOf": [
 							{
-								"$ref": "#/definitions/ViewPreference<never>"
+								"$ref": "#/definitions/ViewPreferenceUrl"
 							},
 							{
-								"$ref": "#/definitions/ViewPreferenceUrl"
+								"$ref": "#/definitions/ViewPreference<never>_1"
 							}
 						]
 					},
 					"type": "array"
 				},
 				"view": {
-					"$ref": "#/definitions/Partial_13",
+					"$ref": "#/definitions/Partial_14",
 					"description": "The option to override a few settings that are specific to views."
 				}
 			},
@@ -4830,6 +4862,18 @@
 			"type": "object"
 		},
 		"ViewPreference<never>": {
+			"additionalProperties": false,
+			"description": "Which Launch Options are updatable and are there any constraints",
+			"properties": {
+				"name": {
+					"$ref": "#/definitions/ViewPreferenceName",
+					"description": "What setting is updatable?"
+				}
+			},
+			"required": ["name"],
+			"type": "object"
+		},
+		"ViewPreference<never>_1": {
 			"additionalProperties": false,
 			"description": "Which Launch Options are updatable and are there any constraints",
 			"properties": {
@@ -5164,17 +5208,17 @@
 					"items": {
 						"anyOf": [
 							{
-								"$ref": "#/definitions/WindowPreference<never>"
+								"$ref": "#/definitions/WindowPreferenceUrl"
 							},
 							{
-								"$ref": "#/definitions/WindowPreferenceUrl"
+								"$ref": "#/definitions/WindowPreference<never>_1"
 							}
 						]
 					},
 					"type": "array"
 				},
 				"window": {
-					"$ref": "#/definitions/Partial_14",
+					"$ref": "#/definitions/Partial_15",
 					"description": "The option to override a few settings that are specific to windows."
 				}
 			},
@@ -5533,6 +5577,18 @@
 			"type": "object"
 		},
 		"WindowPreference<never>": {
+			"additionalProperties": false,
+			"description": "Which Launch Options are updatable and are there any constraints",
+			"properties": {
+				"name": {
+					"$ref": "#/definitions/WebPreferenceName",
+					"description": "What setting is updatable?"
+				}
+			},
+			"required": ["name"],
+			"type": "object"
+		},
+		"WindowPreference<never>_1": {
 			"additionalProperties": false,
 			"description": "Which Launch Options are updatable and are there any constraints",
 			"properties": {
@@ -7500,14 +7556,17 @@
 		"__type_44": {
 			"additionalProperties": false,
 			"properties": {
-				"customData": {
-					"description": "A field that the user can attach serializable data to be ferried around with the window options.\n_When omitted, _inherits_ from the parent application._"
+				"height": {
+					"type": "number"
 				},
-				"interop": {
-					"$ref": "#/definitions/InteropConfig"
+				"left": {
+					"type": "number"
 				},
-				"url": {
-					"type": "string"
+				"top": {
+					"type": "number"
+				},
+				"width": {
+					"type": "number"
 				}
 			},
 			"type": "object"
@@ -7529,6 +7588,17 @@
 		},
 		"__type_46": {
 			"additionalProperties": false,
+			"properties": {
+				"customData": {
+					"description": "A field that the user can attach serializable data to be ferried around with the window options.\n_When omitted, _inherits_ from the parent application._"
+				},
+				"interop": {
+					"$ref": "#/definitions/InteropConfig"
+				},
+				"url": {
+					"type": "string"
+				}
+			},
 			"type": "object"
 		},
 		"__type_47": {
@@ -7536,6 +7606,10 @@
 			"type": "object"
 		},
 		"__type_48": {
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"__type_49": {
 			"additionalProperties": false,
 			"properties": {
 				"alias": {
@@ -7564,46 +7638,6 @@
 				}
 			},
 			"required": ["alias", "src", "version"],
-			"type": "object"
-		},
-		"__type_49": {
-			"additionalProperties": false,
-			"properties": {
-				"interopSnapshotDetails": {
-					"additionalProperties": false,
-					"properties": {
-						"contextGroupStates": {
-							"$ref": "#/definitions/ContextGroupStates"
-						}
-					},
-					"required": ["contextGroupStates"],
-					"type": "object"
-				},
-				"snapshotDetails": {
-					"additionalProperties": false,
-					"properties": {
-						"monitorInfo": {
-							"$ref": "#/definitions/MonitorInfo"
-						},
-						"runtimeVersion": {
-							"type": "string"
-						},
-						"timestamp": {
-							"type": "string"
-						}
-					},
-					"required": ["monitorInfo", "runtimeVersion", "timestamp"],
-					"type": "object"
-				},
-				"windows": {
-					"description": "The array of window options objects",
-					"items": {
-						"$ref": "#/definitions/WindowCreationOptions"
-					},
-					"type": "array"
-				}
-			},
-			"required": ["windows"],
 			"type": "object"
 		},
 		"__type_5": {
@@ -7781,6 +7815,46 @@
 			"type": "object"
 		},
 		"__type_50": {
+			"additionalProperties": false,
+			"properties": {
+				"interopSnapshotDetails": {
+					"additionalProperties": false,
+					"properties": {
+						"contextGroupStates": {
+							"$ref": "#/definitions/ContextGroupStates"
+						}
+					},
+					"required": ["contextGroupStates"],
+					"type": "object"
+				},
+				"snapshotDetails": {
+					"additionalProperties": false,
+					"properties": {
+						"monitorInfo": {
+							"$ref": "#/definitions/MonitorInfo"
+						},
+						"runtimeVersion": {
+							"type": "string"
+						},
+						"timestamp": {
+							"type": "string"
+						}
+					},
+					"required": ["monitorInfo", "runtimeVersion", "timestamp"],
+					"type": "object"
+				},
+				"windows": {
+					"description": "The array of window options objects",
+					"items": {
+						"$ref": "#/definitions/WindowCreationOptions"
+					},
+					"type": "array"
+				}
+			},
+			"required": ["windows"],
+			"type": "object"
+		},
+		"__type_51": {
 			"additionalProperties": false,
 			"properties": {
 				"_internalWorkspaceData": {},
@@ -8069,7 +8143,7 @@
 			},
 			"type": "object"
 		},
-		"__type_51": {
+		"__type_52": {
 			"additionalProperties": false,
 			"properties": {
 				"contextGroups": {
@@ -8081,7 +8155,7 @@
 			},
 			"type": "object"
 		},
-		"__type_52": {
+		"__type_53": {
 			"additionalProperties": false,
 			"description": "Information for a Context Group. Contains metadata for displaying the group properly.",
 			"properties": {
@@ -8097,7 +8171,7 @@
 			"required": ["id"],
 			"type": "object"
 		},
-		"__type_53": {
+		"__type_54": {
 			"additionalProperties": false,
 			"description": "The display data for a context group.",
 			"properties": {
@@ -8116,7 +8190,7 @@
 			},
 			"type": "object"
 		},
-		"__type_54": {
+		"__type_55": {
 			"additionalProperties": false,
 			"properties": {
 				"afterAction": {
@@ -8145,7 +8219,7 @@
 			"required": ["afterAction", "beforeAction"],
 			"type": "object"
 		},
-		"__type_55": {
+		"__type_56": {
 			"additionalProperties": false,
 			"properties": {
 				"rules": {
@@ -8178,7 +8252,7 @@
 			"required": ["rules"],
 			"type": "object"
 		},
-		"__type_56": {
+		"__type_57": {
 			"additionalProperties": false,
 			"properties": {
 				"rules": {


### PR DESCRIPTION
- Added Additional Monitor Awareness
  - Initial set of updates to improve the multi-monitor experience.
  - Extracted Window Positioning Strategy logic from Platform Override to the utils-position.ts file so that it can be used/called from more than one place.
  - Improved launch preferences so that top and left can now be specified as part of the bounds.
  - Improved launch preferences by extending appProvider so that you can specify default updatable preferences that should apply across applications (Caution. Preferences such as url should remain app specific).
  - Dock now takes monitor into account when launching apps using the app entry type or launch-view action or favorites menu option (module). This only applies to views and windows (not snapshots or other types of app).
  - Interop Broker now takes into account who raised the intent/fdc3.open request when launching a view/window in response (it will position it on the same monitor as the requesting app if possible using the window positioning strategy)