### PR TITLE
fix: retain dock order when lifecycle conditions are triggered

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added support for dock submenus
 - Added support for customizing the taskbar icon for the splash screen window
 - Added an example of navigating content using navigation controls. Enabled through default window options in the main [manifest.fin.json](./public/manifest.fin.json) and in our developer docs snapshot [developer.snapshot.fin.json](./public/common/snapshots/developer.snapshot.fin.json)
+- Fixed an issue where the order of entries within dock would change when toggling between light and dark theme.
 
 ## v16.1.0
 


### PR DESCRIPTION
Let me know if you can think of a better way todo this. 

But... when you launch a platform. Reorder the dock entries then toggle the scheme (e.g. light -> dark) this causes the dock to be "refreshed":

https://github.com/built-on-openfin/workspace-starter/blob/2e0d2a1b7646276a90a198994f5c5a03059a8792/how-to/workspace-platform-starter/client/src/framework/workspace/dock.ts#L85

which uses `dockProviderOptions` here:

https://github.com/built-on-openfin/workspace-starter/blob/2e0d2a1b7646276a90a198994f5c5a03059a8792/how-to/workspace-platform-starter/client/src/framework/workspace/dock.ts#L188

this is not updated when the dock is reordered (it's only set when the dock is initially registered)

Hence, when we call `updateDockProviderConfig`, the order is then incorrect.

This PR fixes this behavious, by when `saveConfig` is called, it updates the `dockProviderOptions.entries` variable to reflect the new order.

