### PR TITLE
fix(dock) maintain order of workspace components buttons

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added an example of navigating content using navigation controls. Enabled through default window options in the main [manifest.fin.json](./public/manifest.fin.json) and in our developer docs snapshot [developer.snapshot.fin.json](./public/common/snapshots/developer.snapshot.fin.json)
 - Fixed an issue where the order of entries within dock would change when toggling between light and dark theme.
 - Improved performance when switching themes
+- Fixed an issue where the order of Workspace component entries within dock may change when toggling between light and dark theme.
 
 ## v16.1.0
 


### PR DESCRIPTION
previously, the order of `workspaceComponents` was not respected.

This PR updates it to use/store the version we get back from the endpoint when configuring dock