### PR TITLE
Added updated fdc3 support

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Removed the quote and emoji integration code and dependencies, examples of how they are implemented can be seen in the customize-home-templates example
 - Removed the deprecated dock config for `buttons` and `apps`
 - Added theming support for the new multi state icon urls for browser buttons
+- Added additional FDC3 support so that [context metadata](https://fdc3.finos.org/docs/api/ref/Metadata#contextmetadata) is passed when context is broadcast, an intent is raised or fdc3.open is used. This can be used with fdc3.getInfo to see if the context you received was sent from your app.
+- Updated example call app so that it logs the new context metadata when an intent is raised or context received. Added context support to the call app. Updated the example participant history app so that it console logs the context metadata received.
 
 ## v16
 

--- a/how-to/workspace-platform-starter/client/src/framework/platform/interopbroker.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/platform/interopbroker.ts
@@ -4,7 +4,8 @@ import {
 	type AppIdentifier,
 	type AppMetadata,
 	type ImplementationMetadata,
-	type IntentResolution
+	type IntentResolution,
+	type ContextMetadata
 } from "@finos/fdc3";
 import type OpenFin from "@openfin/core";
 import type { WindowPositioningOptions } from "workspace-platform-starter/shapes/browser-shapes";
@@ -40,7 +41,7 @@ import type {
 	IntentTargetMetaData,
 	ProcessedContext
 } from "../shapes/interopbroker-shapes";
-import { formatError, isEmpty, isString, isStringValue, sanitizeString } from "../utils";
+import { formatError, isEmpty, isString, isStringValue, randomUUID, sanitizeString } from "../utils";
 import { AppIntentHelper } from "./broker/app-intent-helper";
 import { ClientRegistrationHelper } from "./broker/client-registration-helper";
 import { IntentResolverHelper } from "./broker/intent-resolver-helper";
@@ -73,6 +74,8 @@ export function interopOverride(
 
 		private _windowPositionOptions?: WindowPositioningOptions;
 
+		private readonly _metadataKey: Readonly<string>;
+
 		/**
 		 * Create a new instance of InteropBroker.
 		 */
@@ -84,6 +87,7 @@ export function interopOverride(
 				async (clientIdentity: OpenFin.ClientIdentity) => this.lookupAppId(clientIdentity),
 				logger
 			);
+			this._metadataKey = `_metadata_${randomUUID()}`;
 			getSettings()
 				.then(async (customSettings) => {
 					if (!isEmpty(customSettings) && !isEmpty(customSettings.browserProvider)) {
@@ -160,7 +164,36 @@ export function interopOverride(
 			clientIdentity: OpenFin.ClientIdentity
 		): Promise<void> {
 			sentContext.context = await this.processContext(sentContext.context);
+			const contextMetadata = await this.getContextMetadata(clientIdentity);
+
+			sentContext.context = {
+				...sentContext.context,
+				[this._metadataKey]: contextMetadata
+			} as unknown as OpenFin.Context;
 			super.setContext(sentContext, clientIdentity);
+		}
+
+		/**
+		 * Invokes the context handler.
+		 * @param clientIdentity The client identity.
+		 * @param handlerId The handler ID.
+		 * @param context The context to invoke.
+		 * @returns A promise that resolves when the context handler is invoked.
+		 */
+		public async invokeContextHandler(
+			clientIdentity: OpenFin.ClientIdentity,
+			handlerId: string,
+			context: OpenFin.Context
+		): Promise<void> {
+			const passedContext: { [key: string]: unknown } = { ...context };
+			const contextMetadata = passedContext[this._metadataKey];
+			if (!isEmpty(contextMetadata)) {
+				delete passedContext[this._metadataKey];
+			}
+			return super.invokeContextHandler(clientIdentity, handlerId, {
+				...passedContext,
+				contextMetadata
+			} as unknown as OpenFin.Context);
 		}
 
 		/**
@@ -502,6 +535,37 @@ export function interopOverride(
 		}
 
 		/**
+		 * Invoke the intent handler.
+		 * @param clientIdentity The client identity.
+		 * @param handlerId The handler ID.
+		 * @param intent The intent to invoke.
+		 * @returns A promise that resolves when the intent handler is invoked.
+		 */
+		public async invokeIntentHandler(
+			clientIdentity: OpenFin.ClientIdentity,
+			handlerId: string,
+			intent: OpenFin.Intent
+		): Promise<void> {
+			const { context } = intent;
+			let contextMetadata: ContextMetadata | undefined;
+			let passedContext: { [key: string]: unknown } | undefined;
+			if (!isEmpty(context)) {
+				passedContext = { ...context };
+				contextMetadata = passedContext[this._metadataKey] as ContextMetadata;
+				if (!isEmpty(contextMetadata)) {
+					delete passedContext[this._metadataKey];
+				}
+			}
+			return super.invokeIntentHandler(clientIdentity, handlerId, {
+				...intent,
+				context: {
+					...passedContext,
+					contextMetadata
+				} as unknown as OpenFin.Context
+			});
+		}
+
+		/**
 		 * Handle the FDC3 open.
 		 * @param fdc3OpenOptions The options for the open.
 		 * @param fdc3OpenOptions.app The platform app or its id.
@@ -600,10 +664,16 @@ export function interopOverride(
 							}
 
 							if (!isEmpty(trackedHandler)) {
-								await super.invokeContextHandler(
+								const contextToPass = await this.processContext(fdc3OpenOptions.context);
+								const contextMetadata = await this.getContextMetadata(clientIdentity);
+								const updatedContext: OpenFin.Context = {
+									...contextToPass,
+									[this._metadataKey]: contextMetadata
+								};
+								await this.invokeContextHandler(
 									trackedHandler.clientIdentity,
 									trackedHandler.handlerId,
-									fdc3OpenOptions.context
+									updatedContext
 								);
 							} else {
 								logger.warn(
@@ -799,9 +869,14 @@ export function interopOverride(
 			logger.info("Launching app with intent");
 			let platformIdentities: PlatformAppIdentifier[] | undefined = [];
 			let existingInstance = true;
+			let contextMetadata: ContextMetadata | undefined;
 
 			if (!isEmpty(intent?.context)) {
 				intent.context = await this.processContext(intent.context);
+				if (!isEmpty(clientIdentity)) {
+					contextMetadata = await this.getContextMetadata(clientIdentity);
+					intent.context = { ...intent.context, [this._metadataKey]: contextMetadata };
+				}
 			}
 
 			if (!isEmpty(instanceId)) {
@@ -1279,6 +1354,21 @@ export function interopOverride(
 				}
 			}
 			return context;
+		}
+
+		/**
+		 * Get the context metadata for a client identity.
+		 * @param clientIdentity The client identity.
+		 * @returns The context metadata.
+		 */
+		private async getContextMetadata(clientIdentity: OpenFin.ClientIdentity): Promise<ContextMetadata> {
+			const appId = (await this.lookupAppId(clientIdentity)) ?? clientIdentity.name;
+			return {
+				source: {
+					appId,
+					instanceId: clientIdentity.endpointId
+				}
+			};
 		}
 	}
 

--- a/how-to/workspace-platform-starter/public/common/views/contact/call-app/index.js
+++ b/how-to/workspace-platform-starter/public/common/views/contact/call-app/index.js
@@ -72,15 +72,21 @@ function initializeDOM() {
 	if (window.fdc3 !== undefined) {
 		const startCallIntent = 'StartCall';
 		const openAppIntent = 'OpenApp';
-		fdc3.addIntentListener(startCallIntent, (ctx) => {
+		fdc3.addIntentListener(startCallIntent, (ctx, metadata) => {
+			console.log(`Received Context For Intent: ${startCallIntent}`, ctx, metadata);
 			updateCallInformation(ctx, startCallIntent);
 			return new Promise((resolve) => {
 				// To demonstrate getResult in fdc3 2.0 we simply return the context that was sent.
 				resolve(ctx);
 			});
 		});
-		fdc3.addIntentListener(openAppIntent, (ctx) => {
+		fdc3.addIntentListener(openAppIntent, (ctx, metadata) => {
+			console.log(`Received Context For Intent: ${openAppIntent}`, ctx, metadata);
 			updateCallInformation(ctx, openAppIntent);
+		});
+		fdc3.addContextListener('fdc3.contact', (ctx, metadata) => {
+			console.log('Received Context', ctx, metadata);
+			updateCallInformation(ctx);
 		});
 	}
 }

--- a/how-to/workspace-platform-starter/public/common/views/contact/participant-history.view.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/contact/participant-history.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/contact/participant-history/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/workspace-platform-starter/public/common/views/contact/participant-history/index.js
+++ b/how-to/workspace-platform-starter/public/common/views/contact/participant-history/index.js
@@ -11,9 +11,10 @@ function initializeDOM() {
 /**
  * Handler for setting the context.
  * @param ctx The FDC3 context.
+ * @param metadata The FDC3 metadata.
  */
-function contextHandler(ctx) {
-	console.log('Context Received:', ctx);
+function contextHandler(ctx, metadata) {
+	console.log('Context Received:', ctx, metadata);
 	if (ctx.type === 'fdc3.contact') {
 		setContact(ctx);
 	}


### PR DESCRIPTION
- Added additional FDC3 support so that [context metadata](https://fdc3.finos.org/docs/api/ref/Metadata#contextmetadata) is passed when context is broadcast, an intent is raised or fdc3.open is used. This can be used with fdc3.getInfo to see if the context you received was sent from your app.
- Updated example call app so that it logs the new context metadata when an intent is raised or context received. Added context support to the call app. Updated the example participant history app so that it console logs the context metadata received.