### PR TITLE
Add support for fdc3 open  with instanceId

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed an issue where the order of entries within dock would change when toggling between light and dark theme.
 - Improved performance when switching themes
 - Fixed an issue where the order of Workspace component entries within dock may change when toggling between light and dark theme.
+- FDC3 2.0 Open improvement - You can now specify instance id if you wish to open an existing instance of an app and optionally pass it context.
 
 ## v16.1.0
 


### PR DESCRIPTION
If you use fdc3.findInstances to see if any instances of an app exist before opening one with fdc3.open. If an instance exists and it the instance id was passed alongside the app id then it wouldn't be taken into account when fdc3.open was called. This update adds support for using an instance if it exists.