### PR TITLE
Add additional action for a workspace lifecycle event.

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v18.0.0
 
+- Improvement: Added `apply` as an action on the WorkspaceChangedLifecyclePayload. Previously we had `create`, `update`, `delete`. `update` was being fired when a workspace was updated and when a workspace was applied. `apply` now makes it clear when a particular workspace platform override has been triggered.
+- Improvement: modules/integrations/workspaces this module now refreshes the entries when a workspace is applied. So if a workspace entry in Home said it was selected it would be updated and the newly selected workspace would be updated to reflect it is the currently selected workspace.
+- Updated: modules/composite/default-workspace/lifecycle logic to listen out for the new `apply` action.
 - Added support for rspack for faster builds. `npm run build-client-rspack` will npx install rspack and use the webpack config file to build the JavaScript from the TypeScript files. It is faster but no type checking is performed so we still recommend doing validated builds using `npm run build` or `npm run build-client`.
 - Improved performance of switching schemes
 - Improved performance of computing dock configuration, especially on theme changes.

--- a/how-to/workspace-platform-starter/client/src/framework/platform/platform-override.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/platform/platform-override.ts
@@ -412,7 +412,7 @@ export function overrideCallback(
 			}
 
 			await fireLifecycleEvent<WorkspaceChangedLifecyclePayload>(platform, "workspace-changed", {
-				action: "update",
+				action: "apply",
 				id: payload.workspaceId,
 				workspace: payload
 			});

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/lifecycle-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/lifecycle-shapes.ts
@@ -57,7 +57,7 @@ export interface WorkspaceChangedLifecyclePayload {
 	/**
 	 * The action that happened to the workspace.
 	 */
-	action: "create" | "update" | "delete";
+	action: "create" | "apply" | "update" | "delete";
 
 	/**
 	 * The id of the workspace.

--- a/how-to/workspace-platform-starter/client/src/modules/composite/default-workspace/lifecycle.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/composite/default-workspace/lifecycle.ts
@@ -92,7 +92,9 @@ export class ApplyDefaultWorkspaceProvider implements Lifecycle<DefaultWorkspace
 			if (!isEmpty(customData)) {
 				const workspaceUpdate = customData as WorkspaceChangedLifecyclePayload;
 				if (
-					(workspaceUpdate.action === "update" || workspaceUpdate.action === "create") &&
+					(workspaceUpdate.action === "update" ||
+						workspaceUpdate.action === "create" ||
+						workspaceUpdate.action === "apply") &&
 					!isEmpty(this._defaultWorkspaceStorage)
 				) {
 					try {

--- a/how-to/workspace-platform-starter/client/src/modules/integrations/workspaces/integration.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/integrations/workspaces/integration.ts
@@ -146,7 +146,7 @@ export class WorkspacesProvider implements IntegrationModule<WorkspacesSettings>
 					platform: WorkspacePlatformModule,
 					payload?: WorkspaceChangedLifecyclePayload
 				): Promise<void> => {
-					if (payload?.action === "create") {
+					if (payload?.action === "create" || payload?.action === "apply") {
 						if (!isEmpty(this._lastQuery) && !this._lastQuery.startsWith("/w ")) {
 							await this.rebuildResults(platform);
 						}

--- a/how-to/workspace-platform-starter/client/types/module/shapes/lifecycle-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/lifecycle-shapes.d.ts
@@ -51,7 +51,7 @@ export interface WorkspaceChangedLifecyclePayload {
 	/**
 	 * The action that happened to the workspace.
 	 */
-	action: "create" | "update" | "delete";
+	action: "create" | "apply" | "update" | "delete";
 	/**
 	 * The id of the workspace.
 	 */


### PR DESCRIPTION
Added an extra action to make it clear when a workspace was applied. Updated impacted modules.

- Improvement: Added `apply` as an action on the WorkspaceChangedLifecyclePayload. Previously we had `create`, `update`, `delete`. `update` was being fired when a workspace was updated and when a workspace was applied. `apply` now makes it clear when a particular workspace platform override has been triggered.
- Improvement: modules/integrations/workspaces this module now refreshes the entries when a workspace is applied. So if a workspace entry in Home said it was selected it would be updated and the newly selected workspace would be updated to reflect it is the currently selected workspace.
- Updated: modules/composite/default-workspace/lifecycle logic to listen out for the new `apply` action.