### PR TITLE
Updated logic to check for string value

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Added sharing for pages moved into module
 - Added sharing for workspaces moved into module
 - Added example dummy share server for testing locally (stores in memory), to use update manifest.fin.json `https://workspace.openfin.co` references to `http://localhost:8080`
+- Fixed Interop Broker client registration helper logic to ensure that a connectionUrl has a value. Empty strings were resulting in native apps being identified as supporting FDC3 2.0 instead of interop.
 
 ## v15
 

--- a/how-to/workspace-platform-starter/client/src/framework/platform/broker/client-registration-helper.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/platform/broker/client-registration-helper.ts
@@ -9,7 +9,7 @@ import type {
 	ApiMetadata
 } from "../../shapes/interopbroker-shapes";
 import type { Logger } from "../../shapes/logger-shapes";
-import { isEmpty } from "../../utils";
+import { isEmpty, isStringValue } from "../../utils";
 
 /**
  * Used to track client interactions with a broker.
@@ -192,7 +192,7 @@ export class ClientRegistrationHelper {
 				const payloadApiVersion = payload?.apiVersion;
 				if (!isEmpty(payloadApiVersion) && !isEmpty(payloadApiVersion?.type)) {
 					apiVersion = payloadApiVersion;
-				} else if (!isEmpty(id.connectionUrl)) {
+				} else if (isStringValue(id.connectionUrl)) {
 					// if they haven't specified apiVersion meta data and it is external and has a url then we will assume fdc3 2.0
 					apiVersion = { type: "fdc3", version: "2.0" };
 				} else {


### PR DESCRIPTION
If a string value for connection url is provided then we are assuming fdc3 2.0 unless the connecting platform specifies a preference through the payload. This will ensure native apps do not get misidentified (as they passed an empty string for connection url).