### PR TITLE
perf: improve performance of computing dock configuration

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v17.2.0
 
 - Improved performance of switching schemes
+- Improved performance of computing dock configuration, especially on theme changes.
 
 ## v17.0.0
 


### PR DESCRIPTION
optimizews the performance of `buildButtonsFromEntries` by:
1. using Promise.all rather than a sequential for loop to loop over all the entries
2. updating the `IMAGE_CACHE` to store failed images as well as non-failed ones

The following optimizations are still possible:
 1. Every `app` entry makes a call to `getApp`
 
 https://github.com/built-on-openfin/workspace-starter/blob/62f293e86f6e6fb931dd6fb19abf174d5966abf4/how-to/workspace-platform-starter/client/src/framework/apps.ts#L205-L205
 
this calls `getApps` and `Array.prototype.find`. If there are a large number of apps, this could be a potential perf hit. we should consider using a `Map` instead.

3. `getApps` could probably be cached  https://github.com/built-on-openfin/workspace-starter/blob/62f293e86f6e6fb931dd6fb19abf174d5966abf4/how-to/workspace-platform-starter/client/src/framework/apps.ts#L126 (every app calls this)
 