### PR TITLE
feat: platform label inside global context menu quit platform option

### DIFF
--- a/how-to/workspace-platform-starter/client/src/framework/platform/platform.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/platform/platform.ts
@@ -154,6 +154,9 @@ async function setupPlatform(manifestSettings: CustomSettings | undefined): Prom
 	logger.info("Initializing platform");
 	const browser: BrowserInitConfig = {};
 
+	if (!isEmpty(customSettings?.browserProvider?.title)) {
+		browser.title = customSettings?.browserProvider?.title;
+	}
 	if (!isEmpty(customSettings?.browserProvider)) {
 		browser.defaultWindowOptions = await getDefaultWindowOptions(customSettings?.browserProvider);
 	}

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/browser-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/browser-shapes.ts
@@ -12,7 +12,7 @@ import type { MenuEntry, PopupMenuStyles } from "./menu-shapes";
  */
 export type BrowserProviderOptions = Pick<
 	BrowserInitConfig,
-	"defaultWindowOptions" | "defaultPageOptions" | "defaultViewOptions"
+	"defaultWindowOptions" | "defaultPageOptions" | "defaultViewOptions" | "title"
 > & {
 	/**
 	 * This setting lets you override the default workspace browser buttons and specify your own.


### PR DESCRIPTION
This allows the quit platform global context menu entry to use the platform label rather than just `platform`