### PR TITLE
Update 17.2 support

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Improved performance of switching schemes
 - Improved performance of computing dock configuration, especially on theme changes.
+- Added lifecycle events for `language-changed` which includes the selected locale and updated `page-changed` so that you can listen for when a page is focused as there is now a focus event.
+- Added additional context event to the app channel `platform/events` when a language is changed: type: `platform.language` which includes the selected locale.
+- Added ability to specify initial language through platformProvider.language.initialLanguage in your settings. Default browser menu options and tooltips support the following locales: en-US (default), ja-JP, zh-CN, zh-Hant, ko-KR, ru-RU, de-DE. More information about this feature can be found here: <https://developers.openfin.co/of-docs/docs/localization>
+- Added support for specifying notificationsCustomManifest ([self hosted notifications center](https://developers.openfin.co/of-docs/docs/register-notifications#host-on-your-cdn)) in the notificationsProvider settings so that it is used by the platform and the notificationClient passed to modules. As these settings are passed into the platform it will be available through the new platform api call of platform.getNotificationsConfig() (assuming you have used the getCurrentSync function from @openfin/workspace-platform or the function exposed by the module helper if you are building a module for workspace platform starter). Modules shouldn't need this as the notification client returned via the helper takes into account these settings.
 
 ## v17.0.0
 

--- a/how-to/workspace-platform-starter/client/src/framework/platform/platform.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/platform/platform.ts
@@ -27,7 +27,7 @@ import type { CustomSettings } from "../shapes/setting-shapes";
 import * as shareProvider from "../share";
 import * as snapProvider from "../snap";
 import { getThemes, notifyColorScheme, supportsColorSchemes } from "../themes";
-import { isEmpty, randomUUID } from "../utils";
+import { isEmpty, isStringValue, randomUUID } from "../utils";
 import * as versionProvider from "../version";
 import * as lowCodeIntegrationProvider from "../workspace/low-code-integrations";
 import { getDefaultWindowOptions } from "./browser";
@@ -197,7 +197,11 @@ async function setupPlatform(manifestSettings: CustomSettings | undefined): Prom
 
 	await workspacePlatformInit({
 		browser,
+		language: isStringValue(customSettings?.platformProvider?.language?.initialLanguage)
+			? { initialLanguage: customSettings?.platformProvider?.language?.initialLanguage }
+			: undefined,
 		theme,
+		notifications: customSettings?.notificationProvider?.notificationsCustomManifest,
 		customActions,
 		interopOverride,
 		overrideCallback: async (platformConstructor) =>

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/lifecycle-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/lifecycle-shapes.ts
@@ -1,5 +1,5 @@
 import type { Workspace } from "@openfin/workspace";
-import type { CustomPaletteSet, Page, WorkspacePlatformModule } from "@openfin/workspace-platform";
+import type { CustomPaletteSet, Locale, Page, WorkspacePlatformModule } from "@openfin/workspace-platform";
 import type { FavoriteEntry } from "./favorite-shapes";
 import type { ModuleHelpers, ModuleImplementation, ModuleList } from "./module-shapes";
 import type { ColorSchemeMode } from "./theme-shapes";
@@ -18,7 +18,8 @@ export type LifecycleEvents =
 	| "page-changed"
 	| "apps-changed"
 	| "favorite-changed"
-	| "condition-changed";
+	| "condition-changed"
+	| "language-changed";
 
 /**
  * The type for a lifecycle event handler.
@@ -76,7 +77,7 @@ export interface PageChangedLifecyclePayload {
 	/**
 	 * The action that happened to the page.
 	 */
-	action: "create" | "update" | "delete";
+	action: "create" | "update" | "delete" | "focus";
 
 	/**
 	 * The id of the page.
@@ -137,4 +138,13 @@ export interface ConditionChangedLifecyclePayload {
 	 * The condition that changed, or empty to determine many might have changed.
 	 */
 	conditionId?: string;
+}
+/**
+ * Language changed event payload.
+ */
+export interface LanguageChangedLifecyclePayload {
+	/**
+	 * The Locale.
+	 */
+	locale?: Locale;
 }

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/notification-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/notification-shapes.ts
@@ -1,3 +1,4 @@
+import type { NotificationsCustomManifestOptions } from "@openfin/workspace/common/src/api/shapes/notifications";
 import type {
 	NotificationsPlatform,
 	create,
@@ -26,6 +27,11 @@ export interface NotificationProviderOptions extends NotificationsPlatform {
 	 * A collection of rules and settings for notification clients that fall under this platform.
 	 */
 	notificationClients?: NotificationClients;
+
+	/**
+	 * If you have licensed support for a custom notification manifest then you can provide the settings here.
+	 */
+	notificationsCustomManifest?: NotificationsCustomManifestOptions;
 }
 
 /**

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/platform-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/platform-shapes.ts
@@ -1,5 +1,5 @@
 import type { DockButton } from "@openfin/workspace";
-import type { Page, Workspace } from "@openfin/workspace-platform";
+import type { Locale, Page, Workspace } from "@openfin/workspace-platform";
 import type { DockProviderConfigWithIdentity } from "@openfin/workspace-platform/client-api/src";
 import type { IntentResolverOptions, PlatformInteropBrokerOptions } from "./interopbroker-shapes";
 
@@ -11,6 +11,16 @@ export interface PlatformProviderOptions {
 	 * What is the root url of you platform e.g. https://mydomain.com
 	 */
 	rootUrl: string;
+
+	/**
+	 * The language settings for the platform
+	 */
+	language?: {
+		/**
+		 * The initial language to use. Built in browser support for en-US (default), ja-JP, zh-CN, zh-Hant, ko-KR, ru-RU, de-DE
+		 */
+		initialLanguage: Locale | string;
+	};
 
 	/**
 	 * This is optional and only needed if you are using shell mode where you wish to load a small module with just auth

--- a/how-to/workspace-platform-starter/client/src/framework/workspace/notifications.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/workspace/notifications.ts
@@ -37,11 +37,15 @@ export async function register(
 		logger.info("Registering platform with Notification Center.");
 		const settings = await getSettings();
 		if (!isEmpty(settings) && !isEmpty(settings?.notificationProvider)) {
-			const { notificationClients, ...notificationsPlatformOptions } = settings.notificationProvider;
+			const { notificationClients, notificationsCustomManifest, ...notificationsPlatformOptions } =
+				settings.notificationProvider;
 			notificationPlatformId = notificationsPlatformOptions?.id ?? fin.me.identity.uuid;
 			notificationsPlatformOptions.id = notificationPlatformId;
 			try {
-				const registrationResponse = await Notifications.register({ notificationsPlatformOptions });
+				const registrationResponse = await Notifications.register({
+					notificationsPlatformOptions,
+					notificationsCustomManifest
+				});
 
 				metaInfo = {
 					workspaceVersion: registrationResponse.notificationsVersion ?? "",

--- a/how-to/workspace-platform-starter/client/types/module/shapes/lifecycle-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/lifecycle-shapes.d.ts
@@ -1,5 +1,5 @@
 import type { Workspace } from "@openfin/workspace";
-import type { CustomPaletteSet, Page, WorkspacePlatformModule } from "@openfin/workspace-platform";
+import type { CustomPaletteSet, Locale, Page, WorkspacePlatformModule } from "@openfin/workspace-platform";
 import type { FavoriteEntry } from "./favorite-shapes";
 import type { ModuleHelpers, ModuleImplementation, ModuleList } from "./module-shapes";
 import type { ColorSchemeMode } from "./theme-shapes";
@@ -17,7 +17,8 @@ export type LifecycleEvents =
 	| "page-changed"
 	| "apps-changed"
 	| "favorite-changed"
-	| "condition-changed";
+	| "condition-changed"
+	| "language-changed";
 /**
  * The type for a lifecycle event handler.
  */
@@ -67,7 +68,7 @@ export interface PageChangedLifecyclePayload {
 	/**
 	 * The action that happened to the page.
 	 */
-	action: "create" | "update" | "delete";
+	action: "create" | "update" | "delete" | "focus";
 	/**
 	 * The id of the page.
 	 */
@@ -120,4 +121,13 @@ export interface ConditionChangedLifecyclePayload {
 	 * The condition that changed, or empty to determine many might have changed.
 	 */
 	conditionId?: string;
+}
+/**
+ * Language changed event payload.
+ */
+export interface LanguageChangedLifecyclePayload {
+	/**
+	 * The Locale.
+	 */
+	locale?: Locale;
 }

--- a/how-to/workspace-platform-starter/client/types/module/shapes/notification-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/notification-shapes.d.ts
@@ -1,3 +1,4 @@
+import type { NotificationsCustomManifestOptions } from "@openfin/workspace/common/src/api/shapes/notifications";
 import type {
 	NotificationsPlatform,
 	create,
@@ -24,6 +25,10 @@ export interface NotificationProviderOptions extends NotificationsPlatform {
 	 * A collection of rules and settings for notification clients that fall under this platform.
 	 */
 	notificationClients?: NotificationClients;
+	/**
+	 * If you have licensed support for a custom notification manifest then you can provide the settings here.
+	 */
+	notificationsCustomManifest?: NotificationsCustomManifestOptions;
 }
 /**
  * A collection of rules and settings for notification clients that fall under this platform.

--- a/how-to/workspace-platform-starter/client/types/module/shapes/platform-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/platform-shapes.d.ts
@@ -1,5 +1,5 @@
 import type { DockButton } from "@openfin/workspace";
-import type { Page, Workspace } from "@openfin/workspace-platform";
+import type { Locale, Page, Workspace } from "@openfin/workspace-platform";
 import type { DockProviderConfigWithIdentity } from "@openfin/workspace-platform/client-api/src";
 import type { IntentResolverOptions, PlatformInteropBrokerOptions } from "./interopbroker-shapes";
 /**
@@ -10,6 +10,15 @@ export interface PlatformProviderOptions {
 	 * What is the root url of you platform e.g. https://mydomain.com
 	 */
 	rootUrl: string;
+	/**
+	 * The language settings for the platform
+	 */
+	language?: {
+		/**
+		 * The initial language to use. Built in browser support for en-US (default), ja-JP, zh-CN, zh-Hant, ko-KR, ru-RU, de-DE
+		 */
+		initialLanguage: Locale | string;
+	};
 	/**
 	 * This is optional and only needed if you are using shell mode where you wish to load a small module with just auth
 	 * logic first followed by a module with the rest of the platform core. Specify the entry point here. We do generate

--- a/how-to/workspace-platform-starter/docs/how-to-use-lifecycle-events.md
+++ b/how-to/workspace-platform-starter/docs/how-to-use-lifecycle-events.md
@@ -70,10 +70,11 @@ The lifecycle events that are available to connect to are:
 - `before-quit` - The event is called before all the modules and components are torn down during the quit process, this allows your modules to perform any persistence or cleanup operations of their own.
 - `theme-changed` - The event is called when the theme is changed in the system, it is passed the `ThemeChangedLifecyclePayload` payload which contains the `schemeType` and the `palette`.
 - `workspace-changed` - The event is called when a workspace is added/updated/deleted, it is passed the `WorkspaceChangedLifecyclePayload` payload which contains the `action` and information about the workspace.
-- `page-changed` - The event is called when a page is added/updated/deleted, it is passed the `PageChangedLifecyclePayload` payload which contains the `action` and information about the page.
+- `page-changed` - The event is called when a page is added/updated/deleted/focused, it is passed the `PageChangedLifecyclePayload` payload which contains the `action` and information about the page.
 - `apps-changed` - The event is called when the list of apps available to the platform changes.
 - `favorite-changed` - The event is called when a favorite is set/delete, it is passed the `FavoriteChangedLifecyclePayload` payload which contains the `action` and information about the favorite.
 - `condition-changed` - The event is called when a condition is changed, it is passed the `ConditionChangedLifecyclePayload` payload which contains `conditionId` of the condition that changed, if `conditionId` us undefined, a number of conditions might have changed.
+- `language-changed` - The event is called when a language is changed, it is passed the `LanguageChangedLifecyclePayload` payload which contains `locale` which is the locale that was selected.
 
 ## Generate From Template
 

--- a/how-to/workspace-platform-starter/public/manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/manifest.fin.json
@@ -94,6 +94,9 @@
 		},
 		"platformProvider": {
 			"rootUrl": "http://localhost:8080",
+			"language": {
+				"initialLanguage": "ja-JP"
+			},
 			"interop": {
 				"intentResolver": {
 					"url": "http://localhost:8080/common/windows/intents/instance-picker.html",

--- a/how-to/workspace-platform-starter/public/schemas/settings.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/settings.schema.json
@@ -50,7 +50,7 @@
             "$ref": "#/definitions/__type_3"
         },
         "AppAssetInfo": {
-            "$ref": "#/definitions/__type_55"
+            "$ref": "#/definitions/__type_56"
         },
         "AppEndpointOptions": {
             "anyOf": [
@@ -717,7 +717,7 @@
             "type": "object"
         },
         "CertificationInfo": {
-            "$ref": "#/definitions/__type_48"
+            "$ref": "#/definitions/__type_49"
         },
         "ConditionsProviderOptions": {
             "$ref": "#/definitions/ModuleList_3",
@@ -835,7 +835,7 @@
             "$ref": "#/definitions/__type_15"
         },
         "ContextGroupStates": {
-            "$ref": "#/definitions/__type_45"
+            "$ref": "#/definitions/__type_46"
         },
         "ContextMenuOptions": {
             "$ref": "#/definitions/__type_9"
@@ -1223,7 +1223,7 @@
             "type": "object"
         },
         "DipScaleRects": {
-            "$ref": "#/definitions/__type_42"
+            "$ref": "#/definitions/__type_43"
         },
         "DockButtonAction": {
             "additionalProperties": false,
@@ -2084,7 +2084,7 @@
             "$ref": "#/definitions/__type_12"
         },
         "LaunchExternalProcessListener": {
-            "$ref": "#/definitions/__type_47"
+            "$ref": "#/definitions/__type_48"
         },
         "LaunchPreference": {
             "additionalProperties": false,
@@ -3118,10 +3118,10 @@
             "type": "object"
         },
         "MonitorDetails": {
-            "$ref": "#/definitions/__type_44"
+            "$ref": "#/definitions/__type_45"
         },
         "MonitorInfo": {
-            "$ref": "#/definitions/__type_40"
+            "$ref": "#/definitions/__type_41"
         },
         "NativeLaunchOptions": {
             "additionalProperties": false,
@@ -3272,7 +3272,7 @@
             "type": "object"
         },
         "NotificationIndicatorColorsWithScheme": {
-            "$ref": "#/definitions/__type_54"
+            "$ref": "#/definitions/__type_55"
         },
         "NotificationProviderOptions": {
             "additionalProperties": false,
@@ -3290,6 +3290,10 @@
                     "$ref": "#/definitions/NotificationClients",
                     "description": "A collection of rules and settings for notification clients that fall under this platform."
                 },
+                "notificationsCustomManifest": {
+                    "$ref": "#/definitions/NotificationsCustomManifestOptions",
+                    "description": "If you have licensed support for a custom notification manifest then you can provide the settings here."
+                },
                 "title": {
                     "description": "Stream title.\n\nProviding a different displayName for an existing stream id will update the\ndisplayName of the stream stored in Notification Center.",
                     "type": "string"
@@ -3301,6 +3305,9 @@
                 "title"
             ],
             "type": "object"
+        },
+        "NotificationsCustomManifestOptions": {
+            "$ref": "#/definitions/__type_39"
         },
         "O": {},
         "Omit": {
@@ -3609,22 +3616,22 @@
             "$ref": "#/definitions/__type_26"
         },
         "Partial_11": {
-            "$ref": "#/definitions/__type_39"
+            "$ref": "#/definitions/__type_40"
         },
         "Partial_12": {
-            "$ref": "#/definitions/__type_46"
+            "$ref": "#/definitions/__type_47"
         },
         "Partial_13": {
-            "$ref": "#/definitions/__type_49"
-        },
-        "Partial_14": {
             "$ref": "#/definitions/__type_50"
         },
-        "Partial_15": {
+        "Partial_14": {
             "$ref": "#/definitions/__type_51"
         },
-        "Partial_16": {
+        "Partial_15": {
             "$ref": "#/definitions/__type_52"
+        },
+        "Partial_16": {
+            "$ref": "#/definitions/__type_53"
         },
         "Partial_2": {
             "$ref": "#/definitions/__type_6"
@@ -3956,6 +3963,19 @@
                     "$ref": "#/definitions/PlatformInteropBrokerOptions",
                     "description": "interop settings related to this platform"
                 },
+                "language": {
+                    "additionalProperties": false,
+                    "description": "The language settings for the platform",
+                    "properties": {
+                        "initialLanguage": {
+                            "description": "The initial language to use. Built in browser support for en-US (default), ja-JP, zh-CN, zh-Hant, ko-KR, ru-RU, de-DE"
+                        }
+                    },
+                    "required": [
+                        "initialLanguage"
+                    ],
+                    "type": "object"
+                },
                 "rootUrl": {
                     "description": "What is the root url of you platform e.g. https://mydomain.com",
                     "type": "string"
@@ -3967,7 +3987,7 @@
             "type": "object"
         },
         "Point": {
-            "$ref": "#/definitions/__type_41"
+            "$ref": "#/definitions/__type_42"
         },
         "PopupMenuStyles": {
             "description": "The styles that can be used to display the popup menus.",
@@ -4043,10 +4063,10 @@
             "$ref": "#/definitions/__type_19"
         },
         "Record_1": {
-            "$ref": "#/definitions/__type_53"
+            "$ref": "#/definitions/__type_54"
         },
         "RectangleByEdgePositions": {
-            "$ref": "#/definitions/__type_43"
+            "$ref": "#/definitions/__type_44"
         },
         "ResizeRegion": {
             "$ref": "#/definitions/__type_11"
@@ -7162,6 +7182,44 @@
         },
         "__type_39": {
             "additionalProperties": false,
+            "description": "Options for using privately hosted notification service.",
+            "properties": {
+                "manifestUrl": {
+                    "description": "A custom manifest location to start the notification service from.\nThe UUID cannot be OpenFin hosted Notification Service UUID, 'notifications-service'.",
+                    "type": "string"
+                },
+                "manifestUuid": {
+                    "description": "The UUID of the provided custom notifications service manifest.\nThis value **MUST** match the UUID of the manifest provided in `manifestUrl`.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "manifestUrl",
+                "manifestUuid"
+            ],
+            "type": "object"
+        },
+        "__type_4": {
+            "additionalProperties": false,
+            "description": "Unique identifier for a window, view or iframe.",
+            "properties": {
+                "name": {
+                    "description": "The name of the component.  Must be unique within the owning application.",
+                    "type": "string"
+                },
+                "uuid": {
+                    "description": "Universally unique identifier of the application that owns the component.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "uuid"
+            ],
+            "type": "object"
+        },
+        "__type_40": {
+            "additionalProperties": false,
             "properties": {
                 "interopSnapshotDetails": {
                     "additionalProperties": false,
@@ -7205,26 +7263,7 @@
             },
             "type": "object"
         },
-        "__type_4": {
-            "additionalProperties": false,
-            "description": "Unique identifier for a window, view or iframe.",
-            "properties": {
-                "name": {
-                    "description": "The name of the component.  Must be unique within the owning application.",
-                    "type": "string"
-                },
-                "uuid": {
-                    "description": "Universally unique identifier of the application that owns the component.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "uuid"
-            ],
-            "type": "object"
-        },
-        "__type_40": {
+        "__type_41": {
             "additionalProperties": false,
             "properties": {
                 "deviceScaleFactor": {
@@ -7321,7 +7360,7 @@
             ],
             "type": "object"
         },
-        "__type_41": {
+        "__type_42": {
             "additionalProperties": false,
             "properties": {
                 "x": {
@@ -7339,7 +7378,7 @@
             ],
             "type": "object"
         },
-        "__type_42": {
+        "__type_43": {
             "additionalProperties": false,
             "properties": {
                 "dipRect": {
@@ -7355,7 +7394,7 @@
             ],
             "type": "object"
         },
-        "__type_43": {
+        "__type_44": {
             "additionalProperties": false,
             "properties": {
                 "bottom": {
@@ -7379,7 +7418,7 @@
             ],
             "type": "object"
         },
-        "__type_44": {
+        "__type_45": {
             "additionalProperties": false,
             "properties": {
                 "available": {
@@ -7437,7 +7476,7 @@
             ],
             "type": "object"
         },
-        "__type_45": {
+        "__type_46": {
             "additionalProperties": {
                 "additionalProperties": {
                     "additionalProperties": false,
@@ -7468,7 +7507,7 @@
             },
             "type": "object"
         },
-        "__type_46": {
+        "__type_47": {
             "additionalProperties": false,
             "properties": {
                 "alias": {
@@ -7505,11 +7544,11 @@
             },
             "type": "object"
         },
-        "__type_47": {
+        "__type_48": {
             "additionalProperties": false,
             "type": "object"
         },
-        "__type_48": {
+        "__type_49": {
             "additionalProperties": false,
             "properties": {
                 "publickey": {
@@ -7530,7 +7569,24 @@
             },
             "type": "object"
         },
-        "__type_49": {
+        "__type_5": {
+            "additionalProperties": false,
+            "description": "Configures how new content (e,g, from `window.open` or a link) is opened.",
+            "properties": {
+                "rules": {
+                    "description": "List of rules for creation of new content.",
+                    "items": {
+                        "$ref": "#/definitions/ContentCreationRule<ContentCreationBehaviorNames>"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "rules"
+            ],
+            "type": "object"
+        },
+        "__type_50": {
             "additionalProperties": false,
             "properties": {
                 "alias": {
@@ -7560,24 +7616,7 @@
             },
             "type": "object"
         },
-        "__type_5": {
-            "additionalProperties": false,
-            "description": "Configures how new content (e,g, from `window.open` or a link) is opened.",
-            "properties": {
-                "rules": {
-                    "description": "List of rules for creation of new content.",
-                    "items": {
-                        "$ref": "#/definitions/ContentCreationRule<ContentCreationBehaviorNames>"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "rules"
-            ],
-            "type": "object"
-        },
-        "__type_50": {
+        "__type_51": {
             "additionalProperties": false,
             "properties": {
                 "height": {
@@ -7591,21 +7630,6 @@
                 },
                 "width": {
                     "type": "number"
-                }
-            },
-            "type": "object"
-        },
-        "__type_51": {
-            "additionalProperties": false,
-            "properties": {
-                "customData": {
-                    "description": "A field that the user can attach serializable data to be ferried around with the window options.\n_When omitted, _inherits_ from the parent application._"
-                },
-                "interop": {
-                    "$ref": "#/definitions/InteropConfig"
-                },
-                "url": {
-                    "type": "string"
                 }
             },
             "type": "object"
@@ -7627,6 +7651,17 @@
         },
         "__type_53": {
             "additionalProperties": false,
+            "properties": {
+                "customData": {
+                    "description": "A field that the user can attach serializable data to be ferried around with the window options.\n_When omitted, _inherits_ from the parent application._"
+                },
+                "interop": {
+                    "$ref": "#/definitions/InteropConfig"
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "__type_54": {
@@ -7634,6 +7669,10 @@
             "type": "object"
         },
         "__type_55": {
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "__type_56": {
             "additionalProperties": false,
             "properties": {
                 "alias": {

--- a/how-to/workspace-platform-starter/public/schemas/wps.manifest.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/wps.manifest.schema.json
@@ -48,7 +48,7 @@
 			"$ref": "#/definitions/__type_3"
 		},
 		"AppAssetInfo": {
-			"$ref": "#/definitions/__type_55"
+			"$ref": "#/definitions/__type_56"
 		},
 		"AppEndpointOptions": {
 			"anyOf": [
@@ -673,7 +673,7 @@
 			"type": "object"
 		},
 		"CertificationInfo": {
-			"$ref": "#/definitions/__type_48"
+			"$ref": "#/definitions/__type_49"
 		},
 		"ConditionsProviderOptions": {
 			"$ref": "#/definitions/ModuleList_3",
@@ -784,7 +784,7 @@
 			"$ref": "#/definitions/__type_15"
 		},
 		"ContextGroupStates": {
-			"$ref": "#/definitions/__type_45"
+			"$ref": "#/definitions/__type_46"
 		},
 		"ContextMenuOptions": {
 			"$ref": "#/definitions/__type_9"
@@ -1106,7 +1106,7 @@
 			"$ref": "#/definitions/__type_37"
 		},
 		"DefaultDomainSettings": {
-			"$ref": "#/definitions/__type_61"
+			"$ref": "#/definitions/__type_62"
 		},
 		"DelayStrategy": {
 			"additionalProperties": false,
@@ -1157,10 +1157,10 @@
 			"type": "object"
 		},
 		"DipScaleRects": {
-			"$ref": "#/definitions/__type_42"
+			"$ref": "#/definitions/__type_43"
 		},
 		"DisplayMetadata_3": {
-			"$ref": "#/definitions/__type_59"
+			"$ref": "#/definitions/__type_60"
 		},
 		"DockButtonAction": {
 			"additionalProperties": false,
@@ -1643,7 +1643,7 @@
 			"type": "string"
 		},
 		"FileDownloadSettings": {
-			"$ref": "#/definitions/__type_62"
+			"$ref": "#/definitions/__type_63"
 		},
 		"GlobalContextMenuOptionType": {
 			"description": "Types of global context menu options, including pre-defined ones.\nUser-defined context menu items should use the value `Custom`",
@@ -1946,16 +1946,16 @@
 			"type": "object"
 		},
 		"InteropBrokerOptions": {
-			"$ref": "#/definitions/__type_58"
+			"$ref": "#/definitions/__type_59"
 		},
 		"InteropConfig": {
 			"$ref": "#/definitions/__type_12"
 		},
 		"InteropLoggingOptions": {
-			"$ref": "#/definitions/__type_60"
+			"$ref": "#/definitions/__type_61"
 		},
 		"LaunchExternalProcessListener": {
-			"$ref": "#/definitions/__type_47"
+			"$ref": "#/definitions/__type_48"
 		},
 		"LaunchPreference": {
 			"additionalProperties": false,
@@ -2906,10 +2906,10 @@
 			"type": "object"
 		},
 		"MonitorDetails": {
-			"$ref": "#/definitions/__type_44"
+			"$ref": "#/definitions/__type_45"
 		},
 		"MonitorInfo": {
-			"$ref": "#/definitions/__type_40"
+			"$ref": "#/definitions/__type_41"
 		},
 		"NativeLaunchOptions": {
 			"additionalProperties": false,
@@ -3052,7 +3052,7 @@
 			"type": "object"
 		},
 		"NotificationIndicatorColorsWithScheme": {
-			"$ref": "#/definitions/__type_54"
+			"$ref": "#/definitions/__type_55"
 		},
 		"NotificationProviderOptions": {
 			"additionalProperties": false,
@@ -3070,6 +3070,10 @@
 					"$ref": "#/definitions/NotificationClients",
 					"description": "A collection of rules and settings for notification clients that fall under this platform."
 				},
+				"notificationsCustomManifest": {
+					"$ref": "#/definitions/NotificationsCustomManifestOptions",
+					"description": "If you have licensed support for a custom notification manifest then you can provide the settings here."
+				},
 				"title": {
 					"description": "Stream title.\n\nProviding a different displayName for an existing stream id will update the\ndisplayName of the stream stored in Notification Center.",
 					"type": "string"
@@ -3077,6 +3081,9 @@
 			},
 			"required": ["icon", "id", "title"],
 			"type": "object"
+		},
+		"NotificationsCustomManifestOptions": {
+			"$ref": "#/definitions/__type_39"
 		},
 		"O": {},
 		"Omit": {
@@ -3351,25 +3358,25 @@
 			"$ref": "#/definitions/__type_26"
 		},
 		"Partial_11": {
-			"$ref": "#/definitions/__type_39"
+			"$ref": "#/definitions/__type_40"
 		},
 		"Partial_12": {
-			"$ref": "#/definitions/__type_46"
+			"$ref": "#/definitions/__type_47"
 		},
 		"Partial_13": {
-			"$ref": "#/definitions/__type_49"
-		},
-		"Partial_14": {
 			"$ref": "#/definitions/__type_50"
 		},
-		"Partial_15": {
+		"Partial_14": {
 			"$ref": "#/definitions/__type_51"
 		},
-		"Partial_16": {
+		"Partial_15": {
 			"$ref": "#/definitions/__type_52"
 		},
+		"Partial_16": {
+			"$ref": "#/definitions/__type_53"
+		},
 		"Partial_17": {
-			"$ref": "#/definitions/__type_57"
+			"$ref": "#/definitions/__type_58"
 		},
 		"Partial_2": {
 			"$ref": "#/definitions/__type_6"
@@ -3948,6 +3955,17 @@
 					"$ref": "#/definitions/PlatformInteropBrokerOptions",
 					"description": "interop settings related to this platform"
 				},
+				"language": {
+					"additionalProperties": false,
+					"description": "The language settings for the platform",
+					"properties": {
+						"initialLanguage": {
+							"description": "The initial language to use. Built in browser support for en-US (default), ja-JP, zh-CN, zh-Hant, ko-KR, ru-RU, de-DE"
+						}
+					},
+					"required": ["initialLanguage"],
+					"type": "object"
+				},
 				"rootUrl": {
 					"description": "What is the root url of you platform e.g. https://mydomain.com",
 					"type": "string"
@@ -3957,7 +3975,7 @@
 			"type": "object"
 		},
 		"Point": {
-			"$ref": "#/definitions/__type_41"
+			"$ref": "#/definitions/__type_42"
 		},
 		"PopupMenuStyles": {
 			"description": "The styles that can be used to display the popup menus.",
@@ -4027,10 +4045,10 @@
 			"$ref": "#/definitions/__type_19"
 		},
 		"Record_1": {
-			"$ref": "#/definitions/__type_53"
+			"$ref": "#/definitions/__type_54"
 		},
 		"RectangleByEdgePositions": {
-			"$ref": "#/definitions/__type_43"
+			"$ref": "#/definitions/__type_44"
 		},
 		"ResizeRegion": {
 			"$ref": "#/definitions/__type_11"
@@ -4140,7 +4158,7 @@
 			"type": "object"
 		},
 		"Snapshot": {
-			"$ref": "#/definitions/__type_56"
+			"$ref": "#/definitions/__type_57"
 		},
 		"SnapshotSourceConnection": {
 			"additionalProperties": false,
@@ -7435,6 +7453,38 @@
 		},
 		"__type_39": {
 			"additionalProperties": false,
+			"description": "Options for using privately hosted notification service.",
+			"properties": {
+				"manifestUrl": {
+					"description": "A custom manifest location to start the notification service from.\nThe UUID cannot be OpenFin hosted Notification Service UUID, 'notifications-service'.",
+					"type": "string"
+				},
+				"manifestUuid": {
+					"description": "The UUID of the provided custom notifications service manifest.\nThis value **MUST** match the UUID of the manifest provided in `manifestUrl`.",
+					"type": "string"
+				}
+			},
+			"required": ["manifestUrl", "manifestUuid"],
+			"type": "object"
+		},
+		"__type_4": {
+			"additionalProperties": false,
+			"description": "Unique identifier for a window, view or iframe.",
+			"properties": {
+				"name": {
+					"description": "The name of the component.  Must be unique within the owning application.",
+					"type": "string"
+				},
+				"uuid": {
+					"description": "Universally unique identifier of the application that owns the component.",
+					"type": "string"
+				}
+			},
+			"required": ["name", "uuid"],
+			"type": "object"
+		},
+		"__type_40": {
+			"additionalProperties": false,
 			"properties": {
 				"interopSnapshotDetails": {
 					"additionalProperties": false,
@@ -7472,23 +7522,7 @@
 			},
 			"type": "object"
 		},
-		"__type_4": {
-			"additionalProperties": false,
-			"description": "Unique identifier for a window, view or iframe.",
-			"properties": {
-				"name": {
-					"description": "The name of the component.  Must be unique within the owning application.",
-					"type": "string"
-				},
-				"uuid": {
-					"description": "Universally unique identifier of the application that owns the component.",
-					"type": "string"
-				}
-			},
-			"required": ["name", "uuid"],
-			"type": "object"
-		},
-		"__type_40": {
+		"__type_41": {
 			"additionalProperties": false,
 			"properties": {
 				"deviceScaleFactor": {
@@ -7579,7 +7613,7 @@
 			],
 			"type": "object"
 		},
-		"__type_41": {
+		"__type_42": {
 			"additionalProperties": false,
 			"properties": {
 				"x": {
@@ -7594,7 +7628,7 @@
 			"required": ["x", "y"],
 			"type": "object"
 		},
-		"__type_42": {
+		"__type_43": {
 			"additionalProperties": false,
 			"properties": {
 				"dipRect": {
@@ -7607,7 +7641,7 @@
 			"required": ["dipRect", "scaledRect"],
 			"type": "object"
 		},
-		"__type_43": {
+		"__type_44": {
 			"additionalProperties": false,
 			"properties": {
 				"bottom": {
@@ -7626,7 +7660,7 @@
 			"required": ["bottom", "left", "right", "top"],
 			"type": "object"
 		},
-		"__type_44": {
+		"__type_45": {
 			"additionalProperties": false,
 			"properties": {
 				"available": {
@@ -7678,7 +7712,7 @@
 			],
 			"type": "object"
 		},
-		"__type_45": {
+		"__type_46": {
 			"additionalProperties": {
 				"additionalProperties": {
 					"additionalProperties": false,
@@ -7707,7 +7741,7 @@
 			},
 			"type": "object"
 		},
-		"__type_46": {
+		"__type_47": {
 			"additionalProperties": false,
 			"properties": {
 				"alias": {
@@ -7744,11 +7778,11 @@
 			},
 			"type": "object"
 		},
-		"__type_47": {
+		"__type_48": {
 			"additionalProperties": false,
 			"type": "object"
 		},
-		"__type_48": {
+		"__type_49": {
 			"additionalProperties": false,
 			"properties": {
 				"publickey": {
@@ -7769,7 +7803,22 @@
 			},
 			"type": "object"
 		},
-		"__type_49": {
+		"__type_5": {
+			"additionalProperties": false,
+			"description": "Configures how new content (e,g, from `window.open` or a link) is opened.",
+			"properties": {
+				"rules": {
+					"description": "List of rules for creation of new content.",
+					"items": {
+						"$ref": "#/definitions/ContentCreationRule<ContentCreationBehaviorNames>"
+					},
+					"type": "array"
+				}
+			},
+			"required": ["rules"],
+			"type": "object"
+		},
+		"__type_50": {
 			"additionalProperties": false,
 			"properties": {
 				"alias": {
@@ -7799,22 +7848,7 @@
 			},
 			"type": "object"
 		},
-		"__type_5": {
-			"additionalProperties": false,
-			"description": "Configures how new content (e,g, from `window.open` or a link) is opened.",
-			"properties": {
-				"rules": {
-					"description": "List of rules for creation of new content.",
-					"items": {
-						"$ref": "#/definitions/ContentCreationRule<ContentCreationBehaviorNames>"
-					},
-					"type": "array"
-				}
-			},
-			"required": ["rules"],
-			"type": "object"
-		},
-		"__type_50": {
+		"__type_51": {
 			"additionalProperties": false,
 			"properties": {
 				"height": {
@@ -7828,21 +7862,6 @@
 				},
 				"width": {
 					"type": "number"
-				}
-			},
-			"type": "object"
-		},
-		"__type_51": {
-			"additionalProperties": false,
-			"properties": {
-				"customData": {
-					"description": "A field that the user can attach serializable data to be ferried around with the window options.\n_When omitted, _inherits_ from the parent application._"
-				},
-				"interop": {
-					"$ref": "#/definitions/InteropConfig"
-				},
-				"url": {
-					"type": "string"
 				}
 			},
 			"type": "object"
@@ -7864,6 +7883,17 @@
 		},
 		"__type_53": {
 			"additionalProperties": false,
+			"properties": {
+				"customData": {
+					"description": "A field that the user can attach serializable data to be ferried around with the window options.\n_When omitted, _inherits_ from the parent application._"
+				},
+				"interop": {
+					"$ref": "#/definitions/InteropConfig"
+				},
+				"url": {
+					"type": "string"
+				}
+			},
 			"type": "object"
 		},
 		"__type_54": {
@@ -7871,6 +7901,10 @@
 			"type": "object"
 		},
 		"__type_55": {
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"__type_56": {
 			"additionalProperties": false,
 			"properties": {
 				"alias": {
@@ -7901,7 +7935,7 @@
 			"required": ["alias", "src", "version"],
 			"type": "object"
 		},
-		"__type_56": {
+		"__type_57": {
 			"additionalProperties": false,
 			"properties": {
 				"interopSnapshotDetails": {
@@ -7941,7 +7975,7 @@
 			"required": ["windows"],
 			"type": "object"
 		},
-		"__type_57": {
+		"__type_58": {
 			"additionalProperties": false,
 			"properties": {
 				"_internalWorkspaceData": {},
@@ -8245,7 +8279,7 @@
 			},
 			"type": "object"
 		},
-		"__type_58": {
+		"__type_59": {
 			"additionalProperties": false,
 			"properties": {
 				"contextGroups": {
@@ -8269,25 +8303,6 @@
 				},
 				"logging": {
 					"$ref": "#/definitions/InteropLoggingOptions"
-				}
-			},
-			"type": "object"
-		},
-		"__type_59": {
-			"additionalProperties": false,
-			"description": "The display data for a context group.",
-			"properties": {
-				"color": {
-					"description": "The color that should be associated within this context group when displaying this context group in a UI, e.g: `0xFF0000`.",
-					"type": "string"
-				},
-				"glyph": {
-					"description": "A URL of an image that can be used to display this context group",
-					"type": "string"
-				},
-				"name": {
-					"description": "A user-readable name for this context group, e.g: `\"Red\"`",
-					"type": "string"
 				}
 			},
 			"type": "object"
@@ -8594,6 +8609,25 @@
 		},
 		"__type_60": {
 			"additionalProperties": false,
+			"description": "The display data for a context group.",
+			"properties": {
+				"color": {
+					"description": "The color that should be associated within this context group when displaying this context group in a UI, e.g: `0xFF0000`.",
+					"type": "string"
+				},
+				"glyph": {
+					"description": "A URL of an image that can be used to display this context group",
+					"type": "string"
+				},
+				"name": {
+					"description": "A user-readable name for this context group, e.g: `\"Red\"`",
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"__type_61": {
+			"additionalProperties": false,
 			"properties": {
 				"afterAction": {
 					"additionalProperties": false,
@@ -8621,7 +8655,7 @@
 			"required": ["afterAction", "beforeAction"],
 			"type": "object"
 		},
-		"__type_61": {
+		"__type_62": {
 			"additionalProperties": false,
 			"properties": {
 				"rules": {
@@ -8654,7 +8688,7 @@
 			"required": ["rules"],
 			"type": "object"
 		},
-		"__type_62": {
+		"__type_63": {
 			"additionalProperties": false,
 			"properties": {
 				"rules": {


### PR DESCRIPTION
Added support for specifying a locale and listening for locale changes from modules (through lifecycle) and views (through a context event similar to theme changes). Workspace Platform Starter doesn't provide built in support for languages but these changes make it easier for people to try out the changes and built custom menu options to switch a language and update modules to support that switch.

Also added support for self-hosted notification centre if that is licensed. 