### PR TITLE
Empower platform devs to create an unrestricted notification service

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Improved performance when switching themes
 - Fixed an issue where the order of Workspace component entries within dock may change when toggling between light and dark theme.
 - FDC3 2.0 Open improvement - You can now specify instance id if you wish to open an existing instance of an app and optionally pass it context.
+- Add option to allow specific modules to get unrestricted notificationClients if they want to implement custom platform logic without importing notifications directly via the npm package. The notification client options in the notification provider now has a 'restricted' setting which can be set to false.
 
 ## v16.1.0
 

--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed an issue where the order of entries within dock would change when toggling between light and dark theme.
 - Improved performance when switching themes
 - Fixed an issue where the order of Workspace component entries within dock may change when toggling between light and dark theme.
+- FDC3 2.0 Open improvement - You can now specify instance id if you wish to open an existing instance of an app and optionally pass it context.
 
 ## v16.1.0
 

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/notification-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/notification-shapes.ts
@@ -98,6 +98,14 @@ export interface NotificationClientOptions extends NotificationClientDefaultOpti
 	 * Should this module have a notification client. Default is true.
 	 */
 	enabled?: boolean;
+
+	/**
+	 * Should this module's notification client be scoped to it's id or prefix and it's settings controlled (e.g. icon)?
+	 * Default is true.
+	 * This means it will only be able to clear and read notifications scoped to that id.
+	 * If false then it will be get the standard notifications implementation that is not restricted.
+	 */
+	restricted?: boolean;
 }
 
 /**

--- a/how-to/workspace-platform-starter/client/src/framework/workspace/notification-client-implementation.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/workspace/notification-client-implementation.ts
@@ -16,14 +16,14 @@ import {
 import { createLogger } from "workspace-platform-starter/logger-provider";
 import { isEmpty, randomUUID } from "workspace-platform-starter/utils";
 import type {
-	NotificationClient as NotificationClientInterface,
+	NotificationClient,
 	NotificationClientOptions,
 	NotificationsEventMap
 } from "../shapes/notification-shapes";
 /**
  * Notification client for use by modules to be able to create, remove and update notifications against a platform.
  */
-export class NotificationClient implements NotificationClientInterface {
+export class NotificationClientImplementation implements NotificationClient {
 	private readonly _options: NotificationClientOptions;
 
 	private readonly _idPrefix: string;

--- a/how-to/workspace-platform-starter/client/src/framework/workspace/notifications.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/workspace/notifications.ts
@@ -5,10 +5,11 @@ import { getSettings } from "../settings";
 import type {
 	NotificationClientDefaultOptions,
 	NotificationClientOptions,
-	NotificationProviderOptions
+	NotificationProviderOptions,
+	NotificationClient
 } from "../shapes/notification-shapes";
 import { isEmpty } from "../utils";
-import { NotificationClient } from "./notification-client";
+import { NotificationClientImplementation } from "./notification-client-implementation";
 
 const logger = createLogger("Notifications");
 
@@ -171,6 +172,13 @@ export async function getNotificationClient(
 		return undefined;
 	}
 
+	if (!isEmpty(listedClientOptions) && listedClientOptions.restricted === false) {
+		logger.info(
+			`The options passed to create a notification client requests a non-scoped notification client for the module with Id: ${options.id}`
+		);
+		return Notifications;
+	}
+
 	const clientOptions = Object.assign(options, notificationClientDefaults, listedClientOptions ?? {});
 
 	if (isEmpty(clientOptions.icon)) {
@@ -179,5 +187,5 @@ export async function getNotificationClient(
 		);
 		clientOptions.icon = notificationsProviderOptions?.icon;
 	}
-	return new NotificationClient(clientOptions, notificationPlatformId);
+	return new NotificationClientImplementation(clientOptions, notificationPlatformId);
 }

--- a/how-to/workspace-platform-starter/client/types/module/shapes/notification-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/notification-shapes.d.ts
@@ -87,6 +87,13 @@ export interface NotificationClientOptions extends NotificationClientDefaultOpti
 	 * Should this module have a notification client. Default is true.
 	 */
 	enabled?: boolean;
+	/**
+	 * Should this module's notification client be scoped to it's id or prefix and it's settings controlled (e.g. icon)?
+	 * Default is true.
+	 * This means it will only be able to clear and read notifications scoped to that id.
+	 * If false then it will be get the standard notifications implementation that is not restricted.
+	 */
+	restricted?: boolean;
 }
 /**
  * Mapping of all notification events.

--- a/how-to/workspace-platform-starter/public/schemas/settings.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/settings.schema.json
@@ -3238,6 +3238,10 @@
                 "includeInPlatform": {
                     "description": "Should this notification client be defaulted into the platform tab. Default is true\nunless a custom platform id is specified. If false then the current platform's id\nwill not be allowed if passed",
                     "type": "boolean"
+                },
+                "restricted": {
+                    "description": "Should this module's notification client be scoped to it's id or prefix and it's settings controlled (e.g. icon)?\nDefault is true.\nThis means it will only be able to clear and read notifications scoped to that id.\nIf false then it will be get the standard notifications implementation that is not restricted.",
+                    "type": "boolean"
                 }
             },
             "required": [

--- a/how-to/workspace-platform-starter/public/schemas/wps.manifest.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/wps.manifest.schema.json
@@ -3020,6 +3020,10 @@
 				"includeInPlatform": {
 					"description": "Should this notification client be defaulted into the platform tab. Default is true\nunless a custom platform id is specified. If false then the current platform's id\nwill not be allowed if passed",
 					"type": "boolean"
+				},
+				"restricted": {
+					"description": "Should this module's notification client be scoped to it's id or prefix and it's settings controlled (e.g. icon)?\nDefault is true.\nThis means it will only be able to clear and read notifications scoped to that id.\nIf false then it will be get the standard notifications implementation that is not restricted.",
+					"type": "boolean"
 				}
 			},
 			"required": ["id"],


### PR DESCRIPTION
This option allows a platform dev to nominate one or more lifecycle modules (or other types) to have an unrestricted notification client (no icon, or in platform tab enforcement and the notifications are not scoped to prefix id or module id). This is achieved by listing the module in the notification clients section of the notification provider and setting it's restricted setting to false (default is true).