### PR TITLE
Salesforce updates

### DIFF
--- a/how-to/integrate-with-salesforce/README.md
+++ b/how-to/integrate-with-salesforce/README.md
@@ -26,6 +26,7 @@ Once you have completed the configuration steps, update the `customSettings` sec
 
 - **`orgUrl`**: the URL of your Salesforce org (ending in "my.salesforce.com")
 - **`consumerKey`**: the Consumer Key of the Connected App you just created
+- **`contextGroupStrategy`**: When you launch a result from home do you want to assign a context group to the view. Options are: none, first, rotation (rotation is the default)
 
 Optionally, if the enhanced notes feature is [enabled](https://help.salesforce.com/s/articleView?id=sf.notes_admin_setup.htm&type=5), this sample will include notes in the search results displayed in Home.
 

--- a/how-to/integrate-with-salesforce/client/src/provider.ts
+++ b/how-to/integrate-with-salesforce/client/src/provider.ts
@@ -162,7 +162,7 @@ function interopOverride(InteropBroker: OpenFin.Constructor<OpenFin.InteropBroke
 		public async handleFiredIntent(intent: OpenFin.Intent): Promise<void> {
 			console.log("Received request for a raised intent:", intent);
 
-			if (intent.name === "ViewContact") {
+			if (intent.name === "ViewContact" || intent.name === "ViewProfile") {
 				const viewIdentity = { uuid: fin.me.identity.uuid, name: "fdc3-intent-view" };
 				let hasView = false;
 				try {
@@ -181,8 +181,8 @@ function interopOverride(InteropBroker: OpenFin.Constructor<OpenFin.InteropBroke
 						const platform = getCurrentSync();
 						await platform.createView({
 							name: "fdc3-intent-view",
-							url: " https://built-on-openfin.github.io/dev-extensions/extensions/v18.0.0/interop/fdc3/intent/fdc3-intent-view.html",
-							fdc3InteropApi: "1.2",
+							url: "https://built-on-openfin.github.io/dev-extensions/extensions/v18.0.0/interop/fdc3/intent/2-0/fdc3-intent-view.html",
+							fdc3InteropApi: "2.0",
 							interop: {
 								currentContextGroup: "green"
 							}

--- a/how-to/integrate-with-salesforce/client/src/shapes.ts
+++ b/how-to/integrate-with-salesforce/client/src/shapes.ts
@@ -311,6 +311,14 @@ export interface SalesforceSettings {
 	appId?: string;
 
 	/**
+	 * Content Context Group
+	 * none - a context group is not assigned to the content
+	 * first - the first context group of available context groups is always assigned.
+	 * rotation - the context group is rotated through the available context groups.
+	 */
+	contextGroupStrategy?: "none" | "first" | "rotation";
+
+	/**
 	 * Map the data from SF to templates, if you just include the type field the default display will be used.
 	 */
 	mappings?: SalesforceMapping[];

--- a/how-to/integrate-with-salesforce/public/manifest.fin.json
+++ b/how-to/integrate-with-salesforce/public/manifest.fin.json
@@ -39,6 +39,7 @@
 			"orgUrl": "",
 			"enableLibLogging": true,
 			"preload": "http://localhost:8080/js/preload.js",
+			"contextGroupStrategy": "rotation",
 			"iconMap": {
 				"salesforce": "http://localhost:8080/images/salesforce.svg",
 				"contact": "http://localhost:8080/images/contact.svg",

--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v18.0.0
 
+- Added [apps-connector.json](./public/common/apps-connector.json) which includes an example salesforce app that can be added as the appId in the salesforce integration in the main [manifest.fin.json](./public/manifest.fin.json). The [apps-connector.json](./public/common/apps-connector.json) directory would also need to be added to the appProvider for it to be loaded. See [how to use our integrations](./docs/how-to-setup-example-home-integrations.md)
 - Updated WPS Interop Broker implementation so that it includes fdc3 app instances if they exist in the array of apps returned when findIntent is called as recommended by the FDC3 documentation.
 - Extended endpoint so that we now have a requestStream option for those implementing endpoints that want to return a stream of data instead of a simply requestResponse.
 - Included an example of the the requestStream endpoint by implementing an example source of notification data in the [client/src/modules/endpoint/example-notification-source](./client/src/modules/endpoint/example-notification-source/endpoint.ts)

--- a/how-to/workspace-platform-starter/docs/how-to-setup-example-home-integrations.md
+++ b/how-to/workspace-platform-starter/docs/how-to-setup-example-home-integrations.md
@@ -18,6 +18,7 @@ Our Salesforce example already exists in the main [manifest.fin.json](../public/
      "enabled": false,
      "url": "https://built-on-openfin.github.io/workspace-starter/workspace/v18.0.0/integrate-with-salesforce/js/modules/integrations/salesforce.bundle.js",
      "data": {
+      "appId": "",
       "consumerKey": "",
       "orgUrl": "",
       "preload": "https://built-on-openfin.github.io/workspace-starter/workspace/v18.0.0/integrate-with-salesforce/js/preload.js",
@@ -41,6 +42,17 @@ Our Salesforce example already exists in the main [manifest.fin.json](../public/
 This examples supports a number of configuration settings (covered in the sample) so that you can adapt it to your needs. It can give you a UI similar to the following:
 
 ![Salesforce](./assets/home-salesforce.png)
+
+### Add Intent Support to search results
+
+If you wish to have content launched from the Salesforce integration to be an intent target for ViewContact/ViewProfile then you will need:
+
+- An app definition - We have included one in [apps-connector.json](../public/common/apps-connector.json) although you will need to add your salesforce org url. You will also need to add the [apps-connector.json](../public/common/apps-connector.json) directory to your [appsProvider](./what-is-an-apps-provider.md) so that it is included when looking up which applications support ViewContact/ViewProfile.
+- Add the appId (salesforce-app is the id we use in our apps-connector.json file) to the salesforce integration entry in your manifest or settings file. This will tell the integration to launch Salesforce urls as part of the app.
+
+### Preload scripts
+
+In the integration definition and the salesforce app definition you will see a reference to preload scripts. If you are using a [Lightning Web Security Salesforce application](https://developer.salesforce.com/docs/platform/lwc/guide/security-lwsec-intro.html) then you can delete the preload script entries as they are not needed. For more information about the OpenFin SalesForce app which simplifies Salesforce integration please visit: <https://developers.openfin.co/of-docs/docs/salesforce-appexchange>.
 
 ## ServiceNow
 

--- a/how-to/workspace-platform-starter/public/common/apps-connector.json
+++ b/how-to/workspace-platform-starter/public/common/apps-connector.json
@@ -1,0 +1,49 @@
+[
+	{
+		"appId": "salesforce-app",
+		"name": "salesforce-app",
+		"title": "Salesforce",
+		"description": "If you are using the OpenFin Salesforce App on the app exchange then you can make it an intent target and add an app entry for it.",
+		"manifest": {
+			"url": "",
+			"fdc3InteropApi": "2.0",
+			"preloadScripts": [
+				{
+					"url": "https://built-on-openfin.github.io/workspace-starter/workspace/v18.0.0/integrate-with-salesforce/js/preload.js"
+				}
+			]
+		},
+		"manifestType": "inline-view",
+		"icons": [],
+		"contactEmail": "contact@example.com",
+		"supportEmail": "support@example.com",
+		"publisher": "OpenFin",
+		"intents": [
+			{
+				"name": "ViewContact",
+				"displayName": "View Contact",
+				"contexts": ["fdc3.contact"]
+			},
+			{
+				"name": "ViewProfile",
+				"displayName": "View Profile",
+				"contexts": ["fdc3.contact", "fdc3.organization"]
+			}
+		],
+		"private": true,
+		"images": [],
+		"tags": ["fdc3", "interop", "contact", "salesforce"],
+		"launchPreference": {
+			"options": {
+				"type": "view",
+				"updatable": [
+					{
+						"name": "url",
+						"constraint": "url-domain"
+					},
+					{ "name": "interop" }
+				]
+			}
+		}
+	}
+]

--- a/how-to/workspace-platform-starter/public/manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/manifest.fin.json
@@ -1246,6 +1246,7 @@
 					"enabled": false,
 					"url": "https://built-on-openfin.github.io/workspace-starter/workspace/v18.0.0/integrate-with-salesforce/js/modules/integrations/salesforce.bundle.js",
 					"data": {
+						"appId": "",
 						"consumerKey": "",
 						"orgUrl": "",
 						"preload": "https://built-on-openfin.github.io/workspace-starter/workspace/v18.0.0/integrate-with-salesforce/js/preload.js",


### PR DESCRIPTION
Added option to easily decide if browser pages launched from home should be assigned to a context group and whether it should be the same context group or rotated.

Added additional intent target support to the salesforce example.

Added an example of how to add a salesforce app as an intent target to workspace platform starter.