### PR TITLE
Add support for the intent ViewProfile

### DIFF
--- a/how-to/register-with-home/public/common/apps-contact.json
+++ b/how-to/register-with-home/public/common/apps-contact.json
@@ -134,6 +134,11 @@
 				"name": "ViewContact",
 				"displayName": "View Contact",
 				"contexts": ["fdc3.contact"]
+			},
+			{
+				"name": "ViewProfile",
+				"displayName": "View Profile",
+				"contexts": ["fdc3.contact"]
 			}
 		],
 		"images": [
@@ -162,6 +167,11 @@
 			{
 				"name": "ViewContact",
 				"displayName": "View Contact",
+				"contexts": ["fdc3.contact"]
+			},
+			{
+				"name": "ViewProfile",
+				"displayName": "View Profile",
 				"contexts": ["fdc3.contact"]
 			}
 		],

--- a/how-to/register-with-home/public/common/views/contact/participant-summary/index.js
+++ b/how-to/register-with-home/public/common/views/contact/participant-summary/index.js
@@ -29,6 +29,7 @@ async function setupListeners() {
 
 		window.fdc3.addContextListener(contextHandler);
 		window.fdc3.addIntentListener('ViewContact', contextHandler);
+		window.fdc3.addIntentListener('ViewProfile', contextHandler);
 	} catch (error) {
 		console.error('There was an error while setting up all of the fdc3 listeners', error);
 	}

--- a/how-to/register-with-store/public/common/apps-contact.json
+++ b/how-to/register-with-store/public/common/apps-contact.json
@@ -134,6 +134,11 @@
 				"name": "ViewContact",
 				"displayName": "View Contact",
 				"contexts": ["fdc3.contact"]
+			},
+			{
+				"name": "ViewProfile",
+				"displayName": "View Profile",
+				"contexts": ["fdc3.contact"]
 			}
 		],
 		"images": [
@@ -162,6 +167,11 @@
 			{
 				"name": "ViewContact",
 				"displayName": "View Contact",
+				"contexts": ["fdc3.contact"]
+			},
+			{
+				"name": "ViewProfile",
+				"displayName": "View Profile",
 				"contexts": ["fdc3.contact"]
 			}
 		],

--- a/how-to/register-with-store/public/common/views/contact/participant-summary/index.js
+++ b/how-to/register-with-store/public/common/views/contact/participant-summary/index.js
@@ -29,6 +29,7 @@ async function setupListeners() {
 
 		window.fdc3.addContextListener(contextHandler);
 		window.fdc3.addIntentListener('ViewContact', contextHandler);
+		window.fdc3.addIntentListener('ViewProfile', contextHandler);
 	} catch (error) {
 		console.error('There was an error while setting up all of the fdc3 listeners', error);
 	}

--- a/how-to/support-context-and-intents/public/common/apps-contact.json
+++ b/how-to/support-context-and-intents/public/common/apps-contact.json
@@ -134,6 +134,11 @@
 				"name": "ViewContact",
 				"displayName": "View Contact",
 				"contexts": ["fdc3.contact"]
+			},
+			{
+				"name": "ViewProfile",
+				"displayName": "View Profile",
+				"contexts": ["fdc3.contact"]
 			}
 		],
 		"images": [
@@ -162,6 +167,11 @@
 			{
 				"name": "ViewContact",
 				"displayName": "View Contact",
+				"contexts": ["fdc3.contact"]
+			},
+			{
+				"name": "ViewProfile",
+				"displayName": "View Profile",
 				"contexts": ["fdc3.contact"]
 			}
 		],

--- a/how-to/support-context-and-intents/public/common/views/contact/participant-summary/index.js
+++ b/how-to/support-context-and-intents/public/common/views/contact/participant-summary/index.js
@@ -29,6 +29,7 @@ async function setupListeners() {
 
 		window.fdc3.addContextListener(contextHandler);
 		window.fdc3.addIntentListener('ViewContact', contextHandler);
+		window.fdc3.addIntentListener('ViewProfile', contextHandler);
 	} catch (error) {
 		console.error('There was an error while setting up all of the fdc3 listeners', error);
 	}

--- a/how-to/workspace-platform-starter-basic/public/common/views/contact/participant-summary/index.js
+++ b/how-to/workspace-platform-starter-basic/public/common/views/contact/participant-summary/index.js
@@ -29,6 +29,7 @@ async function setupListeners() {
 
 		window.fdc3.addContextListener(contextHandler);
 		window.fdc3.addIntentListener('ViewContact', contextHandler);
+		window.fdc3.addIntentListener('ViewProfile', contextHandler);
 	} catch (error) {
 		console.error('There was an error while setting up all of the fdc3 listeners', error);
 	}

--- a/how-to/workspace-platform-starter/public/common/apps-contact.json
+++ b/how-to/workspace-platform-starter/public/common/apps-contact.json
@@ -134,6 +134,11 @@
 				"name": "ViewContact",
 				"displayName": "View Contact",
 				"contexts": ["fdc3.contact"]
+			},
+			{
+				"name": "ViewProfile",
+				"displayName": "View Profile",
+				"contexts": ["fdc3.contact"]
 			}
 		],
 		"images": [
@@ -162,6 +167,11 @@
 			{
 				"name": "ViewContact",
 				"displayName": "View Contact",
+				"contexts": ["fdc3.contact"]
+			},
+			{
+				"name": "ViewProfile",
+				"displayName": "View Profile",
 				"contexts": ["fdc3.contact"]
 			}
 		],

--- a/how-to/workspace-platform-starter/public/common/apps-fdc3-2-0.json
+++ b/how-to/workspace-platform-starter/public/common/apps-fdc3-2-0.json
@@ -45,6 +45,10 @@
 							"displayName": "View Contact Details",
 							"contexts": ["fdc3.contact"]
 						},
+						"ViewProfile": {
+							"displayName": "View Profile",
+							"contexts": ["fdc3.contact"]
+						},
 						"ViewQuote": {
 							"displayName": "View Quote",
 							"contexts": ["fdc3.instrument"]

--- a/how-to/workspace-platform-starter/public/common/views/contact/participant-summary/index.js
+++ b/how-to/workspace-platform-starter/public/common/views/contact/participant-summary/index.js
@@ -29,6 +29,7 @@ async function setupListeners() {
 
 		window.fdc3.addContextListener(contextHandler);
 		window.fdc3.addIntentListener('ViewContact', contextHandler);
+		window.fdc3.addIntentListener('ViewProfile', contextHandler);
 	} catch (error) {
 		console.error('There was an error while setting up all of the fdc3 listeners', error);
 	}

--- a/how-to/workspace-platform-starter/public/manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/manifest.fin.json
@@ -138,6 +138,11 @@
 							"contexts": ["fdc3.contact"]
 						},
 						{
+							"name": "ViewProfile",
+							"displayName": "View Profile",
+							"contexts": ["fdc3.contact"]
+						},
+						{
 							"name": "ViewQuote",
 							"displayName": "View Quote",
 							"contexts": ["fdc3.instrument"]

--- a/how-to/workspace-platform-starter/public/pack.manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/pack.manifest.fin.json
@@ -132,6 +132,11 @@
 							"contexts": ["fdc3.contact"]
 						},
 						{
+							"name": "ViewProfile",
+							"displayName": "View Profile",
+							"contexts": ["fdc3.contact"]
+						},
+						{
 							"name": "ViewQuote",
 							"displayName": "View Quote",
 							"contexts": ["fdc3.instrument"]

--- a/how-to/workspace-platform-starter/public/settings.json
+++ b/how-to/workspace-platform-starter/public/settings.json
@@ -68,6 +68,11 @@
 						"contexts": ["fdc3.contact"]
 					},
 					{
+						"name": "ViewProfile",
+						"displayName": "View Profile",
+						"contexts": ["fdc3.contact"]
+					},
+					{
 						"name": "ViewQuote",
 						"displayName": "View Quote",
 						"contexts": ["fdc3.instrument"]

--- a/how-to/workspace-platform-starter/public/third.manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/third.manifest.fin.json
@@ -125,6 +125,11 @@
 							"contexts": ["fdc3.contact"]
 						},
 						{
+							"name": "ViewProfile",
+							"displayName": "View Profile",
+							"contexts": ["fdc3.contact"]
+						},
+						{
 							"name": "ViewQuote",
 							"displayName": "View Quote",
 							"contexts": ["fdc3.instrument"]


### PR DESCRIPTION
The default for the salesforce app exchange is ViewProfile (although it also supports ViewContact). Add support for both in our examples.