### PR TITLE
fix: more parallelism when swiching themes

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added support for customizing the taskbar icon for the splash screen window
 - Added an example of navigating content using navigation controls. Enabled through default window options in the main [manifest.fin.json](./public/manifest.fin.json) and in our developer docs snapshot [developer.snapshot.fin.json](./public/common/snapshots/developer.snapshot.fin.json)
 - Fixed an issue where the order of entries within dock would change when toggling between light and dark theme.
+- Improved performance when switching themes
 
 ## v16.1.0
 

--- a/how-to/workspace-platform-starter/client/src/framework/buttons.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/buttons.ts
@@ -154,9 +154,9 @@ async function getConfigToolbarButtons(): Promise<WorkspacePlatformToolbarButton
 		// Update all the browser windows with the new buttons.
 		const platform = getCurrentSync();
 		const browserWindows = await platform.Browser.getAllWindows();
-		for (const browserWindow of browserWindows) {
-			await updateBrowserWindowButtonsColorScheme(browserWindow);
-		}
+		await Promise.all(
+			browserWindows.map(async (browserWindow) => updateBrowserWindowButtonsColorScheme(browserWindow))
+		);
 	});
 
 	return configToolbarButtons;

--- a/how-to/workspace-platform-starter/client/src/framework/lifecycle.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/lifecycle.ts
@@ -72,10 +72,13 @@ export async function fireLifecycleEvent<T = unknown>(
 		// Clone the subscribers, otherwise if calling the handler performs an unsubscribe
 		// the loop gets out of sync and items can be missed
 		const subscribers = [...eventHandlers.subscribers];
-		for (const idHandler of subscribers) {
-			logger.info(`Notifying subscriber ${idHandler.id} of event ${lifecycleEvent}`);
-			await idHandler.handler(platform, payload);
-		}
+
+		await Promise.all(
+			subscribers.map(async (idHandler) => {
+				logger.info(`Notifying subscriber ${idHandler.id} of event ${lifecycleEvent}`);
+				await idHandler.handler(platform, payload);
+			})
+		);
 	}
 }
 

--- a/how-to/workspace-platform-starter/client/src/framework/themes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/themes.ts
@@ -156,10 +156,11 @@ export async function getCurrentIconFolder(): Promise<string> {
  */
 export async function notifyColorScheme(): Promise<void> {
 	const platform = getCurrentSync();
-	const settings = await getSettings();
-
-	const schemeType = await getCurrentColorSchemeMode();
-	const palette = await getCurrentPalette();
+	const [settings, schemeType, palette] = await Promise.all([
+		getSettings(),
+		getCurrentColorSchemeMode(),
+		getCurrentPalette()
+	] as const);
 
 	await fireLifecycleEvent<ThemeChangedLifecyclePayload>(platform, "theme-changed", {
 		schemeType,


### PR DESCRIPTION
uses `promise.all` when switchin browser windows icons, emiting "theme-changed" lifecycle event to reduce the time taken to switch theme