### PR TITLE
Add support for new icons urls

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -13,6 +13,8 @@
   - Dock now takes monitor into account when launching apps using the app entry type or launch-view action or favorites menu option (module). This only applies to views and windows (not snapshots or other types of app).
   - Interop Broker now takes into account who raised the intent/fdc3.open request when launching a view/window in response (it will position it on the same monitor as the requesting app if possible using the window positioning strategy)
 - Removed the quote and emoji integration code and dependencies, examples of how they are implemented can be seen in the customize-home-templates example
+- Removed the deprecated dock config for `buttons` and `apps`
+- Added theming support for the new multi state icon urls for browser buttons
 
 ## v16
 

--- a/how-to/workspace-platform-starter/client/src/framework/buttons.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/buttons.ts
@@ -14,7 +14,7 @@ import { getSettings } from "./settings";
 import type { WorkspacePlatformToolbarButton } from "./shapes/browser-shapes";
 import type { ColorSchemeMode } from "./shapes/theme-shapes";
 import { getCurrentColorSchemeMode, getCurrentIconFolder, themeUrl } from "./themes";
-import { isEmpty, objectClone } from "./utils";
+import { isEmpty, isObject, isString, objectClone } from "./utils";
 
 let configToolbarButtons: WorkspacePlatformToolbarButton[] | undefined;
 let configButtonsRetrieved: boolean = false;
@@ -170,15 +170,33 @@ async function getConfigToolbarButtons(): Promise<WorkspacePlatformToolbarButton
  * @returns The themed button.
  */
 function themeButton(
-	button: ToolbarButton & { iconUrl?: string },
+	button: ToolbarButton,
 	iconFolder: string,
 	colorSchemeMode: ColorSchemeMode
-): ToolbarButton & { iconUrl?: string } {
+): ToolbarButton {
 	// We need to duplicate the button, as we don't want to lose
-	// any placeholders in the iconUrl
-	const buttonCopy: ToolbarButton & { iconUrl?: string } = objectClone(button);
+	// any placeholders in the iconUrl properties
+	const buttonCopy = objectClone(
+		button as unknown as {
+			[id: string]: string | { [id: string]: string | undefined } | undefined;
+		}
+	);
 
-	buttonCopy.iconUrl = themeUrl(buttonCopy.iconUrl, iconFolder, colorSchemeMode);
+	const keys = Object.keys(buttonCopy);
+	for (const key of keys) {
+		// If the property ends with iconUrl then we need to theme it.
+		// It could be a single string or an object with multiple states e.g. enabled/disabled.
+		if (key.toLowerCase().endsWith("iconurl")) {
+			const prop = buttonCopy[key];
+			if (isString(prop)) {
+				buttonCopy[key] = themeUrl(prop, iconFolder, colorSchemeMode);
+			} else if (isObject(prop)) {
+				for (const key2 of Object.keys(prop)) {
+					prop[key2] = themeUrl(prop[key2], iconFolder, colorSchemeMode);
+				}
+			}
+		}
+	}
 
-	return buttonCopy;
+	return buttonCopy as unknown as ToolbarButton;
 }

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/dock-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/dock-shapes.ts
@@ -40,18 +40,6 @@ export interface DockProviderOptions {
 	entries?: DockButtonTypes[];
 
 	/**
-	 * What apps should be made available via the dock, this property is deprecated, use entries.
-	 * @deprecated
-	 */
-	apps?: DockButtonAppsByTag[];
-
-	/**
-	 * What custom actions should be made available via the dock, this property is deprecated, use entries.
-	 * @deprecated
-	 */
-	buttons?: (DockButtonApp | DockButtonAction | DockButtonDropdown)[];
-
-	/**
 	 * Configured a default for the popup menu style, defaults to platform.
 	 */
 	popupMenuStyle?: PopupMenuStyles;

--- a/how-to/workspace-platform-starter/client/src/framework/workspace/dock.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/workspace/dock.ts
@@ -186,12 +186,6 @@ function buildWorkspaceButtons(): WorkspaceButton[] {
 async function buildButtons(): Promise<DockButton[]> {
 	if (dockProviderOptions) {
 		const entries = Array.isArray(dockProviderOptions.entries) ? [...dockProviderOptions.entries] : [];
-		if (Array.isArray(dockProviderOptions.apps)) {
-			entries.push(...dockProviderOptions.apps);
-		}
-		if (Array.isArray(dockProviderOptions.buttons)) {
-			entries.push(...dockProviderOptions.buttons);
-		}
 		usedConditions.clear();
 
 		return buildButtonsFromEntries(entries);

--- a/how-to/workspace-platform-starter/client/types/module/shapes/dock-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/dock-shapes.d.ts
@@ -33,16 +33,6 @@ export interface DockProviderOptions {
 	 */
 	entries?: DockButtonTypes[];
 	/**
-	 * What apps should be made available via the dock, this property is deprecated, use entries.
-	 * @deprecated
-	 */
-	apps?: DockButtonAppsByTag[];
-	/**
-	 * What custom actions should be made available via the dock, this property is deprecated, use entries.
-	 * @deprecated
-	 */
-	buttons?: (DockButtonApp | DockButtonAction | DockButtonDropdown)[];
-	/**
 	 * Configured a default for the popup menu style, defaults to platform.
 	 */
 	popupMenuStyle?: PopupMenuStyles;

--- a/how-to/workspace-platform-starter/public/schemas/settings.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/settings.schema.json
@@ -1365,30 +1365,6 @@
             "additionalProperties": false,
             "description": "Options for the dock provider.",
             "properties": {
-                "apps": {
-                    "description": "What apps should be made available via the dock, this property is deprecated, use entries.",
-                    "items": {
-                        "$ref": "#/definitions/DockButtonAppsByTag"
-                    },
-                    "type": "array"
-                },
-                "buttons": {
-                    "description": "What custom actions should be made available via the dock, this property is deprecated, use entries.",
-                    "items": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/definitions/DockButtonApp"
-                            },
-                            {
-                                "$ref": "#/definitions/DockButtonAction"
-                            },
-                            {
-                                "$ref": "#/definitions/DockButtonDropdown"
-                            }
-                        ]
-                    },
-                    "type": "array"
-                },
                 "disableUserRearrangement": {
                     "description": "Disallow rearrangement of dock icons by setting this flag.",
                     "type": "boolean"

--- a/how-to/workspace-platform-starter/public/schemas/wps.manifest.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/wps.manifest.schema.json
@@ -1295,30 +1295,6 @@
 			"additionalProperties": false,
 			"description": "Options for the dock provider.",
 			"properties": {
-				"apps": {
-					"description": "What apps should be made available via the dock, this property is deprecated, use entries.",
-					"items": {
-						"$ref": "#/definitions/DockButtonAppsByTag"
-					},
-					"type": "array"
-				},
-				"buttons": {
-					"description": "What custom actions should be made available via the dock, this property is deprecated, use entries.",
-					"items": {
-						"anyOf": [
-							{
-								"$ref": "#/definitions/DockButtonApp"
-							},
-							{
-								"$ref": "#/definitions/DockButtonAction"
-							},
-							{
-								"$ref": "#/definitions/DockButtonDropdown"
-							}
-						]
-					},
-					"type": "array"
-				},
 				"disableUserRearrangement": {
 					"description": "Disallow rearrangement of dock icons by setting this flag.",
 					"type": "boolean"


### PR DESCRIPTION
- Add support for new customisable browser buttons urls e.g. locked and tab icons
- Removed deprecated dock `apps` and `buttons` entries