### PR TITLE
Added support for configuring the interop broker to not send context to the sender

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Updated manifests to disable app logging (where console log entries are written to disk). You can still see console log messages in dev tools or you can turn it back on by setting enableAppLogging to true.
 - Added new v38 runtime setting appLogsTimezone and set it to utc for when you do capture logs to disk.
 - Removed startup_app from manifests as the name setting in platform is sufficient for naming the app folder name when app logging is enabled.
+- Added support to the interop broker for preventing context from being sent back to the originator (default behavior). See the [how to add context support to your app](./docs/how-to-add-context-support-to-your-app.md) document and scroll down to the section titled: Should the context object be sent back to the sender?
 
 ## v18.0.0
 

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/interopbroker-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/interopbroker-shapes.ts
@@ -54,6 +54,11 @@ export interface PlatformInteropBrokerOptions extends ModuleList {
 	openOptions?: OpenOptions;
 
 	/**
+	 * Options for when fdc3.broadcast or fin.me.interop.setContext is called.
+	 */
+	contextOptions?: ContextOptions;
+
+	/**
 	 * If an unregistered app is included here then it indicates you wish to support selecting views/windows that are
 	 * not linked to an app from an intent picker that supports instances. The intents and contexts in this app specify
 	 * which you support for unregistered instances. Do not specify a manifest or manifestType for this entry (we don't
@@ -152,6 +157,16 @@ export interface IntentOptions {
 	 * is 15000 (15 seconds)
 	 */
 	intentTimeout?: number;
+}
+
+/**
+ * Option for the Context Handling.
+ */
+export interface ContextOptions {
+	/**
+	 * Should the broker send context messages back to the sender? Default is true.
+	 */
+	includeOriginator?: boolean;
 }
 
 /**

--- a/how-to/workspace-platform-starter/client/types/module/shapes/init-options-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/init-options-shapes.d.ts
@@ -1,3 +1,4 @@
+import type { OpenFin } from "@openfin/core";
 import type { ModuleImplementation, ModuleList } from "./module-shapes";
 /**
  * InitOptions Provider Options. This is a list of modules that will be loaded and used to handle init params (similar
@@ -66,6 +67,6 @@ export type InitOptionsActionHandler<T = unknown> = (
  * The handler for an init options listener.
  */
 export type InitOptionsListener = (
-	initOptions: UserAppConfigArgs,
+	initOptions: OpenFin.UserAppConfigArgs,
 	context: ActionHandlerContext
 ) => Promise<void>;

--- a/how-to/workspace-platform-starter/client/types/module/shapes/interopbroker-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/interopbroker-shapes.d.ts
@@ -48,6 +48,10 @@ export interface PlatformInteropBrokerOptions extends ModuleList {
 	 */
 	openOptions?: OpenOptions;
 	/**
+	 * Options for when fdc3.broadcast or fin.me.interop.setContext is called.
+	 */
+	contextOptions?: ContextOptions;
+	/**
 	 * If an unregistered app is included here then it indicates you wish to support selecting views/windows that are
 	 * not linked to an app from an intent picker that supports instances. The intents and contexts in this app specify
 	 * which you support for unregistered instances. Do not specify a manifest or manifestType for this entry (we don't
@@ -138,6 +142,15 @@ export interface IntentOptions {
 	 * is 15000 (15 seconds)
 	 */
 	intentTimeout?: number;
+}
+/**
+ * Option for the Context Handling.
+ */
+export interface ContextOptions {
+	/**
+	 * Should the broker send context messages back to the sender? Default is true.
+	 */
+	includeOriginator?: boolean;
 }
 /**
  * Intent resolver options.

--- a/how-to/workspace-platform-starter/docs/how-to-add-context-support-to-your-app.md
+++ b/how-to/workspace-platform-starter/docs/how-to-add-context-support-to-your-app.md
@@ -180,6 +180,57 @@ If you are a platform owner with a variable number of apps from different conten
 
 We have an example of what this could be like in workspace platform starter. You can define endpoints ([See how to define endpoints](./how-to-define-endpoints.md)) that support a requestResponse function where the context will be passed to the function, enriched and then returned. This could be a single JavaScript module for one or more context types or you might have teams that build and own their own JavaScript module for their specific context types. This will let your platform scale without requiring direct changes to your broker's setContext function.
 
+## Should the context object be sent back to the sender?
+
+By default if you have a user channel context listener (e.g. listening on green) and you also publish a context message via fdc3.broadcast or fin.me.interop.setContext then the listener will receive the message you sent.
+
+### Checking to see if you are the originator of the context message
+
+Workspace Platform Starter supports the fdc3 preference of including app metadata alongside the context. You can check to see if you are the sender through a snippet like this:
+
+```javascript
+// get the app Id and instance Id of the current webpage
+const info = await fdc3.getInfo();
+const appMetadata = info.appMetadata;
+console.log(
+  `I am associated with appId: ${appMetadata.appId} and this specific instance of this app has the following instanceId: ${appMetadata.instanceId}`
+);
+
+// ... other logic followed by your contextListener
+// --------------------------------
+// Listening code
+// --------------------------------
+const userChannelHandler = (ctx, metadata) => {
+  if (
+    metadata !== undefined &&
+    metadata.source.appId === appMetadata.appId &&
+    metadata.source.instanceId === appMetadata.instanceId
+  ) {
+    console.log('We are not going to do anything with this context object as it came from ourselves');
+  } else {
+    console.log('User Context Received: ', ctx);
+  }
+};
+
+const userChannelListener = fdc3.addContextListener(null, userChannelHandler);
+```
+
+### Configure your interop broker to not pass context messages to the originator
+
+From workspace platform starter v19.0 we have added a new configuration option to the interop section of the platformProvider settings called contextOptions. ContextOptions has a setting called **includeOriginator**. By default this is true but if you set it to false it won't pass context to the source of the sent context.
+
+```json
+"platformProvider": {
+   ...
+   "interop": {
+    ...
+    "contextOptions": {
+     "includeOriginator": false
+    }
+   }
+  }
+```
+
 ## Test Harnesses
 
 It is useful to be able to test your app against something. When you reference the common apps feed in your instance of workspace platform starter you get a number of useful utilities. We provide two entries related to context sharing in FDC3:

--- a/how-to/workspace-platform-starter/public/manifest.fin.json
+++ b/how-to/workspace-platform-starter/public/manifest.fin.json
@@ -108,6 +108,7 @@
 				},
 				"intentOptions": {},
 				"openOptions": {},
+				"contextOptions": {},
 				"unregisteredApp": {
 					"appId": "unregistered",
 					"title": "Other",

--- a/how-to/workspace-platform-starter/public/schemas/openfin.manifest.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/openfin.manifest.schema.json
@@ -15,7 +15,7 @@
 			"type": "array"
 		},
 		"AutoResizeOptions": {
-			"$ref": "#/definitions/__type_26"
+			"$ref": "#/definitions/__type_27"
 		},
 		"AutoplayPolicyOptions": {
 			"description": "Autoplay policy to apply to content in the window, can be\n`no-user-gesture-required`, `user-gesture-required`,\n`document-user-activation-required`. Defaults to `no-user-gesture-required`.",
@@ -46,7 +46,7 @@
 			"type": "object"
 		},
 		"Bounds": {
-			"$ref": "#/definitions/__type_25"
+			"$ref": "#/definitions/__type_26"
 		},
 		"BrowserContentCreationRule": {
 			"additionalProperties": false,
@@ -98,11 +98,16 @@
 		"ContentNavigation": {
 			"$ref": "#/definitions/__type_12"
 		},
+		"ContentPermission": {
+			"description": "Whether a content url is allowed or blocked for navigation or redirection.\n\n* 'allow': The content url is allowed.\n* 'block': The content url is blocked.",
+			"enum": ["allow", "block"],
+			"type": "string"
+		},
 		"ContentRedirect": {
 			"$ref": "#/definitions/__type_12"
 		},
 		"ContextGroupStates": {
-			"$ref": "#/definitions/__type_32"
+			"$ref": "#/definitions/__type_33"
 		},
 		"ContextMenuOptions": {
 			"$ref": "#/definitions/__type_3"
@@ -111,7 +116,7 @@
 			"$ref": "#/definitions/__type_2"
 		},
 		"DefaultDomainSettings": {
-			"$ref": "#/definitions/__type_37"
+			"$ref": "#/definitions/__type_38"
 		},
 		"DipRect": {
 			"additionalProperties": false,
@@ -127,19 +132,19 @@
 			"type": "object"
 		},
 		"DipScaleRects": {
-			"$ref": "#/definitions/__type_29"
+			"$ref": "#/definitions/__type_30"
 		},
-		"DisplayMetadata_3": {
-			"$ref": "#/definitions/__type_35"
+		"DisplayMetadata": {
+			"$ref": "#/definitions/__type_36"
 		},
 		"DomainApiSettings": {
-			"$ref": "#/definitions/__type_39"
+			"$ref": "#/definitions/__type_41"
 		},
 		"DomainSettings": {
-			"$ref": "#/definitions/__type_37"
+			"$ref": "#/definitions/__type_38"
 		},
 		"DownloadShelfOptions": {
-			"$ref": "#/definitions/__type_14"
+			"$ref": "#/definitions/__type_15"
 		},
 		"FileDownloadBehavior": {
 			"description": "Whether file downloads raise a user prompt.",
@@ -147,10 +152,10 @@
 			"type": "string"
 		},
 		"FileDownloadSettings": {
-			"$ref": "#/definitions/__type_38"
+			"$ref": "#/definitions/__type_40"
 		},
 		"Identity_5": {
-			"$ref": "#/definitions/__type_17"
+			"$ref": "#/definitions/__type_18"
 		},
 		"InjectionType": {
 			"description": "Injection setting for the `fin` API.\n\n* 'none': The `fin` API will be not available.\n* 'global': The entire `fin` API will be available.",
@@ -158,22 +163,22 @@
 			"type": "string"
 		},
 		"InteropBrokerOptions": {
-			"$ref": "#/definitions/__type_34"
+			"$ref": "#/definitions/__type_35"
 		},
 		"InteropConfig": {
 			"$ref": "#/definitions/__type_6"
 		},
 		"InteropLoggingOptions": {
-			"$ref": "#/definitions/__type_36"
+			"$ref": "#/definitions/__type_37"
 		},
 		"LayoutSnapshot": {
-			"$ref": "#/definitions/__type_15"
+			"$ref": "#/definitions/__type_16"
 		},
 		"MonitorDetails": {
-			"$ref": "#/definitions/__type_31"
+			"$ref": "#/definitions/__type_32"
 		},
 		"MonitorInfo": {
-			"$ref": "#/definitions/__type_27"
+			"$ref": "#/definitions/__type_28"
 		},
 		"OpenExternalPermission": {
 			"additionalProperties": false,
@@ -379,25 +384,31 @@
 			"$ref": "#/definitions/__type_11"
 		},
 		"Partial_3": {
-			"$ref": "#/definitions/__type_13"
+			"$ref": "#/definitions/__type_14"
 		},
 		"Partial_4": {
-			"$ref": "#/definitions/__type_18"
-		},
-		"Partial_5": {
 			"$ref": "#/definitions/__type_19"
 		},
-		"Partial_6": {
+		"Partial_5": {
 			"$ref": "#/definitions/__type_20"
 		},
-		"Partial_7": {
-			"$ref": "#/definitions/__type_23"
+		"Partial_6": {
+			"$ref": "#/definitions/__type_21"
 		},
-		"Partial_8": {
+		"Partial_7": {
 			"$ref": "#/definitions/__type_24"
 		},
+		"Partial_8": {
+			"$ref": "#/definitions/__type_25"
+		},
 		"Partial_9": {
-			"$ref": "#/definitions/__type_33"
+			"$ref": "#/definitions/__type_34"
+		},
+		"PerDomainSettings": {
+			"$ref": "#/definitions/__type_39"
+		},
+		"Permissions_2": {
+			"$ref": "#/definitions/__type_42"
 		},
 		"PlatformOptions": {
 			"additionalProperties": false,
@@ -420,6 +431,10 @@
 				},
 				"apiDiagnostics": {
 					"type": "boolean"
+				},
+				"appLogsTimezone": {
+					"$ref": "#/definitions/TimeZones",
+					"description": "Set the timezone for the app logs. When setting this value the timestamp will be in ISO 8601 format. By default, if no value is set, it will show the local time in this format: 'y-MM-dd HH:mm:ss.SSS'"
 				},
 				"aspectRatio": {
 					"type": "number"
@@ -680,7 +695,7 @@
 			"type": "object"
 		},
 		"Point": {
-			"$ref": "#/definitions/__type_28"
+			"$ref": "#/definitions/__type_29"
 		},
 		"PrebuiltContextMenuItem": {
 			"description": "Context menu item with an implementation provided by OpenFin.",
@@ -711,13 +726,16 @@
 			"$ref": "#/definitions/__type_1"
 		},
 		"Record": {
-			"$ref": "#/definitions/__type_16"
+			"$ref": "#/definitions/__type_17"
 		},
 		"RectangleByEdgePositions": {
-			"$ref": "#/definitions/__type_30"
+			"$ref": "#/definitions/__type_31"
 		},
 		"ResizeRegion": {
 			"$ref": "#/definitions/__type_5"
+		},
+		"RuleMatchOptions": {
+			"$ref": "#/definitions/__type_13"
 		},
 		"ShortcutOverride": {
 			"additionalProperties": false,
@@ -767,6 +785,10 @@
 			"required": ["edge", "rect"],
 			"type": "object"
 		},
+		"TimeZones": {
+			"enum": ["local", "utc"],
+			"type": "string"
+		},
 		"ViewContentCreationRule": {
 			"additionalProperties": false,
 			"description": "A rule prescribing content creation in a {@link OpenFin.View}.",
@@ -794,11 +816,16 @@
 			"required": ["behavior", "match"],
 			"type": "object"
 		},
+		"ViewThrottling": {
+			"description": "View throttling state.\n\n* `enabled`: Both background throttling and scheduler throttling are true. It's fully throttled.\n* `scheduler-disabled`: background throttling is true, but scheduler throttling is disabled.",
+			"enum": ["enabled", "scheduler-disabled"],
+			"type": "string"
+		},
 		"ViewVisibilityOption": {
-			"$ref": "#/definitions/__type_22"
+			"$ref": "#/definitions/__type_23"
 		},
 		"ViewVisibilityOptions": {
-			"$ref": "#/definitions/__type_21"
+			"$ref": "#/definitions/__type_22"
 		},
 		"WebPermission": {
 			"anyOf": [
@@ -889,6 +916,9 @@
 				"backgroundColor": {
 					"description": "The window’s _backfill_ color as a hexadecimal value. Not to be confused with the content background color\n(`document.body.style.backgroundColor`),\nthis color briefly fills a window’s (a) content area before its content is loaded as well as (b) newly exposed\nareas when growing a window. Setting\nthis value to the anticipated content background color can help improve user experience.\nDefault is white.",
 					"type": "string"
+				},
+				"backgroundThrottling": {
+					"type": "boolean"
 				},
 				"closeOnLastViewRemoved": {
 					"type": "boolean"
@@ -1058,7 +1088,8 @@
 					"type": "number"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_4"
+					"$ref": "#/definitions/Partial_4",
+					"description": "API permissions for code running in the window."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -1119,6 +1150,10 @@
 				"taskbarIconGroup": {
 					"description": "Specify a taskbar group for the window.\n_If omitted, defaults to app's uuid (`fin.Application.getCurrentSync().identity.uuid`)._",
 					"type": "string"
+				},
+				"throttling": {
+					"$ref": "#/definitions/WindowThrottling",
+					"description": "{@inheritDoc WindowThrottling}"
 				},
 				"url": {
 					"type": "string"
@@ -1189,6 +1224,9 @@
 				"backgroundColor": {
 					"description": "The window’s _backfill_ color as a hexadecimal value. Not to be confused with the content background color\n(`document.body.style.backgroundColor`),\nthis color briefly fills a window’s (a) content area before its content is loaded as well as (b) newly exposed\nareas when growing a window. Setting\nthis value to the anticipated content background color can help improve user experience.\nDefault is white.",
 					"type": "string"
+				},
+				"backgroundThrottling": {
+					"type": "boolean"
 				},
 				"closeOnLastViewRemoved": {
 					"type": "boolean"
@@ -1359,7 +1397,8 @@
 					"type": "number"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_4"
+					"$ref": "#/definitions/Partial_4",
+					"description": "API permissions for code running in the window."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -1421,6 +1460,10 @@
 					"description": "Specify a taskbar group for the window.\n_If omitted, defaults to app's uuid (`fin.Application.getCurrentSync().identity.uuid`)._",
 					"type": "string"
 				},
+				"throttling": {
+					"$ref": "#/definitions/WindowThrottling",
+					"description": "{@inheritDoc WindowThrottling}"
+				},
 				"url": {
 					"type": "string"
 				},
@@ -1462,6 +1505,7 @@
 				"autoShow",
 				"autoplayPolicy",
 				"backgroundColor",
+				"backgroundThrottling",
 				"closeOnLastViewRemoved",
 				"contentCreation",
 				"contentNavigation",
@@ -1511,6 +1555,7 @@
 				"state",
 				"taskbarIcon",
 				"taskbarIconGroup",
+				"throttling",
 				"url",
 				"uuid",
 				"viewsPreventingClose",
@@ -1525,6 +1570,11 @@
 		"WindowState": {
 			"description": "Visibility state of a window.",
 			"enum": ["maximized", "minimized", "normal"],
+			"type": "string"
+		},
+		"WindowThrottling": {
+			"description": "Window throttling state.\n\n* `enabled`: Both background throttling and scheduler throttling are true. It's fully throttled.\n* `scheduler-disabled`: The background throttling is true, but scheduler throttling is disabled.\n* `disabled`: The background throttling is false. The throttling is fully disabled.",
+			"enum": ["disabled", "enabled", "scheduler-disabled"],
 			"type": "string"
 		},
 		"WorkspacePlatformOptions": {
@@ -1638,6 +1688,9 @@
 					"description": "The window’s _backfill_ color as a hexadecimal value. Not to be confused with the content background color\n(`document.body.style.backgroundColor`),\nthis color briefly fills a window’s (a) content area before its content is loaded as well as (b) newly exposed\nareas when growing a window. Setting\nthis value to the anticipated content background color can help improve user experience.\nDefault is white.",
 					"type": "string"
 				},
+				"backgroundThrottling": {
+					"type": "boolean"
+				},
 				"closeOnLastViewRemoved": {
 					"type": "boolean"
 				},
@@ -1807,7 +1860,8 @@
 					"type": "number"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_4"
+					"$ref": "#/definitions/Partial_4",
+					"description": "API permissions for code running in the window."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -1869,6 +1923,10 @@
 					"description": "Specify a taskbar group for the window.\n_If omitted, defaults to app's uuid (`fin.Application.getCurrentSync().identity.uuid`)._",
 					"type": "string"
 				},
+				"throttling": {
+					"$ref": "#/definitions/WindowThrottling",
+					"description": "{@inheritDoc WindowThrottling}"
+				},
 				"url": {
 					"type": "string"
 				},
@@ -1924,6 +1982,10 @@
 					},
 					"type": "array"
 				},
+				"matchOptions": {
+					"$ref": "#/definitions/RuleMatchOptions",
+					"description": "Options to use when comparing URIs to the `allowlist` and `denylist` patterns."
+				},
 				"whitelist": {
 					"items": {
 						"type": "string"
@@ -1934,6 +1996,17 @@
 			"type": "object"
 		},
 		"__type_13": {
+			"additionalProperties": false,
+			"description": "Controls the behavior of the navigation URI pattern matching algorithm.",
+			"properties": {
+				"matchAllSchemes": {
+					"description": "Matches all schemes rather than just http and https when a wild card is specified. For example, `'*://*.site.com'` will\nonly match urls which begin with `'http:'` or `'https:'` unless this setting is `true`.",
+					"type": "boolean"
+				}
+			},
+			"type": "object"
+		},
+		"__type_14": {
 			"additionalProperties": false,
 			"properties": {
 				"allowlist": {
@@ -1956,6 +2029,10 @@
 					},
 					"type": "array"
 				},
+				"matchOptions": {
+					"$ref": "#/definitions/RuleMatchOptions",
+					"description": "Options to use when comparing URIs to the `allowlist` and `denylist` patterns."
+				},
 				"whitelist": {
 					"items": {
 						"type": "string"
@@ -1965,7 +2042,7 @@
 			},
 			"type": "object"
 		},
-		"__type_14": {
+		"__type_15": {
 			"additionalProperties": false,
 			"properties": {
 				"border": {
@@ -1991,7 +2068,7 @@
 			"required": ["enabled"],
 			"type": "object"
 		},
-		"__type_15": {
+		"__type_16": {
 			"additionalProperties": false,
 			"properties": {
 				"layouts": {
@@ -2001,11 +2078,11 @@
 			"required": ["layouts"],
 			"type": "object"
 		},
-		"__type_16": {
+		"__type_17": {
 			"additionalProperties": false,
 			"type": "object"
 		},
-		"__type_17": {
+		"__type_18": {
 			"additionalProperties": false,
 			"description": "Unique identifier for a window, view or iframe.",
 			"properties": {
@@ -2021,7 +2098,7 @@
 			"required": ["name", "uuid"],
 			"type": "object"
 		},
-		"__type_18": {
+		"__type_19": {
 			"additionalProperties": false,
 			"properties": {
 				"Application": {
@@ -2055,18 +2132,6 @@
 			},
 			"type": "object"
 		},
-		"__type_19": {
-			"additionalProperties": false,
-			"properties": {
-				"getFileDownloadLocation": {
-					"type": "boolean"
-				},
-				"setFileDownloadLocation": {
-					"type": "boolean"
-				}
-			},
-			"type": "object"
-		},
 		"__type_2": {
 			"additionalProperties": false,
 			"properties": {
@@ -2087,6 +2152,18 @@
 			"type": "object"
 		},
 		"__type_20": {
+			"additionalProperties": false,
+			"properties": {
+				"getFileDownloadLocation": {
+					"type": "boolean"
+				},
+				"setFileDownloadLocation": {
+					"type": "boolean"
+				}
+			},
+			"type": "object"
+		},
+		"__type_21": {
 			"additionalProperties": false,
 			"properties": {
 				"getAllExternalWindows": {
@@ -2293,7 +2370,7 @@
 			},
 			"type": "object"
 		},
-		"__type_21": {
+		"__type_22": {
 			"additionalProperties": false,
 			"description": "_Platform Windows Only_. Controls behavior for showing views when they are being resized by the user.",
 			"properties": {
@@ -2312,7 +2389,7 @@
 			},
 			"type": "object"
 		},
-		"__type_22": {
+		"__type_23": {
 			"additionalProperties": false,
 			"description": "Configuration for view visibility settings",
 			"properties": {
@@ -2322,7 +2399,7 @@
 			},
 			"type": "object"
 		},
-		"__type_23": {
+		"__type_24": {
 			"additionalProperties": false,
 			"properties": {
 				"customContext": {
@@ -2340,7 +2417,7 @@
 			},
 			"type": "object"
 		},
-		"__type_24": {
+		"__type_25": {
 			"additionalProperties": false,
 			"properties": {
 				"_internalWorkspaceData": {},
@@ -2485,7 +2562,8 @@
 					"type": "string"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_4"
+					"$ref": "#/definitions/Partial_4",
+					"description": "API permissions for code running in the view."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -2522,6 +2600,10 @@
 					"$ref": "#/definitions/Identity_5",
 					"description": "The identity of the window this view should be attached to."
 				},
+				"throttling": {
+					"$ref": "#/definitions/ViewThrottling",
+					"description": "{@inheritDoc ViewThrottling}"
+				},
 				"url": {
 					"type": "string"
 				},
@@ -2531,7 +2613,7 @@
 			},
 			"type": "object"
 		},
-		"__type_25": {
+		"__type_26": {
 			"additionalProperties": false,
 			"properties": {
 				"height": {
@@ -2550,7 +2632,7 @@
 			"required": ["height", "left", "top", "width"],
 			"type": "object"
 		},
-		"__type_26": {
+		"__type_27": {
 			"additionalProperties": false,
 			"properties": {
 				"height": {
@@ -2572,7 +2654,7 @@
 			},
 			"type": "object"
 		},
-		"__type_27": {
+		"__type_28": {
 			"additionalProperties": false,
 			"properties": {
 				"deviceScaleFactor": {
@@ -2663,7 +2745,7 @@
 			],
 			"type": "object"
 		},
-		"__type_28": {
+		"__type_29": {
 			"additionalProperties": false,
 			"properties": {
 				"x": {
@@ -2676,19 +2758,6 @@
 				}
 			},
 			"required": ["x", "y"],
-			"type": "object"
-		},
-		"__type_29": {
-			"additionalProperties": false,
-			"properties": {
-				"dipRect": {
-					"$ref": "#/definitions/RectangleByEdgePositions"
-				},
-				"scaledRect": {
-					"$ref": "#/definitions/RectangleByEdgePositions"
-				}
-			},
-			"required": ["dipRect", "scaledRect"],
 			"type": "object"
 		},
 		"__type_3": {
@@ -2709,6 +2778,19 @@
 		"__type_30": {
 			"additionalProperties": false,
 			"properties": {
+				"dipRect": {
+					"$ref": "#/definitions/RectangleByEdgePositions"
+				},
+				"scaledRect": {
+					"$ref": "#/definitions/RectangleByEdgePositions"
+				}
+			},
+			"required": ["dipRect", "scaledRect"],
+			"type": "object"
+		},
+		"__type_31": {
+			"additionalProperties": false,
+			"properties": {
 				"bottom": {
 					"type": "number"
 				},
@@ -2725,7 +2807,7 @@
 			"required": ["bottom", "left", "right", "top"],
 			"type": "object"
 		},
-		"__type_31": {
+		"__type_32": {
 			"additionalProperties": false,
 			"properties": {
 				"available": {
@@ -2777,7 +2859,7 @@
 			],
 			"type": "object"
 		},
-		"__type_32": {
+		"__type_33": {
 			"additionalProperties": {
 				"additionalProperties": {
 					"additionalProperties": false,
@@ -2806,7 +2888,7 @@
 			},
 			"type": "object"
 		},
-		"__type_33": {
+		"__type_34": {
 			"additionalProperties": false,
 			"properties": {
 				"_internalWorkspaceData": {},
@@ -2842,6 +2924,9 @@
 				"backgroundColor": {
 					"description": "The window’s _backfill_ color as a hexadecimal value. Not to be confused with the content background color\n(`document.body.style.backgroundColor`),\nthis color briefly fills a window’s (a) content area before its content is loaded as well as (b) newly exposed\nareas when growing a window. Setting\nthis value to the anticipated content background color can help improve user experience.\nDefault is white.",
 					"type": "string"
+				},
+				"backgroundThrottling": {
+					"type": "boolean"
 				},
 				"closeOnLastViewRemoved": {
 					"type": "boolean"
@@ -3012,7 +3097,8 @@
 					"type": "number"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_4"
+					"$ref": "#/definitions/Partial_4",
+					"description": "API permissions for code running in the window."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -3078,6 +3164,10 @@
 					"description": "Specify a taskbar group for the window.\n_If omitted, defaults to app's uuid (`fin.Application.getCurrentSync().identity.uuid`)._",
 					"type": "string"
 				},
+				"throttling": {
+					"$ref": "#/definitions/WindowThrottling",
+					"description": "{@inheritDoc WindowThrottling}"
+				},
 				"url": {
 					"type": "string"
 				},
@@ -3110,7 +3200,7 @@
 			},
 			"type": "object"
 		},
-		"__type_34": {
+		"__type_35": {
 			"additionalProperties": false,
 			"properties": {
 				"contextGroups": {
@@ -3119,7 +3209,7 @@
 						"description": "Information for a Context Group. Contains metadata for displaying the group properly.",
 						"properties": {
 							"displayMetadata": {
-								"$ref": "#/definitions/DisplayMetadata_3",
+								"$ref": "#/definitions/DisplayMetadata",
 								"description": "Metadata for the Context Group. Contains the group's human-readable name, color, and an image, as defined by the Interop Broker."
 							},
 							"id": {
@@ -3138,7 +3228,7 @@
 			},
 			"type": "object"
 		},
-		"__type_35": {
+		"__type_36": {
 			"additionalProperties": false,
 			"description": "The display data for a context group.",
 			"properties": {
@@ -3157,7 +3247,7 @@
 			},
 			"type": "object"
 		},
-		"__type_36": {
+		"__type_37": {
 			"additionalProperties": false,
 			"properties": {
 				"afterAction": {
@@ -3186,9 +3276,13 @@
 			"required": ["afterAction", "beforeAction"],
 			"type": "object"
 		},
-		"__type_37": {
+		"__type_38": {
 			"additionalProperties": false,
 			"properties": {
+				"default": {
+					"$ref": "#/definitions/PerDomainSettings",
+					"description": "Default values for settings in {@link DomainSettingsRule}."
+				},
 				"rules": {
 					"description": "{@inheritDoc DomainSettingsRule}",
 					"items": {
@@ -3201,23 +3295,16 @@
 								},
 								"type": "array"
 							},
+							"matchOptions": {
+								"$ref": "#/definitions/RuleMatchOptions",
+								"description": "Options to use when comparing URIs to the `match` patterns."
+							},
 							"options": {
-								"additionalProperties": false,
-								"description": "Settings applied when a webcontents has been navigated to a matched domain.",
-								"properties": {
-									"api": {
-										"$ref": "#/definitions/DomainApiSettings",
-										"description": "{@inheritDoc ApiInjection}"
-									},
-									"downloadSettings": {
-										"$ref": "#/definitions/FileDownloadSettings",
-										"description": "{@inheritDoc FileDownloadSettings}"
-									}
-								},
-								"type": "object"
+								"$ref": "#/definitions/PerDomainSettings",
+								"description": "Settings applied when a webcontents has been navigated to a matched domain."
 							}
 						},
-						"required": ["match", "options"],
+						"required": ["options"],
 						"type": "object"
 					},
 					"type": "array"
@@ -3226,7 +3313,37 @@
 			"required": ["rules"],
 			"type": "object"
 		},
-		"__type_38": {
+		"__type_39": {
+			"additionalProperties": false,
+			"properties": {
+				"api": {
+					"$ref": "#/definitions/DomainApiSettings",
+					"description": "{@inheritDoc ApiInjection}"
+				},
+				"content": {
+					"$ref": "#/definitions/ContentPermission",
+					"description": "Whether DOM content can be loaded (by navigation or redirect)."
+				},
+				"downloadSettings": {
+					"$ref": "#/definitions/FileDownloadSettings",
+					"description": "{@inheritDoc FileDownloadSettings}"
+				}
+			},
+			"type": "object"
+		},
+		"__type_4": {
+			"additionalProperties": false,
+			"properties": {
+				"height": {
+					"type": "number"
+				},
+				"width": {
+					"type": "number"
+				}
+			},
+			"type": "object"
+		},
+		"__type_40": {
 			"additionalProperties": false,
 			"description": "Domain-conditional rules for file downloads.",
 			"properties": {
@@ -3256,25 +3373,50 @@
 			"required": ["rules"],
 			"type": "object"
 		},
-		"__type_39": {
+		"__type_41": {
 			"additionalProperties": false,
 			"properties": {
 				"fin": {
 					"$ref": "#/definitions/InjectionType",
 					"description": "Injection setting for the `fin` API for contexts on a matched domain.\n\n* 'none': The `fin` API will be not available.\n* 'global': The entire `fin` API will be available."
+				},
+				"permissions": {
+					"$ref": "#/definitions/Permissions_2",
+					"description": "API permissions for domains matched to the current {@link DomainSettingsRule}."
 				}
 			},
-			"required": ["fin"],
 			"type": "object"
 		},
-		"__type_4": {
+		"__type_42": {
 			"additionalProperties": false,
 			"properties": {
-				"height": {
-					"type": "number"
+				"Application": {
+					"$ref": "#/definitions/Partial_5"
 				},
-				"width": {
-					"type": "number"
+				"System": {
+					"$ref": "#/definitions/Partial_6"
+				},
+				"devices": {
+					"items": {
+						"additionalProperties": false,
+						"properties": {
+							"productId": {
+								"type": ["string", "number"]
+							},
+							"vendorId": {
+								"type": ["string", "number"]
+							}
+						},
+						"required": ["productId", "vendorId"],
+						"type": "object"
+					},
+					"type": "array"
+				},
+				"webAPIs": {
+					"items": {
+						"$ref": "#/definitions/WebPermission"
+					},
+					"type": "array"
 				}
 			},
 			"type": "object"

--- a/how-to/workspace-platform-starter/public/schemas/platform-apps.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/platform-apps.schema.json
@@ -146,7 +146,7 @@
 			"type": "array"
 		},
 		"AutoResizeOptions": {
-			"$ref": "#/definitions/__type_25"
+			"$ref": "#/definitions/__type_26"
 		},
 		"AutoplayPolicyOptions": {
 			"description": "Autoplay policy to apply to content in the window, can be\n`no-user-gesture-required`, `user-gesture-required`,\n`document-user-activation-required`. Defaults to `no-user-gesture-required`.",
@@ -177,7 +177,7 @@
 			"type": "object"
 		},
 		"Bounds": {
-			"$ref": "#/definitions/__type_24"
+			"$ref": "#/definitions/__type_25"
 		},
 		"BrowserContentCreationRule": {
 			"additionalProperties": false,
@@ -203,7 +203,7 @@
 			"type": "object"
 		},
 		"CertificationInfo": {
-			"$ref": "#/definitions/__type_35"
+			"$ref": "#/definitions/__type_36"
 		},
 		"ContentCreationOptions": {
 			"$ref": "#/definitions/__type_3"
@@ -236,7 +236,7 @@
 			"$ref": "#/definitions/__type_13"
 		},
 		"ContextGroupStates": {
-			"$ref": "#/definitions/__type_32"
+			"$ref": "#/definitions/__type_33"
 		},
 		"ContextMenuOptions": {
 			"$ref": "#/definitions/__type_7"
@@ -289,10 +289,10 @@
 			"type": "object"
 		},
 		"DipScaleRects": {
-			"$ref": "#/definitions/__type_29"
+			"$ref": "#/definitions/__type_30"
 		},
 		"DownloadShelfOptions": {
-			"$ref": "#/definitions/__type_15"
+			"$ref": "#/definitions/__type_16"
 		},
 		"HostLaunchOptions": {
 			"additionalProperties": false,
@@ -365,7 +365,7 @@
 			"$ref": "#/definitions/__type_10"
 		},
 		"LaunchExternalProcessListener": {
-			"$ref": "#/definitions/__type_34"
+			"$ref": "#/definitions/__type_35"
 		},
 		"LaunchPreference": {
 			"additionalProperties": false,
@@ -410,13 +410,13 @@
 			]
 		},
 		"LayoutSnapshot": {
-			"$ref": "#/definitions/__type_16"
+			"$ref": "#/definitions/__type_17"
 		},
 		"MonitorDetails": {
-			"$ref": "#/definitions/__type_31"
+			"$ref": "#/definitions/__type_32"
 		},
 		"MonitorInfo": {
-			"$ref": "#/definitions/__type_27"
+			"$ref": "#/definitions/__type_28"
 		},
 		"NativeLaunchOptions": {
 			"additionalProperties": false,
@@ -499,19 +499,19 @@
 			"$ref": "#/definitions/__type_4"
 		},
 		"Partial_10": {
-			"$ref": "#/definitions/__type_33"
+			"$ref": "#/definitions/__type_34"
 		},
 		"Partial_11": {
-			"$ref": "#/definitions/__type_36"
-		},
-		"Partial_12": {
 			"$ref": "#/definitions/__type_37"
 		},
-		"Partial_13": {
+		"Partial_12": {
 			"$ref": "#/definitions/__type_38"
 		},
-		"Partial_14": {
+		"Partial_13": {
 			"$ref": "#/definitions/__type_39"
+		},
+		"Partial_14": {
+			"$ref": "#/definitions/__type_40"
 		},
 		"Partial_2": {
 			"$ref": "#/definitions/__type_8"
@@ -520,22 +520,22 @@
 			"$ref": "#/definitions/__type_12"
 		},
 		"Partial_4": {
-			"$ref": "#/definitions/__type_14"
+			"$ref": "#/definitions/__type_15"
 		},
 		"Partial_5": {
-			"$ref": "#/definitions/__type_18"
-		},
-		"Partial_6": {
 			"$ref": "#/definitions/__type_19"
 		},
-		"Partial_7": {
+		"Partial_6": {
 			"$ref": "#/definitions/__type_20"
 		},
+		"Partial_7": {
+			"$ref": "#/definitions/__type_21"
+		},
 		"Partial_8": {
-			"$ref": "#/definitions/__type_23"
+			"$ref": "#/definitions/__type_24"
 		},
 		"Partial_9": {
-			"$ref": "#/definitions/__type_26"
+			"$ref": "#/definitions/__type_27"
 		},
 		"PlatformApp": {
 			"additionalProperties": false,
@@ -676,7 +676,7 @@
 			"description": "Application interop."
 		},
 		"Point": {
-			"$ref": "#/definitions/__type_28"
+			"$ref": "#/definitions/__type_29"
 		},
 		"PrebuiltContextMenuItem": {
 			"description": "Context menu item with an implementation provided by OpenFin.",
@@ -707,13 +707,16 @@
 			"$ref": "#/definitions/__type_5"
 		},
 		"Record": {
-			"$ref": "#/definitions/__type_17"
+			"$ref": "#/definitions/__type_18"
 		},
 		"RectangleByEdgePositions": {
-			"$ref": "#/definitions/__type_30"
+			"$ref": "#/definitions/__type_31"
 		},
 		"ResizeRegion": {
 			"$ref": "#/definitions/__type_9"
+		},
+		"RuleMatchOptions": {
+			"$ref": "#/definitions/__type_14"
 		},
 		"ShowViewOnWindowResizeOptions": {
 			"additionalProperties": false,
@@ -872,11 +875,16 @@
 			"required": ["name"],
 			"type": "object"
 		},
+		"ViewThrottling": {
+			"description": "View throttling state.\n\n* `enabled`: Both background throttling and scheduler throttling are true. It's fully throttled.\n* `scheduler-disabled`: background throttling is true, but scheduler throttling is disabled.",
+			"enum": ["enabled", "scheduler-disabled"],
+			"type": "string"
+		},
 		"ViewVisibilityOption": {
-			"$ref": "#/definitions/__type_22"
+			"$ref": "#/definitions/__type_23"
 		},
 		"ViewVisibilityOptions": {
-			"$ref": "#/definitions/__type_21"
+			"$ref": "#/definitions/__type_22"
 		},
 		"WaitForWindowClassStrategy": {
 			"additionalProperties": false,
@@ -1051,6 +1059,11 @@
 			"enum": ["maximized", "minimized", "normal"],
 			"type": "string"
 		},
+		"WindowThrottling": {
+			"description": "Window throttling state.\n\n* `enabled`: Both background throttling and scheduler throttling are true. It's fully throttled.\n* `scheduler-disabled`: The background throttling is true, but scheduler throttling is disabled.\n* `disabled`: The background throttling is false. The throttling is fully disabled.",
+			"enum": ["disabled", "enabled", "scheduler-disabled"],
+			"type": "string"
+		},
 		"WorkspacePlatformOptions": {
 			"$ref": "#/definitions/__type_11"
 		},
@@ -1199,7 +1212,8 @@
 					"type": "string"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_5"
+					"$ref": "#/definitions/Partial_5",
+					"description": "API permissions for code running in the view."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -1235,6 +1249,10 @@
 				"target": {
 					"$ref": "#/definitions/Identity_5",
 					"description": "The identity of the window this view should be attached to."
+				},
+				"throttling": {
+					"$ref": "#/definitions/ViewThrottling",
+					"description": "{@inheritDoc ViewThrottling}"
 				},
 				"url": {
 					"type": "string"
@@ -1338,6 +1356,10 @@
 					},
 					"type": "array"
 				},
+				"matchOptions": {
+					"$ref": "#/definitions/RuleMatchOptions",
+					"description": "Options to use when comparing URIs to the `allowlist` and `denylist` patterns."
+				},
 				"whitelist": {
 					"items": {
 						"type": "string"
@@ -1348,6 +1370,17 @@
 			"type": "object"
 		},
 		"__type_14": {
+			"additionalProperties": false,
+			"description": "Controls the behavior of the navigation URI pattern matching algorithm.",
+			"properties": {
+				"matchAllSchemes": {
+					"description": "Matches all schemes rather than just http and https when a wild card is specified. For example, `'*://*.site.com'` will\nonly match urls which begin with `'http:'` or `'https:'` unless this setting is `true`.",
+					"type": "boolean"
+				}
+			},
+			"type": "object"
+		},
+		"__type_15": {
 			"additionalProperties": false,
 			"properties": {
 				"allowlist": {
@@ -1370,6 +1403,10 @@
 					},
 					"type": "array"
 				},
+				"matchOptions": {
+					"$ref": "#/definitions/RuleMatchOptions",
+					"description": "Options to use when comparing URIs to the `allowlist` and `denylist` patterns."
+				},
 				"whitelist": {
 					"items": {
 						"type": "string"
@@ -1379,7 +1416,7 @@
 			},
 			"type": "object"
 		},
-		"__type_15": {
+		"__type_16": {
 			"additionalProperties": false,
 			"properties": {
 				"border": {
@@ -1405,7 +1442,7 @@
 			"required": ["enabled"],
 			"type": "object"
 		},
-		"__type_16": {
+		"__type_17": {
 			"additionalProperties": false,
 			"properties": {
 				"layouts": {
@@ -1415,11 +1452,11 @@
 			"required": ["layouts"],
 			"type": "object"
 		},
-		"__type_17": {
+		"__type_18": {
 			"additionalProperties": false,
 			"type": "object"
 		},
-		"__type_18": {
+		"__type_19": {
 			"additionalProperties": false,
 			"properties": {
 				"Application": {
@@ -1453,18 +1490,6 @@
 			},
 			"type": "object"
 		},
-		"__type_19": {
-			"additionalProperties": false,
-			"properties": {
-				"getFileDownloadLocation": {
-					"type": "boolean"
-				},
-				"setFileDownloadLocation": {
-					"type": "boolean"
-				}
-			},
-			"type": "object"
-		},
 		"__type_2": {
 			"additionalProperties": false,
 			"description": "Unique identifier for a window, view or iframe.",
@@ -1482,6 +1507,18 @@
 			"type": "object"
 		},
 		"__type_20": {
+			"additionalProperties": false,
+			"properties": {
+				"getFileDownloadLocation": {
+					"type": "boolean"
+				},
+				"setFileDownloadLocation": {
+					"type": "boolean"
+				}
+			},
+			"type": "object"
+		},
+		"__type_21": {
 			"additionalProperties": false,
 			"properties": {
 				"getAllExternalWindows": {
@@ -1688,7 +1725,7 @@
 			},
 			"type": "object"
 		},
-		"__type_21": {
+		"__type_22": {
 			"additionalProperties": false,
 			"description": "_Platform Windows Only_. Controls behavior for showing views when they are being resized by the user.",
 			"properties": {
@@ -1707,7 +1744,7 @@
 			},
 			"type": "object"
 		},
-		"__type_22": {
+		"__type_23": {
 			"additionalProperties": false,
 			"description": "Configuration for view visibility settings",
 			"properties": {
@@ -1717,7 +1754,7 @@
 			},
 			"type": "object"
 		},
-		"__type_23": {
+		"__type_24": {
 			"additionalProperties": false,
 			"properties": {
 				"customContext": {
@@ -1735,7 +1772,7 @@
 			},
 			"type": "object"
 		},
-		"__type_24": {
+		"__type_25": {
 			"additionalProperties": false,
 			"properties": {
 				"height": {
@@ -1754,7 +1791,7 @@
 			"required": ["height", "left", "top", "width"],
 			"type": "object"
 		},
-		"__type_25": {
+		"__type_26": {
 			"additionalProperties": false,
 			"properties": {
 				"height": {
@@ -1776,7 +1813,7 @@
 			},
 			"type": "object"
 		},
-		"__type_26": {
+		"__type_27": {
 			"additionalProperties": false,
 			"properties": {
 				"interopSnapshotDetails": {
@@ -1815,7 +1852,7 @@
 			},
 			"type": "object"
 		},
-		"__type_27": {
+		"__type_28": {
 			"additionalProperties": false,
 			"properties": {
 				"deviceScaleFactor": {
@@ -1906,7 +1943,7 @@
 			],
 			"type": "object"
 		},
-		"__type_28": {
+		"__type_29": {
 			"additionalProperties": false,
 			"properties": {
 				"x": {
@@ -1919,19 +1956,6 @@
 				}
 			},
 			"required": ["x", "y"],
-			"type": "object"
-		},
-		"__type_29": {
-			"additionalProperties": false,
-			"properties": {
-				"dipRect": {
-					"$ref": "#/definitions/RectangleByEdgePositions"
-				},
-				"scaledRect": {
-					"$ref": "#/definitions/RectangleByEdgePositions"
-				}
-			},
-			"required": ["dipRect", "scaledRect"],
 			"type": "object"
 		},
 		"__type_3": {
@@ -1952,6 +1976,19 @@
 		"__type_30": {
 			"additionalProperties": false,
 			"properties": {
+				"dipRect": {
+					"$ref": "#/definitions/RectangleByEdgePositions"
+				},
+				"scaledRect": {
+					"$ref": "#/definitions/RectangleByEdgePositions"
+				}
+			},
+			"required": ["dipRect", "scaledRect"],
+			"type": "object"
+		},
+		"__type_31": {
+			"additionalProperties": false,
+			"properties": {
 				"bottom": {
 					"type": "number"
 				},
@@ -1968,7 +2005,7 @@
 			"required": ["bottom", "left", "right", "top"],
 			"type": "object"
 		},
-		"__type_31": {
+		"__type_32": {
 			"additionalProperties": false,
 			"properties": {
 				"available": {
@@ -2020,7 +2057,7 @@
 			],
 			"type": "object"
 		},
-		"__type_32": {
+		"__type_33": {
 			"additionalProperties": {
 				"additionalProperties": {
 					"additionalProperties": false,
@@ -2049,7 +2086,7 @@
 			},
 			"type": "object"
 		},
-		"__type_33": {
+		"__type_34": {
 			"additionalProperties": false,
 			"properties": {
 				"alias": {
@@ -2086,11 +2123,11 @@
 			},
 			"type": "object"
 		},
-		"__type_34": {
+		"__type_35": {
 			"additionalProperties": false,
 			"type": "object"
 		},
-		"__type_35": {
+		"__type_36": {
 			"additionalProperties": false,
 			"properties": {
 				"publickey": {
@@ -2111,7 +2148,7 @@
 			},
 			"type": "object"
 		},
-		"__type_36": {
+		"__type_37": {
 			"additionalProperties": false,
 			"properties": {
 				"alias": {
@@ -2141,7 +2178,7 @@
 			},
 			"type": "object"
 		},
-		"__type_37": {
+		"__type_38": {
 			"additionalProperties": false,
 			"properties": {
 				"height": {
@@ -2155,21 +2192,6 @@
 				},
 				"width": {
 					"type": "number"
-				}
-			},
-			"type": "object"
-		},
-		"__type_38": {
-			"additionalProperties": false,
-			"properties": {
-				"customData": {
-					"description": "A field that the user can attach serializable data to be ferried around with the window options.\n_When omitted, _inherits_ from the parent application._"
-				},
-				"interop": {
-					"$ref": "#/definitions/InteropConfig"
-				},
-				"url": {
-					"type": "string"
 				}
 			},
 			"type": "object"
@@ -2225,6 +2247,9 @@
 				"backgroundColor": {
 					"description": "The window’s _backfill_ color as a hexadecimal value. Not to be confused with the content background color\n(`document.body.style.backgroundColor`),\nthis color briefly fills a window’s (a) content area before its content is loaded as well as (b) newly exposed\nareas when growing a window. Setting\nthis value to the anticipated content background color can help improve user experience.\nDefault is white.",
 					"type": "string"
+				},
+				"backgroundThrottling": {
+					"type": "boolean"
 				},
 				"closeOnLastViewRemoved": {
 					"type": "boolean"
@@ -2395,7 +2420,8 @@
 					"type": "number"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_5"
+					"$ref": "#/definitions/Partial_5",
+					"description": "API permissions for code running in the window."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -2457,6 +2483,10 @@
 					"description": "Specify a taskbar group for the window.\n_If omitted, defaults to app's uuid (`fin.Application.getCurrentSync().identity.uuid`)._",
 					"type": "string"
 				},
+				"throttling": {
+					"$ref": "#/definitions/WindowThrottling",
+					"description": "{@inheritDoc WindowThrottling}"
+				},
 				"url": {
 					"type": "string"
 				},
@@ -2485,6 +2515,21 @@
 				},
 				"y": {
 					"type": "number"
+				}
+			},
+			"type": "object"
+		},
+		"__type_40": {
+			"additionalProperties": false,
+			"properties": {
+				"customData": {
+					"description": "A field that the user can attach serializable data to be ferried around with the window options.\n_When omitted, _inherits_ from the parent application._"
+				},
+				"interop": {
+					"$ref": "#/definitions/InteropConfig"
+				},
+				"url": {
+					"type": "string"
 				}
 			},
 			"type": "object"

--- a/how-to/workspace-platform-starter/public/schemas/settings.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/settings.schema.json
@@ -53,7 +53,7 @@
             "$ref": "#/definitions/__type_3"
         },
         "AppAssetInfo": {
-            "$ref": "#/definitions/__type_56"
+            "$ref": "#/definitions/__type_57"
         },
         "AppEndpointOptions": {
             "anyOf": [
@@ -359,7 +359,7 @@
             "type": "object"
         },
         "AutoResizeOptions": {
-            "$ref": "#/definitions/__type_28"
+            "$ref": "#/definitions/__type_29"
         },
         "AutoplayPolicyOptions": {
             "description": "Autoplay policy to apply to content in the window, can be\n`no-user-gesture-required`, `user-gesture-required`,\n`document-user-activation-required`. Defaults to `no-user-gesture-required`.",
@@ -441,7 +441,7 @@
             "type": "object"
         },
         "Bounds": {
-            "$ref": "#/definitions/__type_27"
+            "$ref": "#/definitions/__type_28"
         },
         "BrokerConnection": {
             "additionalProperties": false,
@@ -771,7 +771,7 @@
             "type": "object"
         },
         "CertificationInfo": {
-            "$ref": "#/definitions/__type_49"
+            "$ref": "#/definitions/__type_50"
         },
         "ConditionsProviderOptions": {
             "$ref": "#/definitions/ModuleList_3",
@@ -889,13 +889,24 @@
             "$ref": "#/definitions/__type_15"
         },
         "ContextGroupStates": {
-            "$ref": "#/definitions/__type_46"
+            "$ref": "#/definitions/__type_47"
         },
         "ContextMenuOptions": {
             "$ref": "#/definitions/__type_9"
         },
         "ContextMenuSettings": {
             "$ref": "#/definitions/__type_8"
+        },
+        "ContextOptions": {
+            "additionalProperties": false,
+            "description": "Option for the Context Handling.",
+            "properties": {
+                "includeOriginator": {
+                    "description": "Should the broker send context messages back to the sender? Default is true.",
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
         },
         "CustomActionSpecifier": {
             "additionalProperties": false,
@@ -1223,7 +1234,7 @@
         },
         "Data": {},
         "DeepPartial": {
-            "$ref": "#/definitions/__type_37"
+            "$ref": "#/definitions/__type_38"
         },
         "DelayStrategy": {
             "additionalProperties": false,
@@ -1280,7 +1291,7 @@
             "type": "object"
         },
         "DipScaleRects": {
-            "$ref": "#/definitions/__type_43"
+            "$ref": "#/definitions/__type_44"
         },
         "DockButtonAction": {
             "additionalProperties": false,
@@ -1558,7 +1569,7 @@
             "type": "object"
         },
         "DownloadShelfOptions": {
-            "$ref": "#/definitions/__type_17"
+            "$ref": "#/definitions/__type_18"
         },
         "EndpointClientDefaultOptions": {
             "additionalProperties": false,
@@ -1971,7 +1982,7 @@
             "$ref": "#/definitions/__type_4"
         },
         "Identity_5_1": {
-            "$ref": "#/definitions/__type_38"
+            "$ref": "#/definitions/__type_39"
         },
         "Image": {
             "additionalProperties": false,
@@ -2149,7 +2160,7 @@
             "$ref": "#/definitions/__type_12"
         },
         "LaunchExternalProcessListener": {
-            "$ref": "#/definitions/__type_48"
+            "$ref": "#/definitions/__type_49"
         },
         "LaunchPreference": {
             "additionalProperties": false,
@@ -2244,14 +2255,14 @@
             "type": "object"
         },
         "LayoutSnapshot": {
-            "$ref": "#/definitions/__type_18"
+            "$ref": "#/definitions/__type_19"
         },
         "LifecycleProviderOptions": {
             "$ref": "#/definitions/ModuleList_4",
             "description": "List of modules."
         },
         "LockUnlockPageConfig": {
-            "$ref": "#/definitions/__type_31"
+            "$ref": "#/definitions/__type_32"
         },
         "LoggerProviderOptions": {
             "$ref": "#/definitions/ModuleList_1",
@@ -3183,10 +3194,10 @@
             "type": "object"
         },
         "MonitorDetails": {
-            "$ref": "#/definitions/__type_45"
+            "$ref": "#/definitions/__type_46"
         },
         "MonitorInfo": {
-            "$ref": "#/definitions/__type_41"
+            "$ref": "#/definitions/__type_42"
         },
         "NativeLaunchOptions": {
             "additionalProperties": false,
@@ -3337,7 +3348,7 @@
             "type": "object"
         },
         "NotificationIndicatorColorsWithScheme": {
-            "$ref": "#/definitions/__type_55"
+            "$ref": "#/definitions/__type_56"
         },
         "NotificationProviderOptions": {
             "additionalProperties": false,
@@ -3372,23 +3383,23 @@
             "type": "object"
         },
         "NotificationsCustomManifestOptions": {
-            "$ref": "#/definitions/__type_39"
+            "$ref": "#/definitions/__type_40"
         },
         "O": {},
         "Omit": {
-            "$ref": "#/definitions/__type_29"
+            "$ref": "#/definitions/__type_30"
         },
         "Omit_1": {
-            "$ref": "#/definitions/__type_33"
-        },
-        "Omit_2": {
             "$ref": "#/definitions/__type_34"
         },
-        "Omit_3": {
+        "Omit_2": {
             "$ref": "#/definitions/__type_35"
         },
-        "Omit_4": {
+        "Omit_3": {
             "$ref": "#/definitions/__type_36"
+        },
+        "Omit_4": {
+            "$ref": "#/definitions/__type_37"
         },
         "OpenExternalPermission": {
             "additionalProperties": false,
@@ -3557,6 +3568,9 @@
                         "preventDragOut": {
                             "type": "boolean"
                         },
+                        "preventSplitterResize": {
+                            "type": "boolean"
+                        },
                         "reorderEnabled": {
                             "type": "boolean"
                         },
@@ -3600,9 +3614,11 @@
                 "Rename",
                 "Save",
                 "Save As",
+                "Delete Page",
                 "SaveWorkspaceAs",
                 "Refresh",
                 "Close others",
+                "Delete",
                 "Custom"
             ],
             "type": "string"
@@ -3681,25 +3697,25 @@
             "$ref": "#/definitions/__type_2"
         },
         "Partial_10": {
-            "$ref": "#/definitions/__type_26"
+            "$ref": "#/definitions/__type_27"
         },
         "Partial_11": {
-            "$ref": "#/definitions/__type_40"
+            "$ref": "#/definitions/__type_41"
         },
         "Partial_12": {
-            "$ref": "#/definitions/__type_47"
+            "$ref": "#/definitions/__type_48"
         },
         "Partial_13": {
-            "$ref": "#/definitions/__type_50"
-        },
-        "Partial_14": {
             "$ref": "#/definitions/__type_51"
         },
-        "Partial_15": {
+        "Partial_14": {
             "$ref": "#/definitions/__type_52"
         },
-        "Partial_16": {
+        "Partial_15": {
             "$ref": "#/definitions/__type_53"
+        },
+        "Partial_16": {
+            "$ref": "#/definitions/__type_54"
         },
         "Partial_2": {
             "$ref": "#/definitions/__type_6"
@@ -3711,22 +3727,22 @@
             "$ref": "#/definitions/__type_14"
         },
         "Partial_5": {
-            "$ref": "#/definitions/__type_16"
+            "$ref": "#/definitions/__type_17"
         },
         "Partial_6": {
-            "$ref": "#/definitions/__type_20"
-        },
-        "Partial_7": {
             "$ref": "#/definitions/__type_21"
         },
-        "Partial_8": {
+        "Partial_7": {
             "$ref": "#/definitions/__type_22"
         },
+        "Partial_8": {
+            "$ref": "#/definitions/__type_23"
+        },
         "Partial_9": {
-            "$ref": "#/definitions/__type_25"
+            "$ref": "#/definitions/__type_26"
         },
         "Pick": {
-            "$ref": "#/definitions/__type_32"
+            "$ref": "#/definitions/__type_33"
         },
         "PlatformApp": {
             "additionalProperties": false,
@@ -3992,6 +4008,10 @@
             "additionalProperties": false,
             "description": "Options for the platform interop broker.",
             "properties": {
+                "contextOptions": {
+                    "$ref": "#/definitions/ContextOptions",
+                    "description": "Options for when fdc3.broadcast or fin.me.interop.setContext is called."
+                },
                 "intentOptions": {
                     "$ref": "#/definitions/IntentOptions",
                     "description": "Options related to the way this platform supports intents"
@@ -4062,7 +4082,7 @@
             "type": "object"
         },
         "Point": {
-            "$ref": "#/definitions/__type_42"
+            "$ref": "#/definitions/__type_43"
         },
         "PopupMenuStyles": {
             "description": "The styles that can be used to display the popup menus.",
@@ -4138,16 +4158,19 @@
             "$ref": "#/definitions/__type_7"
         },
         "Record": {
-            "$ref": "#/definitions/__type_19"
+            "$ref": "#/definitions/__type_20"
         },
         "Record_1": {
-            "$ref": "#/definitions/__type_54"
+            "$ref": "#/definitions/__type_55"
         },
         "RectangleByEdgePositions": {
-            "$ref": "#/definitions/__type_44"
+            "$ref": "#/definitions/__type_45"
         },
         "ResizeRegion": {
             "$ref": "#/definitions/__type_11"
+        },
+        "RuleMatchOptions": {
+            "$ref": "#/definitions/__type_16"
         },
         "ScoreOrder": {
             "description": "The order to sort scored search results in.",
@@ -4197,7 +4220,7 @@
             "type": "object"
         },
         "ShowHideTabsConfig": {
-            "$ref": "#/definitions/__type_30"
+            "$ref": "#/definitions/__type_31"
         },
         "ShowViewOnWindowResizeOptions": {
             "additionalProperties": false,
@@ -4996,11 +5019,19 @@
             ],
             "type": "string"
         },
+        "ViewThrottling": {
+            "description": "View throttling state.\n\n* `enabled`: Both background throttling and scheduler throttling are true. It's fully throttled.\n* `scheduler-disabled`: background throttling is true, but scheduler throttling is disabled.",
+            "enum": [
+                "enabled",
+                "scheduler-disabled"
+            ],
+            "type": "string"
+        },
         "ViewVisibilityOption": {
-            "$ref": "#/definitions/__type_24"
+            "$ref": "#/definitions/__type_25"
         },
         "ViewVisibilityOptions": {
-            "$ref": "#/definitions/__type_23"
+            "$ref": "#/definitions/__type_24"
         },
         "WaitForWindowClassStrategy": {
             "additionalProperties": false,
@@ -5255,6 +5286,15 @@
             ],
             "type": "object"
         },
+        "WindowThrottling": {
+            "description": "Window throttling state.\n\n* `enabled`: Both background throttling and scheduler throttling are true. It's fully throttled.\n* `scheduler-disabled`: The background throttling is true, but scheduler throttling is disabled.\n* `disabled`: The background throttling is false. The throttling is fully disabled.",
+            "enum": [
+                "disabled",
+                "enabled",
+                "scheduler-disabled"
+            ],
+            "type": "string"
+        },
         "WindowType": {
             "enum": [
                 "browser",
@@ -5336,6 +5376,9 @@
                 "backgroundColor": {
                     "description": "The window’s _backfill_ color as a hexadecimal value. Not to be confused with the content background color\n(`document.body.style.backgroundColor`),\nthis color briefly fills a window’s (a) content area before its content is loaded as well as (b) newly exposed\nareas when growing a window. Setting\nthis value to the anticipated content background color can help improve user experience.\nDefault is white.",
                     "type": "string"
+                },
+                "backgroundThrottling": {
+                    "type": "boolean"
                 },
                 "closeOnLastViewRemoved": {
                     "type": "boolean"
@@ -5511,7 +5554,8 @@
                     "type": "number"
                 },
                 "permissions": {
-                    "$ref": "#/definitions/Partial_6"
+                    "$ref": "#/definitions/Partial_6",
+                    "description": "API permissions for code running in the window."
                 },
                 "preloadScripts": {
                     "description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -5583,6 +5627,10 @@
                 "taskbarIconGroup": {
                     "description": "Specify a taskbar group for the window.\n_If omitted, defaults to app's uuid (`fin.Application.getCurrentSync().identity.uuid`)._",
                     "type": "string"
+                },
+                "throttling": {
+                    "$ref": "#/definitions/WindowThrottling",
+                    "description": "{@inheritDoc WindowThrottling}"
                 },
                 "updateStateIfExists": {
                     "type": "boolean"
@@ -5791,6 +5839,10 @@
                     },
                     "type": "array"
                 },
+                "matchOptions": {
+                    "$ref": "#/definitions/RuleMatchOptions",
+                    "description": "Options to use when comparing URIs to the `allowlist` and `denylist` patterns."
+                },
                 "whitelist": {
                     "items": {
                         "type": "string"
@@ -5801,6 +5853,17 @@
             "type": "object"
         },
         "__type_16": {
+            "additionalProperties": false,
+            "description": "Controls the behavior of the navigation URI pattern matching algorithm.",
+            "properties": {
+                "matchAllSchemes": {
+                    "description": "Matches all schemes rather than just http and https when a wild card is specified. For example, `'*://*.site.com'` will\nonly match urls which begin with `'http:'` or `'https:'` unless this setting is `true`.",
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "__type_17": {
             "additionalProperties": false,
             "properties": {
                 "allowlist": {
@@ -5823,6 +5886,10 @@
                     },
                     "type": "array"
                 },
+                "matchOptions": {
+                    "$ref": "#/definitions/RuleMatchOptions",
+                    "description": "Options to use when comparing URIs to the `allowlist` and `denylist` patterns."
+                },
                 "whitelist": {
                     "items": {
                         "type": "string"
@@ -5832,7 +5899,7 @@
             },
             "type": "object"
         },
-        "__type_17": {
+        "__type_18": {
             "additionalProperties": false,
             "properties": {
                 "border": {
@@ -5860,7 +5927,7 @@
             ],
             "type": "object"
         },
-        "__type_18": {
+        "__type_19": {
             "additionalProperties": false,
             "properties": {
                 "layouts": {
@@ -5870,10 +5937,6 @@
             "required": [
                 "layouts"
             ],
-            "type": "object"
-        },
-        "__type_19": {
-            "additionalProperties": false,
             "type": "object"
         },
         "__type_2": {
@@ -6032,7 +6095,8 @@
                     "type": "string"
                 },
                 "permissions": {
-                    "$ref": "#/definitions/Partial_6"
+                    "$ref": "#/definitions/Partial_6",
+                    "description": "API permissions for code running in the view."
                 },
                 "preloadScripts": {
                     "description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -6077,6 +6141,10 @@
                     "$ref": "#/definitions/Identity_5",
                     "description": "The identity of the window this view should be attached to."
                 },
+                "throttling": {
+                    "$ref": "#/definitions/ViewThrottling",
+                    "description": "{@inheritDoc ViewThrottling}"
+                },
                 "url": {
                     "type": "string"
                 },
@@ -6087,6 +6155,10 @@
             "type": "object"
         },
         "__type_20": {
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "__type_21": {
             "additionalProperties": false,
             "properties": {
                 "Application": {
@@ -6129,7 +6201,7 @@
             },
             "type": "object"
         },
-        "__type_21": {
+        "__type_22": {
             "additionalProperties": false,
             "properties": {
                 "getFileDownloadLocation": {
@@ -6141,7 +6213,7 @@
             },
             "type": "object"
         },
-        "__type_22": {
+        "__type_23": {
             "additionalProperties": false,
             "properties": {
                 "getAllExternalWindows": {
@@ -6383,7 +6455,7 @@
             },
             "type": "object"
         },
-        "__type_23": {
+        "__type_24": {
             "additionalProperties": false,
             "description": "_Platform Windows Only_. Controls behavior for showing views when they are being resized by the user.",
             "properties": {
@@ -6402,7 +6474,7 @@
             },
             "type": "object"
         },
-        "__type_24": {
+        "__type_25": {
             "additionalProperties": false,
             "description": "Configuration for view visibility settings",
             "properties": {
@@ -6412,7 +6484,7 @@
             },
             "type": "object"
         },
-        "__type_25": {
+        "__type_26": {
             "additionalProperties": false,
             "properties": {
                 "customContext": {
@@ -6430,7 +6502,7 @@
             },
             "type": "object"
         },
-        "__type_26": {
+        "__type_27": {
             "additionalProperties": false,
             "properties": {
                 "_internalWorkspaceData": {},
@@ -6586,7 +6658,8 @@
                     "type": "string"
                 },
                 "permissions": {
-                    "$ref": "#/definitions/Partial_6"
+                    "$ref": "#/definitions/Partial_6",
+                    "description": "API permissions for code running in the view."
                 },
                 "preloadScripts": {
                     "description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -6631,6 +6704,10 @@
                     "$ref": "#/definitions/Identity_5",
                     "description": "The identity of the window this view should be attached to."
                 },
+                "throttling": {
+                    "$ref": "#/definitions/ViewThrottling",
+                    "description": "{@inheritDoc ViewThrottling}"
+                },
                 "url": {
                     "type": "string"
                 },
@@ -6640,7 +6717,7 @@
             },
             "type": "object"
         },
-        "__type_27": {
+        "__type_28": {
             "additionalProperties": false,
             "properties": {
                 "height": {
@@ -6664,7 +6741,7 @@
             ],
             "type": "object"
         },
-        "__type_28": {
+        "__type_29": {
             "additionalProperties": false,
             "properties": {
                 "height": {
@@ -6686,7 +6763,36 @@
             },
             "type": "object"
         },
-        "__type_29": {
+        "__type_3": {
+            "additionalProperties": false,
+            "description": "Configurations for API injection.",
+            "properties": {
+                "fin": {
+                    "$ref": "#/definitions/InjectionType",
+                    "description": "Configure injection of the `fin` API in this context.\n\n* 'none': The `fin` API will be not available in this context.\n* 'global': The entire `fin` API will be available in this context."
+                },
+                "iframe": {
+                    "additionalProperties": false,
+                    "description": "Configure conditional injection of OpenFin API into iframes",
+                    "properties": {
+                        "crossOriginInjection": {
+                            "description": "Inject OpenFin API into cross-origin iframes",
+                            "type": "boolean"
+                        },
+                        "enableDeprecatedSharedName": {
+                            "type": "boolean"
+                        },
+                        "sameOriginInjection": {
+                            "description": "Inject OpenFin API into same-origin iframes",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "__type_30": {
             "additionalProperties": false,
             "properties": {
                 "_internalWorkspaceData": {},
@@ -6838,7 +6944,8 @@
                     "type": "string"
                 },
                 "permissions": {
-                    "$ref": "#/definitions/Partial_6"
+                    "$ref": "#/definitions/Partial_6",
+                    "description": "API permissions for code running in the view."
                 },
                 "preloadScripts": {
                     "description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -6879,6 +6986,10 @@
                     "description": "String tag that attempts to group like-tagged renderers together. Will only be used if pages are on the same origin.",
                     "type": "string"
                 },
+                "throttling": {
+                    "$ref": "#/definitions/ViewThrottling",
+                    "description": "{@inheritDoc ViewThrottling}"
+                },
                 "url": {
                     "type": "string"
                 },
@@ -6888,36 +6999,7 @@
             },
             "type": "object"
         },
-        "__type_3": {
-            "additionalProperties": false,
-            "description": "Configurations for API injection.",
-            "properties": {
-                "fin": {
-                    "$ref": "#/definitions/InjectionType",
-                    "description": "Configure injection of the `fin` API in this context.\n\n* 'none': The `fin` API will be not available in this context.\n* 'global': The entire `fin` API will be available in this context."
-                },
-                "iframe": {
-                    "additionalProperties": false,
-                    "description": "Configure conditional injection of OpenFin API into iframes",
-                    "properties": {
-                        "crossOriginInjection": {
-                            "description": "Inject OpenFin API into cross-origin iframes",
-                            "type": "boolean"
-                        },
-                        "enableDeprecatedSharedName": {
-                            "type": "boolean"
-                        },
-                        "sameOriginInjection": {
-                            "description": "Inject OpenFin API into same-origin iframes",
-                            "type": "boolean"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "__type_30": {
+        "__type_31": {
             "additionalProperties": false,
             "description": "Configuration Object for the show/hide tabs button within the browser toolbar",
             "properties": {
@@ -6961,7 +7043,7 @@
             ],
             "type": "object"
         },
-        "__type_31": {
+        "__type_32": {
             "additionalProperties": false,
             "description": "Configuration Object for the page lock/unlock button within the browser toolbar",
             "properties": {
@@ -6983,7 +7065,7 @@
             ],
             "type": "object"
         },
-        "__type_32": {
+        "__type_33": {
             "additionalProperties": false,
             "properties": {
                 "closeButton": {
@@ -7017,7 +7099,7 @@
             },
             "type": "object"
         },
-        "__type_33": {
+        "__type_34": {
             "additionalProperties": false,
             "properties": {
                 "conditions": {
@@ -7064,7 +7146,7 @@
             ],
             "type": "object"
         },
-        "__type_34": {
+        "__type_35": {
             "additionalProperties": false,
             "properties": {
                 "appId": {
@@ -7096,7 +7178,7 @@
             ],
             "type": "object"
         },
-        "__type_35": {
+        "__type_36": {
             "additionalProperties": false,
             "properties": {
                 "action": {
@@ -7141,7 +7223,7 @@
             ],
             "type": "object"
         },
-        "__type_36": {
+        "__type_37": {
             "additionalProperties": false,
             "properties": {
                 "conditions": {
@@ -7193,7 +7275,7 @@
             ],
             "type": "object"
         },
-        "__type_37": {
+        "__type_38": {
             "additionalProperties": false,
             "properties": {
                 "clientAPIVersion": {
@@ -7251,7 +7333,7 @@
             },
             "type": "object"
         },
-        "__type_38": {
+        "__type_39": {
             "additionalProperties": false,
             "properties": {
                 "name": {
@@ -7263,25 +7345,6 @@
                     "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "__type_39": {
-            "additionalProperties": false,
-            "description": "Options for using privately hosted notification service.",
-            "properties": {
-                "manifestUrl": {
-                    "description": "A custom manifest location to start the notification service from.\nThe UUID cannot be OpenFin hosted Notification Service UUID, 'notifications-service'.",
-                    "type": "string"
-                },
-                "manifestUuid": {
-                    "description": "The UUID of the provided custom notifications service manifest.\nThis value **MUST** match the UUID of the manifest provided in `manifestUrl`.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "manifestUrl",
-                "manifestUuid"
-            ],
             "type": "object"
         },
         "__type_4": {
@@ -7304,6 +7367,25 @@
             "type": "object"
         },
         "__type_40": {
+            "additionalProperties": false,
+            "description": "Options for using privately hosted notification service.",
+            "properties": {
+                "manifestUrl": {
+                    "description": "A custom manifest location to start the notification service from.\nThe UUID cannot be OpenFin hosted Notification Service UUID, 'notifications-service'.",
+                    "type": "string"
+                },
+                "manifestUuid": {
+                    "description": "The UUID of the provided custom notifications service manifest.\nThis value **MUST** match the UUID of the manifest provided in `manifestUrl`.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "manifestUrl",
+                "manifestUuid"
+            ],
+            "type": "object"
+        },
+        "__type_41": {
             "additionalProperties": false,
             "properties": {
                 "interopSnapshotDetails": {
@@ -7348,7 +7430,7 @@
             },
             "type": "object"
         },
-        "__type_41": {
+        "__type_42": {
             "additionalProperties": false,
             "properties": {
                 "deviceScaleFactor": {
@@ -7445,7 +7527,7 @@
             ],
             "type": "object"
         },
-        "__type_42": {
+        "__type_43": {
             "additionalProperties": false,
             "properties": {
                 "x": {
@@ -7463,7 +7545,7 @@
             ],
             "type": "object"
         },
-        "__type_43": {
+        "__type_44": {
             "additionalProperties": false,
             "properties": {
                 "dipRect": {
@@ -7479,7 +7561,7 @@
             ],
             "type": "object"
         },
-        "__type_44": {
+        "__type_45": {
             "additionalProperties": false,
             "properties": {
                 "bottom": {
@@ -7503,7 +7585,7 @@
             ],
             "type": "object"
         },
-        "__type_45": {
+        "__type_46": {
             "additionalProperties": false,
             "properties": {
                 "available": {
@@ -7561,7 +7643,7 @@
             ],
             "type": "object"
         },
-        "__type_46": {
+        "__type_47": {
             "additionalProperties": {
                 "additionalProperties": {
                     "additionalProperties": false,
@@ -7592,7 +7674,7 @@
             },
             "type": "object"
         },
-        "__type_47": {
+        "__type_48": {
             "additionalProperties": false,
             "properties": {
                 "alias": {
@@ -7629,29 +7711,8 @@
             },
             "type": "object"
         },
-        "__type_48": {
-            "additionalProperties": false,
-            "type": "object"
-        },
         "__type_49": {
             "additionalProperties": false,
-            "properties": {
-                "publickey": {
-                    "type": "string"
-                },
-                "serial": {
-                    "type": "string"
-                },
-                "subject": {
-                    "type": "string"
-                },
-                "thumbprint": {
-                    "type": "string"
-                },
-                "trusted": {
-                    "type": "boolean"
-                }
-            },
             "type": "object"
         },
         "__type_5": {
@@ -7672,6 +7733,27 @@
             "type": "object"
         },
         "__type_50": {
+            "additionalProperties": false,
+            "properties": {
+                "publickey": {
+                    "type": "string"
+                },
+                "serial": {
+                    "type": "string"
+                },
+                "subject": {
+                    "type": "string"
+                },
+                "thumbprint": {
+                    "type": "string"
+                },
+                "trusted": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "__type_51": {
             "additionalProperties": false,
             "properties": {
                 "alias": {
@@ -7701,7 +7783,7 @@
             },
             "type": "object"
         },
-        "__type_51": {
+        "__type_52": {
             "additionalProperties": false,
             "properties": {
                 "height": {
@@ -7715,21 +7797,6 @@
                 },
                 "width": {
                     "type": "number"
-                }
-            },
-            "type": "object"
-        },
-        "__type_52": {
-            "additionalProperties": false,
-            "properties": {
-                "customData": {
-                    "description": "A field that the user can attach serializable data to be ferried around with the window options.\n_When omitted, _inherits_ from the parent application._"
-                },
-                "interop": {
-                    "$ref": "#/definitions/InteropConfig"
-                },
-                "url": {
-                    "type": "string"
                 }
             },
             "type": "object"
@@ -7751,6 +7818,17 @@
         },
         "__type_54": {
             "additionalProperties": false,
+            "properties": {
+                "customData": {
+                    "description": "A field that the user can attach serializable data to be ferried around with the window options.\n_When omitted, _inherits_ from the parent application._"
+                },
+                "interop": {
+                    "$ref": "#/definitions/InteropConfig"
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "__type_55": {
@@ -7758,6 +7836,10 @@
             "type": "object"
         },
         "__type_56": {
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "__type_57": {
             "additionalProperties": false,
             "properties": {
                 "alias": {
@@ -7828,6 +7910,9 @@
                 "backgroundColor": {
                     "description": "The window’s _backfill_ color as a hexadecimal value. Not to be confused with the content background color\n(`document.body.style.backgroundColor`),\nthis color briefly fills a window’s (a) content area before its content is loaded as well as (b) newly exposed\nareas when growing a window. Setting\nthis value to the anticipated content background color can help improve user experience.\nDefault is white.",
                     "type": "string"
+                },
+                "backgroundThrottling": {
+                    "type": "boolean"
                 },
                 "closeOnLastViewRemoved": {
                     "type": "boolean"
@@ -8003,7 +8088,8 @@
                     "type": "number"
                 },
                 "permissions": {
-                    "$ref": "#/definitions/Partial_6"
+                    "$ref": "#/definitions/Partial_6",
+                    "description": "API permissions for code running in the window."
                 },
                 "preloadScripts": {
                     "description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -8072,6 +8158,10 @@
                 "taskbarIconGroup": {
                     "description": "Specify a taskbar group for the window.\n_If omitted, defaults to app's uuid (`fin.Application.getCurrentSync().identity.uuid`)._",
                     "type": "string"
+                },
+                "throttling": {
+                    "$ref": "#/definitions/WindowThrottling",
+                    "description": "{@inheritDoc WindowThrottling}"
                 },
                 "url": {
                     "type": "string"

--- a/how-to/workspace-platform-starter/public/schemas/snapshot.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/snapshot.schema.json
@@ -15,7 +15,7 @@
 			"type": "array"
 		},
 		"AutoResizeOptions": {
-			"$ref": "#/definitions/__type_25"
+			"$ref": "#/definitions/__type_26"
 		},
 		"AutoplayPolicyOptions": {
 			"description": "Autoplay policy to apply to content in the window, can be\n`no-user-gesture-required`, `user-gesture-required`,\n`document-user-activation-required`. Defaults to `no-user-gesture-required`.",
@@ -46,7 +46,7 @@
 			"type": "object"
 		},
 		"Bounds": {
-			"$ref": "#/definitions/__type_24"
+			"$ref": "#/definitions/__type_25"
 		},
 		"BrowserContentCreationRule": {
 			"additionalProperties": false,
@@ -102,7 +102,7 @@
 			"$ref": "#/definitions/__type_11"
 		},
 		"ContextGroupStates": {
-			"$ref": "#/definitions/__type_31"
+			"$ref": "#/definitions/__type_32"
 		},
 		"ContextMenuOptions": {
 			"$ref": "#/definitions/__type_2"
@@ -124,13 +124,13 @@
 			"type": "object"
 		},
 		"DipScaleRects": {
-			"$ref": "#/definitions/__type_28"
+			"$ref": "#/definitions/__type_29"
 		},
 		"DownloadShelfOptions": {
-			"$ref": "#/definitions/__type_13"
+			"$ref": "#/definitions/__type_14"
 		},
 		"Identity_5": {
-			"$ref": "#/definitions/__type_16"
+			"$ref": "#/definitions/__type_17"
 		},
 		"InjectionType": {
 			"description": "Injection setting for the `fin` API.\n\n* 'none': The `fin` API will be not available.\n* 'global': The entire `fin` API will be available.",
@@ -141,13 +141,13 @@
 			"$ref": "#/definitions/__type_5"
 		},
 		"LayoutSnapshot": {
-			"$ref": "#/definitions/__type_14"
+			"$ref": "#/definitions/__type_15"
 		},
 		"MonitorDetails": {
-			"$ref": "#/definitions/__type_30"
+			"$ref": "#/definitions/__type_31"
 		},
 		"MonitorInfo": {
-			"$ref": "#/definitions/__type_26"
+			"$ref": "#/definitions/__type_27"
 		},
 		"OpenExternalPermission": {
 			"additionalProperties": false,
@@ -178,25 +178,25 @@
 			"$ref": "#/definitions/__type_10"
 		},
 		"Partial_3": {
-			"$ref": "#/definitions/__type_12"
+			"$ref": "#/definitions/__type_13"
 		},
 		"Partial_4": {
-			"$ref": "#/definitions/__type_17"
-		},
-		"Partial_5": {
 			"$ref": "#/definitions/__type_18"
 		},
-		"Partial_6": {
+		"Partial_5": {
 			"$ref": "#/definitions/__type_19"
 		},
-		"Partial_7": {
-			"$ref": "#/definitions/__type_22"
+		"Partial_6": {
+			"$ref": "#/definitions/__type_20"
 		},
-		"Partial_8": {
+		"Partial_7": {
 			"$ref": "#/definitions/__type_23"
 		},
+		"Partial_8": {
+			"$ref": "#/definitions/__type_24"
+		},
 		"Point": {
-			"$ref": "#/definitions/__type_27"
+			"$ref": "#/definitions/__type_28"
 		},
 		"PrebuiltContextMenuItem": {
 			"description": "Context menu item with an implementation provided by OpenFin.",
@@ -222,13 +222,16 @@
 			"$ref": "#/definitions/__type"
 		},
 		"Record": {
-			"$ref": "#/definitions/__type_15"
+			"$ref": "#/definitions/__type_16"
 		},
 		"RectangleByEdgePositions": {
-			"$ref": "#/definitions/__type_29"
+			"$ref": "#/definitions/__type_30"
 		},
 		"ResizeRegion": {
 			"$ref": "#/definitions/__type_4"
+		},
+		"RuleMatchOptions": {
+			"$ref": "#/definitions/__type_12"
 		},
 		"ShowViewOnWindowResizeOptions": {
 			"additionalProperties": false,
@@ -285,11 +288,16 @@
 			"required": ["behavior", "match"],
 			"type": "object"
 		},
+		"ViewThrottling": {
+			"description": "View throttling state.\n\n* `enabled`: Both background throttling and scheduler throttling are true. It's fully throttled.\n* `scheduler-disabled`: background throttling is true, but scheduler throttling is disabled.",
+			"enum": ["enabled", "scheduler-disabled"],
+			"type": "string"
+		},
 		"ViewVisibilityOption": {
-			"$ref": "#/definitions/__type_21"
+			"$ref": "#/definitions/__type_22"
 		},
 		"ViewVisibilityOptions": {
-			"$ref": "#/definitions/__type_20"
+			"$ref": "#/definitions/__type_21"
 		},
 		"WebPermission": {
 			"anyOf": [
@@ -380,6 +388,9 @@
 				"backgroundColor": {
 					"description": "The window’s _backfill_ color as a hexadecimal value. Not to be confused with the content background color\n(`document.body.style.backgroundColor`),\nthis color briefly fills a window’s (a) content area before its content is loaded as well as (b) newly exposed\nareas when growing a window. Setting\nthis value to the anticipated content background color can help improve user experience.\nDefault is white.",
 					"type": "string"
+				},
+				"backgroundThrottling": {
+					"type": "boolean"
 				},
 				"closeOnLastViewRemoved": {
 					"type": "boolean"
@@ -549,7 +560,8 @@
 					"type": "number"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_4"
+					"$ref": "#/definitions/Partial_4",
+					"description": "API permissions for code running in the window."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -611,6 +623,10 @@
 					"description": "Specify a taskbar group for the window.\n_If omitted, defaults to app's uuid (`fin.Application.getCurrentSync().identity.uuid`)._",
 					"type": "string"
 				},
+				"throttling": {
+					"$ref": "#/definitions/WindowThrottling",
+					"description": "{@inheritDoc WindowThrottling}"
+				},
 				"url": {
 					"type": "string"
 				},
@@ -647,6 +663,11 @@
 		"WindowState": {
 			"description": "Visibility state of a window.",
 			"enum": ["maximized", "minimized", "normal"],
+			"type": "string"
+		},
+		"WindowThrottling": {
+			"description": "Window throttling state.\n\n* `enabled`: Both background throttling and scheduler throttling are true. It's fully throttled.\n* `scheduler-disabled`: The background throttling is true, but scheduler throttling is disabled.\n* `disabled`: The background throttling is false. The throttling is fully disabled.",
+			"enum": ["disabled", "enabled", "scheduler-disabled"],
 			"type": "string"
 		},
 		"WorkspacePlatformOptions": {
@@ -723,6 +744,9 @@
 				"backgroundColor": {
 					"description": "The window’s _backfill_ color as a hexadecimal value. Not to be confused with the content background color\n(`document.body.style.backgroundColor`),\nthis color briefly fills a window’s (a) content area before its content is loaded as well as (b) newly exposed\nareas when growing a window. Setting\nthis value to the anticipated content background color can help improve user experience.\nDefault is white.",
 					"type": "string"
+				},
+				"backgroundThrottling": {
+					"type": "boolean"
 				},
 				"closeOnLastViewRemoved": {
 					"type": "boolean"
@@ -893,7 +917,8 @@
 					"type": "number"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_4"
+					"$ref": "#/definitions/Partial_4",
+					"description": "API permissions for code running in the window."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -955,6 +980,10 @@
 					"description": "Specify a taskbar group for the window.\n_If omitted, defaults to app's uuid (`fin.Application.getCurrentSync().identity.uuid`)._",
 					"type": "string"
 				},
+				"throttling": {
+					"$ref": "#/definitions/WindowThrottling",
+					"description": "{@inheritDoc WindowThrottling}"
+				},
 				"url": {
 					"type": "string"
 				},
@@ -1010,6 +1039,10 @@
 					},
 					"type": "array"
 				},
+				"matchOptions": {
+					"$ref": "#/definitions/RuleMatchOptions",
+					"description": "Options to use when comparing URIs to the `allowlist` and `denylist` patterns."
+				},
 				"whitelist": {
 					"items": {
 						"type": "string"
@@ -1020,6 +1053,17 @@
 			"type": "object"
 		},
 		"__type_12": {
+			"additionalProperties": false,
+			"description": "Controls the behavior of the navigation URI pattern matching algorithm.",
+			"properties": {
+				"matchAllSchemes": {
+					"description": "Matches all schemes rather than just http and https when a wild card is specified. For example, `'*://*.site.com'` will\nonly match urls which begin with `'http:'` or `'https:'` unless this setting is `true`.",
+					"type": "boolean"
+				}
+			},
+			"type": "object"
+		},
+		"__type_13": {
 			"additionalProperties": false,
 			"properties": {
 				"allowlist": {
@@ -1042,6 +1086,10 @@
 					},
 					"type": "array"
 				},
+				"matchOptions": {
+					"$ref": "#/definitions/RuleMatchOptions",
+					"description": "Options to use when comparing URIs to the `allowlist` and `denylist` patterns."
+				},
 				"whitelist": {
 					"items": {
 						"type": "string"
@@ -1051,7 +1099,7 @@
 			},
 			"type": "object"
 		},
-		"__type_13": {
+		"__type_14": {
 			"additionalProperties": false,
 			"properties": {
 				"border": {
@@ -1077,7 +1125,7 @@
 			"required": ["enabled"],
 			"type": "object"
 		},
-		"__type_14": {
+		"__type_15": {
 			"additionalProperties": false,
 			"properties": {
 				"layouts": {
@@ -1087,11 +1135,11 @@
 			"required": ["layouts"],
 			"type": "object"
 		},
-		"__type_15": {
+		"__type_16": {
 			"additionalProperties": false,
 			"type": "object"
 		},
-		"__type_16": {
+		"__type_17": {
 			"additionalProperties": false,
 			"description": "Unique identifier for a window, view or iframe.",
 			"properties": {
@@ -1107,7 +1155,7 @@
 			"required": ["name", "uuid"],
 			"type": "object"
 		},
-		"__type_17": {
+		"__type_18": {
 			"additionalProperties": false,
 			"properties": {
 				"Application": {
@@ -1141,7 +1189,7 @@
 			},
 			"type": "object"
 		},
-		"__type_18": {
+		"__type_19": {
 			"additionalProperties": false,
 			"properties": {
 				"getFileDownloadLocation": {
@@ -1153,7 +1201,22 @@
 			},
 			"type": "object"
 		},
-		"__type_19": {
+		"__type_2": {
+			"additionalProperties": false,
+			"description": "Configure the context menu when right-clicking on a window.",
+			"properties": {
+				"enabled": {
+					"description": "Displays the context menu on right click.",
+					"type": "boolean"
+				},
+				"template": {
+					"$ref": "#/definitions/Array",
+					"description": "Context menu items to display on right-click."
+				}
+			},
+			"type": "object"
+		},
+		"__type_20": {
 			"additionalProperties": false,
 			"properties": {
 				"getAllExternalWindows": {
@@ -1360,22 +1423,7 @@
 			},
 			"type": "object"
 		},
-		"__type_2": {
-			"additionalProperties": false,
-			"description": "Configure the context menu when right-clicking on a window.",
-			"properties": {
-				"enabled": {
-					"description": "Displays the context menu on right click.",
-					"type": "boolean"
-				},
-				"template": {
-					"$ref": "#/definitions/Array",
-					"description": "Context menu items to display on right-click."
-				}
-			},
-			"type": "object"
-		},
-		"__type_20": {
+		"__type_21": {
 			"additionalProperties": false,
 			"description": "_Platform Windows Only_. Controls behavior for showing views when they are being resized by the user.",
 			"properties": {
@@ -1394,7 +1442,7 @@
 			},
 			"type": "object"
 		},
-		"__type_21": {
+		"__type_22": {
 			"additionalProperties": false,
 			"description": "Configuration for view visibility settings",
 			"properties": {
@@ -1404,7 +1452,7 @@
 			},
 			"type": "object"
 		},
-		"__type_22": {
+		"__type_23": {
 			"additionalProperties": false,
 			"properties": {
 				"customContext": {
@@ -1422,7 +1470,7 @@
 			},
 			"type": "object"
 		},
-		"__type_23": {
+		"__type_24": {
 			"additionalProperties": false,
 			"properties": {
 				"_internalWorkspaceData": {},
@@ -1567,7 +1615,8 @@
 					"type": "string"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_4"
+					"$ref": "#/definitions/Partial_4",
+					"description": "API permissions for code running in the view."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -1604,6 +1653,10 @@
 					"$ref": "#/definitions/Identity_5",
 					"description": "The identity of the window this view should be attached to."
 				},
+				"throttling": {
+					"$ref": "#/definitions/ViewThrottling",
+					"description": "{@inheritDoc ViewThrottling}"
+				},
 				"url": {
 					"type": "string"
 				},
@@ -1613,7 +1666,7 @@
 			},
 			"type": "object"
 		},
-		"__type_24": {
+		"__type_25": {
 			"additionalProperties": false,
 			"properties": {
 				"height": {
@@ -1632,7 +1685,7 @@
 			"required": ["height", "left", "top", "width"],
 			"type": "object"
 		},
-		"__type_25": {
+		"__type_26": {
 			"additionalProperties": false,
 			"properties": {
 				"height": {
@@ -1654,7 +1707,7 @@
 			},
 			"type": "object"
 		},
-		"__type_26": {
+		"__type_27": {
 			"additionalProperties": false,
 			"properties": {
 				"deviceScaleFactor": {
@@ -1745,7 +1798,7 @@
 			],
 			"type": "object"
 		},
-		"__type_27": {
+		"__type_28": {
 			"additionalProperties": false,
 			"properties": {
 				"x": {
@@ -1760,7 +1813,7 @@
 			"required": ["x", "y"],
 			"type": "object"
 		},
-		"__type_28": {
+		"__type_29": {
 			"additionalProperties": false,
 			"properties": {
 				"dipRect": {
@@ -1773,7 +1826,19 @@
 			"required": ["dipRect", "scaledRect"],
 			"type": "object"
 		},
-		"__type_29": {
+		"__type_3": {
+			"additionalProperties": false,
+			"properties": {
+				"height": {
+					"type": "number"
+				},
+				"width": {
+					"type": "number"
+				}
+			},
+			"type": "object"
+		},
+		"__type_30": {
 			"additionalProperties": false,
 			"properties": {
 				"bottom": {
@@ -1792,19 +1857,7 @@
 			"required": ["bottom", "left", "right", "top"],
 			"type": "object"
 		},
-		"__type_3": {
-			"additionalProperties": false,
-			"properties": {
-				"height": {
-					"type": "number"
-				},
-				"width": {
-					"type": "number"
-				}
-			},
-			"type": "object"
-		},
-		"__type_30": {
+		"__type_31": {
 			"additionalProperties": false,
 			"properties": {
 				"available": {
@@ -1856,7 +1909,7 @@
 			],
 			"type": "object"
 		},
-		"__type_31": {
+		"__type_32": {
 			"additionalProperties": {
 				"additionalProperties": {
 					"additionalProperties": false,

--- a/how-to/workspace-platform-starter/public/schemas/view.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/view.schema.json
@@ -15,7 +15,7 @@
 			"type": "array"
 		},
 		"AutoResizeOptions": {
-			"$ref": "#/definitions/__type_25"
+			"$ref": "#/definitions/__type_26"
 		},
 		"AutoplayPolicyOptions": {
 			"description": "Autoplay policy to apply to content in the window, can be\n`no-user-gesture-required`, `user-gesture-required`,\n`document-user-activation-required`. Defaults to `no-user-gesture-required`.",
@@ -46,7 +46,7 @@
 			"type": "object"
 		},
 		"Bounds": {
-			"$ref": "#/definitions/__type_24"
+			"$ref": "#/definitions/__type_25"
 		},
 		"BrowserContentCreationRule": {
 			"additionalProperties": false,
@@ -108,7 +108,7 @@
 			"$ref": "#/definitions/__type_5"
 		},
 		"DownloadShelfOptions": {
-			"$ref": "#/definitions/__type_14"
+			"$ref": "#/definitions/__type_15"
 		},
 		"Identity_5": {
 			"$ref": "#/definitions/__type_1"
@@ -122,7 +122,7 @@
 			"$ref": "#/definitions/__type_9"
 		},
 		"LayoutSnapshot": {
-			"$ref": "#/definitions/__type_15"
+			"$ref": "#/definitions/__type_16"
 		},
 		"OpenExternalPermission": {
 			"additionalProperties": false,
@@ -153,22 +153,22 @@
 			"$ref": "#/definitions/__type_11"
 		},
 		"Partial_3": {
-			"$ref": "#/definitions/__type_13"
+			"$ref": "#/definitions/__type_14"
 		},
 		"Partial_4": {
-			"$ref": "#/definitions/__type_17"
-		},
-		"Partial_5": {
 			"$ref": "#/definitions/__type_18"
 		},
-		"Partial_6": {
+		"Partial_5": {
 			"$ref": "#/definitions/__type_19"
 		},
+		"Partial_6": {
+			"$ref": "#/definitions/__type_20"
+		},
 		"Partial_7": {
-			"$ref": "#/definitions/__type_22"
+			"$ref": "#/definitions/__type_23"
 		},
 		"Partial_8": {
-			"$ref": "#/definitions/__type_23"
+			"$ref": "#/definitions/__type_24"
 		},
 		"PrebuiltContextMenuItem": {
 			"description": "Context menu item with an implementation provided by OpenFin.",
@@ -194,10 +194,13 @@
 			"$ref": "#/definitions/__type_4"
 		},
 		"Record": {
-			"$ref": "#/definitions/__type_16"
+			"$ref": "#/definitions/__type_17"
 		},
 		"ResizeRegion": {
 			"$ref": "#/definitions/__type_8"
+		},
+		"RuleMatchOptions": {
+			"$ref": "#/definitions/__type_13"
 		},
 		"ShowViewOnWindowResizeOptions": {
 			"additionalProperties": false,
@@ -385,7 +388,8 @@
 					"type": "string"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_4"
+					"$ref": "#/definitions/Partial_4",
+					"description": "API permissions for code running in the view."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -421,6 +425,10 @@
 				"target": {
 					"$ref": "#/definitions/Identity_5",
 					"description": "The identity of the window this view should be attached to."
+				},
+				"throttling": {
+					"$ref": "#/definitions/ViewThrottling",
+					"description": "{@inheritDoc ViewThrottling}"
 				},
 				"url": {
 					"type": "string"
@@ -459,16 +467,22 @@
 				"preventDragOut",
 				"processAffinity",
 				"target",
+				"throttling",
 				"url",
 				"zoomLevel"
 			],
 			"type": "object"
 		},
+		"ViewThrottling": {
+			"description": "View throttling state.\n\n* `enabled`: Both background throttling and scheduler throttling are true. It's fully throttled.\n* `scheduler-disabled`: background throttling is true, but scheduler throttling is disabled.",
+			"enum": ["enabled", "scheduler-disabled"],
+			"type": "string"
+		},
 		"ViewVisibilityOption": {
-			"$ref": "#/definitions/__type_21"
+			"$ref": "#/definitions/__type_22"
 		},
 		"ViewVisibilityOptions": {
-			"$ref": "#/definitions/__type_20"
+			"$ref": "#/definitions/__type_21"
 		},
 		"WebPermission": {
 			"anyOf": [
@@ -525,6 +539,11 @@
 		"WindowState": {
 			"description": "Visibility state of a window.",
 			"enum": ["maximized", "minimized", "normal"],
+			"type": "string"
+		},
+		"WindowThrottling": {
+			"description": "Window throttling state.\n\n* `enabled`: Both background throttling and scheduler throttling are true. It's fully throttled.\n* `scheduler-disabled`: The background throttling is true, but scheduler throttling is disabled.\n* `disabled`: The background throttling is false. The throttling is fully disabled.",
+			"enum": ["disabled", "enabled", "scheduler-disabled"],
 			"type": "string"
 		},
 		"WorkspacePlatformOptions": {
@@ -624,6 +643,10 @@
 					},
 					"type": "array"
 				},
+				"matchOptions": {
+					"$ref": "#/definitions/RuleMatchOptions",
+					"description": "Options to use when comparing URIs to the `allowlist` and `denylist` patterns."
+				},
 				"whitelist": {
 					"items": {
 						"type": "string"
@@ -634,6 +657,17 @@
 			"type": "object"
 		},
 		"__type_13": {
+			"additionalProperties": false,
+			"description": "Controls the behavior of the navigation URI pattern matching algorithm.",
+			"properties": {
+				"matchAllSchemes": {
+					"description": "Matches all schemes rather than just http and https when a wild card is specified. For example, `'*://*.site.com'` will\nonly match urls which begin with `'http:'` or `'https:'` unless this setting is `true`.",
+					"type": "boolean"
+				}
+			},
+			"type": "object"
+		},
+		"__type_14": {
 			"additionalProperties": false,
 			"properties": {
 				"allowlist": {
@@ -656,6 +690,10 @@
 					},
 					"type": "array"
 				},
+				"matchOptions": {
+					"$ref": "#/definitions/RuleMatchOptions",
+					"description": "Options to use when comparing URIs to the `allowlist` and `denylist` patterns."
+				},
 				"whitelist": {
 					"items": {
 						"type": "string"
@@ -665,7 +703,7 @@
 			},
 			"type": "object"
 		},
-		"__type_14": {
+		"__type_15": {
 			"additionalProperties": false,
 			"properties": {
 				"border": {
@@ -691,7 +729,7 @@
 			"required": ["enabled"],
 			"type": "object"
 		},
-		"__type_15": {
+		"__type_16": {
 			"additionalProperties": false,
 			"properties": {
 				"layouts": {
@@ -701,11 +739,11 @@
 			"required": ["layouts"],
 			"type": "object"
 		},
-		"__type_16": {
+		"__type_17": {
 			"additionalProperties": false,
 			"type": "object"
 		},
-		"__type_17": {
+		"__type_18": {
 			"additionalProperties": false,
 			"properties": {
 				"Application": {
@@ -739,7 +777,7 @@
 			},
 			"type": "object"
 		},
-		"__type_18": {
+		"__type_19": {
 			"additionalProperties": false,
 			"properties": {
 				"getFileDownloadLocation": {
@@ -751,7 +789,22 @@
 			},
 			"type": "object"
 		},
-		"__type_19": {
+		"__type_2": {
+			"additionalProperties": false,
+			"description": "Configures how new content (e,g, from `window.open` or a link) is opened.",
+			"properties": {
+				"rules": {
+					"description": "List of rules for creation of new content.",
+					"items": {
+						"$ref": "#/definitions/ContentCreationRule<ContentCreationBehavior>"
+					},
+					"type": "array"
+				}
+			},
+			"required": ["rules"],
+			"type": "object"
+		},
+		"__type_20": {
 			"additionalProperties": false,
 			"properties": {
 				"getAllExternalWindows": {
@@ -958,22 +1011,7 @@
 			},
 			"type": "object"
 		},
-		"__type_2": {
-			"additionalProperties": false,
-			"description": "Configures how new content (e,g, from `window.open` or a link) is opened.",
-			"properties": {
-				"rules": {
-					"description": "List of rules for creation of new content.",
-					"items": {
-						"$ref": "#/definitions/ContentCreationRule<ContentCreationBehavior>"
-					},
-					"type": "array"
-				}
-			},
-			"required": ["rules"],
-			"type": "object"
-		},
-		"__type_20": {
+		"__type_21": {
 			"additionalProperties": false,
 			"description": "_Platform Windows Only_. Controls behavior for showing views when they are being resized by the user.",
 			"properties": {
@@ -992,7 +1030,7 @@
 			},
 			"type": "object"
 		},
-		"__type_21": {
+		"__type_22": {
 			"additionalProperties": false,
 			"description": "Configuration for view visibility settings",
 			"properties": {
@@ -1002,7 +1040,7 @@
 			},
 			"type": "object"
 		},
-		"__type_22": {
+		"__type_23": {
 			"additionalProperties": false,
 			"properties": {
 				"customContext": {
@@ -1020,7 +1058,7 @@
 			},
 			"type": "object"
 		},
-		"__type_23": {
+		"__type_24": {
 			"additionalProperties": false,
 			"properties": {
 				"_internalWorkspaceData": {},
@@ -1165,7 +1203,8 @@
 					"type": "string"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_4"
+					"$ref": "#/definitions/Partial_4",
+					"description": "API permissions for code running in the view."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -1202,6 +1241,10 @@
 					"$ref": "#/definitions/Identity_5",
 					"description": "The identity of the window this view should be attached to."
 				},
+				"throttling": {
+					"$ref": "#/definitions/ViewThrottling",
+					"description": "{@inheritDoc ViewThrottling}"
+				},
 				"url": {
 					"type": "string"
 				},
@@ -1211,7 +1254,7 @@
 			},
 			"type": "object"
 		},
-		"__type_24": {
+		"__type_25": {
 			"additionalProperties": false,
 			"properties": {
 				"height": {
@@ -1230,7 +1273,7 @@
 			"required": ["height", "left", "top", "width"],
 			"type": "object"
 		},
-		"__type_25": {
+		"__type_26": {
 			"additionalProperties": false,
 			"properties": {
 				"height": {
@@ -1288,6 +1331,9 @@
 				"backgroundColor": {
 					"description": "The window’s _backfill_ color as a hexadecimal value. Not to be confused with the content background color\n(`document.body.style.backgroundColor`),\nthis color briefly fills a window’s (a) content area before its content is loaded as well as (b) newly exposed\nareas when growing a window. Setting\nthis value to the anticipated content background color can help improve user experience.\nDefault is white.",
 					"type": "string"
+				},
+				"backgroundThrottling": {
+					"type": "boolean"
 				},
 				"closeOnLastViewRemoved": {
 					"type": "boolean"
@@ -1458,7 +1504,8 @@
 					"type": "number"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_4"
+					"$ref": "#/definitions/Partial_4",
+					"description": "API permissions for code running in the window."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -1519,6 +1566,10 @@
 				"taskbarIconGroup": {
 					"description": "Specify a taskbar group for the window.\n_If omitted, defaults to app's uuid (`fin.Application.getCurrentSync().identity.uuid`)._",
 					"type": "string"
+				},
+				"throttling": {
+					"$ref": "#/definitions/WindowThrottling",
+					"description": "{@inheritDoc WindowThrottling}"
 				},
 				"url": {
 					"type": "string"

--- a/how-to/workspace-platform-starter/public/schemas/window.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/window.schema.json
@@ -15,7 +15,7 @@
 			"type": "array"
 		},
 		"AutoResizeOptions": {
-			"$ref": "#/definitions/__type_25"
+			"$ref": "#/definitions/__type_26"
 		},
 		"AutoplayPolicyOptions": {
 			"description": "Autoplay policy to apply to content in the window, can be\n`no-user-gesture-required`, `user-gesture-required`,\n`document-user-activation-required`. Defaults to `no-user-gesture-required`.",
@@ -46,7 +46,7 @@
 			"type": "object"
 		},
 		"Bounds": {
-			"$ref": "#/definitions/__type_24"
+			"$ref": "#/definitions/__type_25"
 		},
 		"BrowserContentCreationRule": {
 			"additionalProperties": false,
@@ -108,10 +108,10 @@
 			"$ref": "#/definitions/__type_1"
 		},
 		"DownloadShelfOptions": {
-			"$ref": "#/definitions/__type_13"
+			"$ref": "#/definitions/__type_14"
 		},
 		"Identity_5": {
-			"$ref": "#/definitions/__type_16"
+			"$ref": "#/definitions/__type_17"
 		},
 		"InjectionType": {
 			"description": "Injection setting for the `fin` API.\n\n* 'none': The `fin` API will be not available.\n* 'global': The entire `fin` API will be available.",
@@ -122,7 +122,7 @@
 			"$ref": "#/definitions/__type_5"
 		},
 		"LayoutSnapshot": {
-			"$ref": "#/definitions/__type_14"
+			"$ref": "#/definitions/__type_15"
 		},
 		"OpenExternalPermission": {
 			"additionalProperties": false,
@@ -153,22 +153,22 @@
 			"$ref": "#/definitions/__type_10"
 		},
 		"Partial_3": {
-			"$ref": "#/definitions/__type_12"
+			"$ref": "#/definitions/__type_13"
 		},
 		"Partial_4": {
-			"$ref": "#/definitions/__type_17"
-		},
-		"Partial_5": {
 			"$ref": "#/definitions/__type_18"
 		},
-		"Partial_6": {
+		"Partial_5": {
 			"$ref": "#/definitions/__type_19"
 		},
+		"Partial_6": {
+			"$ref": "#/definitions/__type_20"
+		},
 		"Partial_7": {
-			"$ref": "#/definitions/__type_22"
+			"$ref": "#/definitions/__type_23"
 		},
 		"Partial_8": {
-			"$ref": "#/definitions/__type_23"
+			"$ref": "#/definitions/__type_24"
 		},
 		"PlatformWindowOptions": {
 			"additionalProperties": false,
@@ -207,6 +207,9 @@
 				"backgroundColor": {
 					"description": "The window’s _backfill_ color as a hexadecimal value. Not to be confused with the content background color\n(`document.body.style.backgroundColor`),\nthis color briefly fills a window’s (a) content area before its content is loaded as well as (b) newly exposed\nareas when growing a window. Setting\nthis value to the anticipated content background color can help improve user experience.\nDefault is white.",
 					"type": "string"
+				},
+				"backgroundThrottling": {
+					"type": "boolean"
 				},
 				"closeOnLastViewRemoved": {
 					"type": "boolean"
@@ -376,7 +379,8 @@
 					"type": "number"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_4"
+					"$ref": "#/definitions/Partial_4",
+					"description": "API permissions for code running in the window."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -442,6 +446,10 @@
 					"description": "Specify a taskbar group for the window.\n_If omitted, defaults to app's uuid (`fin.Application.getCurrentSync().identity.uuid`)._",
 					"type": "string"
 				},
+				"throttling": {
+					"$ref": "#/definitions/WindowThrottling",
+					"description": "{@inheritDoc WindowThrottling}"
+				},
 				"url": {
 					"type": "string"
 				},
@@ -499,10 +507,13 @@
 			"$ref": "#/definitions/__type"
 		},
 		"Record": {
-			"$ref": "#/definitions/__type_15"
+			"$ref": "#/definitions/__type_16"
 		},
 		"ResizeRegion": {
 			"$ref": "#/definitions/__type_4"
+		},
+		"RuleMatchOptions": {
+			"$ref": "#/definitions/__type_12"
 		},
 		"ShowViewOnWindowResizeOptions": {
 			"additionalProperties": false,
@@ -544,11 +555,16 @@
 			"required": ["behavior", "match"],
 			"type": "object"
 		},
+		"ViewThrottling": {
+			"description": "View throttling state.\n\n* `enabled`: Both background throttling and scheduler throttling are true. It's fully throttled.\n* `scheduler-disabled`: background throttling is true, but scheduler throttling is disabled.",
+			"enum": ["enabled", "scheduler-disabled"],
+			"type": "string"
+		},
 		"ViewVisibilityOption": {
-			"$ref": "#/definitions/__type_21"
+			"$ref": "#/definitions/__type_22"
 		},
 		"ViewVisibilityOptions": {
-			"$ref": "#/definitions/__type_20"
+			"$ref": "#/definitions/__type_21"
 		},
 		"WebPermission": {
 			"anyOf": [
@@ -605,6 +621,11 @@
 		"WindowState": {
 			"description": "Visibility state of a window.",
 			"enum": ["maximized", "minimized", "normal"],
+			"type": "string"
+		},
+		"WindowThrottling": {
+			"description": "Window throttling state.\n\n* `enabled`: Both background throttling and scheduler throttling are true. It's fully throttled.\n* `scheduler-disabled`: The background throttling is true, but scheduler throttling is disabled.\n* `disabled`: The background throttling is false. The throttling is fully disabled.",
+			"enum": ["disabled", "enabled", "scheduler-disabled"],
 			"type": "string"
 		},
 		"WorkspacePlatformOptions": {
@@ -681,6 +702,9 @@
 				"backgroundColor": {
 					"description": "The window’s _backfill_ color as a hexadecimal value. Not to be confused with the content background color\n(`document.body.style.backgroundColor`),\nthis color briefly fills a window’s (a) content area before its content is loaded as well as (b) newly exposed\nareas when growing a window. Setting\nthis value to the anticipated content background color can help improve user experience.\nDefault is white.",
 					"type": "string"
+				},
+				"backgroundThrottling": {
+					"type": "boolean"
 				},
 				"closeOnLastViewRemoved": {
 					"type": "boolean"
@@ -851,7 +875,8 @@
 					"type": "number"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_4"
+					"$ref": "#/definitions/Partial_4",
+					"description": "API permissions for code running in the window."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -913,6 +938,10 @@
 					"description": "Specify a taskbar group for the window.\n_If omitted, defaults to app's uuid (`fin.Application.getCurrentSync().identity.uuid`)._",
 					"type": "string"
 				},
+				"throttling": {
+					"$ref": "#/definitions/WindowThrottling",
+					"description": "{@inheritDoc WindowThrottling}"
+				},
 				"url": {
 					"type": "string"
 				},
@@ -968,6 +997,10 @@
 					},
 					"type": "array"
 				},
+				"matchOptions": {
+					"$ref": "#/definitions/RuleMatchOptions",
+					"description": "Options to use when comparing URIs to the `allowlist` and `denylist` patterns."
+				},
 				"whitelist": {
 					"items": {
 						"type": "string"
@@ -978,6 +1011,17 @@
 			"type": "object"
 		},
 		"__type_12": {
+			"additionalProperties": false,
+			"description": "Controls the behavior of the navigation URI pattern matching algorithm.",
+			"properties": {
+				"matchAllSchemes": {
+					"description": "Matches all schemes rather than just http and https when a wild card is specified. For example, `'*://*.site.com'` will\nonly match urls which begin with `'http:'` or `'https:'` unless this setting is `true`.",
+					"type": "boolean"
+				}
+			},
+			"type": "object"
+		},
+		"__type_13": {
 			"additionalProperties": false,
 			"properties": {
 				"allowlist": {
@@ -1000,6 +1044,10 @@
 					},
 					"type": "array"
 				},
+				"matchOptions": {
+					"$ref": "#/definitions/RuleMatchOptions",
+					"description": "Options to use when comparing URIs to the `allowlist` and `denylist` patterns."
+				},
 				"whitelist": {
 					"items": {
 						"type": "string"
@@ -1009,7 +1057,7 @@
 			},
 			"type": "object"
 		},
-		"__type_13": {
+		"__type_14": {
 			"additionalProperties": false,
 			"properties": {
 				"border": {
@@ -1035,7 +1083,7 @@
 			"required": ["enabled"],
 			"type": "object"
 		},
-		"__type_14": {
+		"__type_15": {
 			"additionalProperties": false,
 			"properties": {
 				"layouts": {
@@ -1045,11 +1093,11 @@
 			"required": ["layouts"],
 			"type": "object"
 		},
-		"__type_15": {
+		"__type_16": {
 			"additionalProperties": false,
 			"type": "object"
 		},
-		"__type_16": {
+		"__type_17": {
 			"additionalProperties": false,
 			"description": "Unique identifier for a window, view or iframe.",
 			"properties": {
@@ -1065,7 +1113,7 @@
 			"required": ["name", "uuid"],
 			"type": "object"
 		},
-		"__type_17": {
+		"__type_18": {
 			"additionalProperties": false,
 			"properties": {
 				"Application": {
@@ -1099,7 +1147,7 @@
 			},
 			"type": "object"
 		},
-		"__type_18": {
+		"__type_19": {
 			"additionalProperties": false,
 			"properties": {
 				"getFileDownloadLocation": {
@@ -1111,7 +1159,22 @@
 			},
 			"type": "object"
 		},
-		"__type_19": {
+		"__type_2": {
+			"additionalProperties": false,
+			"description": "Configure the context menu when right-clicking on a window.",
+			"properties": {
+				"enabled": {
+					"description": "Displays the context menu on right click.",
+					"type": "boolean"
+				},
+				"template": {
+					"$ref": "#/definitions/Array",
+					"description": "Context menu items to display on right-click."
+				}
+			},
+			"type": "object"
+		},
+		"__type_20": {
 			"additionalProperties": false,
 			"properties": {
 				"getAllExternalWindows": {
@@ -1318,22 +1381,7 @@
 			},
 			"type": "object"
 		},
-		"__type_2": {
-			"additionalProperties": false,
-			"description": "Configure the context menu when right-clicking on a window.",
-			"properties": {
-				"enabled": {
-					"description": "Displays the context menu on right click.",
-					"type": "boolean"
-				},
-				"template": {
-					"$ref": "#/definitions/Array",
-					"description": "Context menu items to display on right-click."
-				}
-			},
-			"type": "object"
-		},
-		"__type_20": {
+		"__type_21": {
 			"additionalProperties": false,
 			"description": "_Platform Windows Only_. Controls behavior for showing views when they are being resized by the user.",
 			"properties": {
@@ -1352,7 +1400,7 @@
 			},
 			"type": "object"
 		},
-		"__type_21": {
+		"__type_22": {
 			"additionalProperties": false,
 			"description": "Configuration for view visibility settings",
 			"properties": {
@@ -1362,7 +1410,7 @@
 			},
 			"type": "object"
 		},
-		"__type_22": {
+		"__type_23": {
 			"additionalProperties": false,
 			"properties": {
 				"customContext": {
@@ -1380,7 +1428,7 @@
 			},
 			"type": "object"
 		},
-		"__type_23": {
+		"__type_24": {
 			"additionalProperties": false,
 			"properties": {
 				"_internalWorkspaceData": {},
@@ -1525,7 +1573,8 @@
 					"type": "string"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_4"
+					"$ref": "#/definitions/Partial_4",
+					"description": "API permissions for code running in the view."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -1562,6 +1611,10 @@
 					"$ref": "#/definitions/Identity_5",
 					"description": "The identity of the window this view should be attached to."
 				},
+				"throttling": {
+					"$ref": "#/definitions/ViewThrottling",
+					"description": "{@inheritDoc ViewThrottling}"
+				},
 				"url": {
 					"type": "string"
 				},
@@ -1571,7 +1624,7 @@
 			},
 			"type": "object"
 		},
-		"__type_24": {
+		"__type_25": {
 			"additionalProperties": false,
 			"properties": {
 				"height": {
@@ -1590,7 +1643,7 @@
 			"required": ["height", "left", "top", "width"],
 			"type": "object"
 		},
-		"__type_25": {
+		"__type_26": {
 			"additionalProperties": false,
 			"properties": {
 				"height": {

--- a/how-to/workspace-platform-starter/public/schemas/wps.manifest.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/wps.manifest.schema.json
@@ -51,7 +51,7 @@
 			"$ref": "#/definitions/__type_3"
 		},
 		"AppAssetInfo": {
-			"$ref": "#/definitions/__type_56"
+			"$ref": "#/definitions/__type_57"
 		},
 		"AppEndpointOptions": {
 			"anyOf": [
@@ -338,7 +338,7 @@
 			"type": "object"
 		},
 		"AutoResizeOptions": {
-			"$ref": "#/definitions/__type_28"
+			"$ref": "#/definitions/__type_29"
 		},
 		"AutoplayPolicyOptions": {
 			"description": "Autoplay policy to apply to content in the window, can be\n`no-user-gesture-required`, `user-gesture-required`,\n`document-user-activation-required`. Defaults to `no-user-gesture-required`.",
@@ -408,7 +408,7 @@
 			"type": "object"
 		},
 		"Bounds": {
-			"$ref": "#/definitions/__type_27"
+			"$ref": "#/definitions/__type_28"
 		},
 		"BrokerConnection": {
 			"additionalProperties": false,
@@ -720,7 +720,7 @@
 			"type": "object"
 		},
 		"CertificationInfo": {
-			"$ref": "#/definitions/__type_49"
+			"$ref": "#/definitions/__type_50"
 		},
 		"ConditionsProviderOptions": {
 			"$ref": "#/definitions/ModuleList_3",
@@ -827,17 +827,33 @@
 		"ContentNavigation": {
 			"$ref": "#/definitions/__type_15"
 		},
+		"ContentPermission": {
+			"description": "Whether a content url is allowed or blocked for navigation or redirection.\n\n* 'allow': The content url is allowed.\n* 'block': The content url is blocked.",
+			"enum": ["allow", "block"],
+			"type": "string"
+		},
 		"ContentRedirect": {
 			"$ref": "#/definitions/__type_15"
 		},
 		"ContextGroupStates": {
-			"$ref": "#/definitions/__type_46"
+			"$ref": "#/definitions/__type_47"
 		},
 		"ContextMenuOptions": {
 			"$ref": "#/definitions/__type_9"
 		},
 		"ContextMenuSettings": {
 			"$ref": "#/definitions/__type_8"
+		},
+		"ContextOptions": {
+			"additionalProperties": false,
+			"description": "Option for the Context Handling.",
+			"properties": {
+				"includeOriginator": {
+					"description": "Should the broker send context messages back to the sender? Default is true.",
+					"type": "boolean"
+				}
+			},
+			"type": "object"
 		},
 		"CustomActionSpecifier": {
 			"additionalProperties": false,
@@ -1153,10 +1169,10 @@
 		},
 		"Data": {},
 		"DeepPartial": {
-			"$ref": "#/definitions/__type_37"
+			"$ref": "#/definitions/__type_38"
 		},
 		"DefaultDomainSettings": {
-			"$ref": "#/definitions/__type_62"
+			"$ref": "#/definitions/__type_63"
 		},
 		"DelayStrategy": {
 			"additionalProperties": false,
@@ -1207,10 +1223,10 @@
 			"type": "object"
 		},
 		"DipScaleRects": {
-			"$ref": "#/definitions/__type_43"
+			"$ref": "#/definitions/__type_44"
 		},
-		"DisplayMetadata_3": {
-			"$ref": "#/definitions/__type_60"
+		"DisplayMetadata": {
+			"$ref": "#/definitions/__type_61"
 		},
 		"DockButtonAction": {
 			"additionalProperties": false,
@@ -1467,13 +1483,13 @@
 			"type": "object"
 		},
 		"DomainApiSettings": {
-			"$ref": "#/definitions/__type_64"
+			"$ref": "#/definitions/__type_66"
 		},
 		"DomainSettings": {
-			"$ref": "#/definitions/__type_62"
+			"$ref": "#/definitions/__type_63"
 		},
 		"DownloadShelfOptions": {
-			"$ref": "#/definitions/__type_17"
+			"$ref": "#/definitions/__type_18"
 		},
 		"EndpointClientDefaultOptions": {
 			"additionalProperties": false,
@@ -1700,7 +1716,7 @@
 			"type": "string"
 		},
 		"FileDownloadSettings": {
-			"$ref": "#/definitions/__type_63"
+			"$ref": "#/definitions/__type_65"
 		},
 		"GlobalContextMenuOptionType": {
 			"description": "Types of global context menu options, including pre-defined ones.\nUser-defined context menu items should use the value `Custom`",
@@ -1844,7 +1860,7 @@
 			"$ref": "#/definitions/__type_4"
 		},
 		"Identity_5_1": {
-			"$ref": "#/definitions/__type_38"
+			"$ref": "#/definitions/__type_39"
 		},
 		"Image": {
 			"additionalProperties": false,
@@ -2008,16 +2024,16 @@
 			"type": "object"
 		},
 		"InteropBrokerOptions": {
-			"$ref": "#/definitions/__type_59"
+			"$ref": "#/definitions/__type_60"
 		},
 		"InteropConfig": {
 			"$ref": "#/definitions/__type_12"
 		},
 		"InteropLoggingOptions": {
-			"$ref": "#/definitions/__type_61"
+			"$ref": "#/definitions/__type_62"
 		},
 		"LaunchExternalProcessListener": {
-			"$ref": "#/definitions/__type_48"
+			"$ref": "#/definitions/__type_49"
 		},
 		"LaunchPreference": {
 			"additionalProperties": false,
@@ -2106,14 +2122,14 @@
 			"type": "object"
 		},
 		"LayoutSnapshot": {
-			"$ref": "#/definitions/__type_18"
+			"$ref": "#/definitions/__type_19"
 		},
 		"LifecycleProviderOptions": {
 			"$ref": "#/definitions/ModuleList_4",
 			"description": "List of modules."
 		},
 		"LockUnlockPageConfig": {
-			"$ref": "#/definitions/__type_31"
+			"$ref": "#/definitions/__type_32"
 		},
 		"LoggerProviderOptions": {
 			"$ref": "#/definitions/ModuleList_1",
@@ -2968,10 +2984,10 @@
 			"type": "object"
 		},
 		"MonitorDetails": {
-			"$ref": "#/definitions/__type_45"
+			"$ref": "#/definitions/__type_46"
 		},
 		"MonitorInfo": {
-			"$ref": "#/definitions/__type_41"
+			"$ref": "#/definitions/__type_42"
 		},
 		"NativeLaunchOptions": {
 			"additionalProperties": false,
@@ -3114,7 +3130,7 @@
 			"type": "object"
 		},
 		"NotificationIndicatorColorsWithScheme": {
-			"$ref": "#/definitions/__type_55"
+			"$ref": "#/definitions/__type_56"
 		},
 		"NotificationProviderOptions": {
 			"additionalProperties": false,
@@ -3145,23 +3161,23 @@
 			"type": "object"
 		},
 		"NotificationsCustomManifestOptions": {
-			"$ref": "#/definitions/__type_39"
+			"$ref": "#/definitions/__type_40"
 		},
 		"O": {},
 		"Omit": {
-			"$ref": "#/definitions/__type_29"
+			"$ref": "#/definitions/__type_30"
 		},
 		"Omit_1": {
-			"$ref": "#/definitions/__type_33"
-		},
-		"Omit_2": {
 			"$ref": "#/definitions/__type_34"
 		},
-		"Omit_3": {
+		"Omit_2": {
 			"$ref": "#/definitions/__type_35"
 		},
-		"Omit_4": {
+		"Omit_3": {
 			"$ref": "#/definitions/__type_36"
+		},
+		"Omit_4": {
+			"$ref": "#/definitions/__type_37"
 		},
 		"OpenExternalPermission": {
 			"additionalProperties": false,
@@ -3319,6 +3335,9 @@
 						"preventDragOut": {
 							"type": "boolean"
 						},
+						"preventSplitterResize": {
+							"type": "boolean"
+						},
 						"reorderEnabled": {
 							"type": "boolean"
 						},
@@ -3360,9 +3379,11 @@
 				"Rename",
 				"Save",
 				"Save As",
+				"Delete Page",
 				"SaveWorkspaceAs",
 				"Refresh",
 				"Close others",
+				"Delete",
 				"Custom"
 			],
 			"type": "string"
@@ -3427,28 +3448,28 @@
 			"$ref": "#/definitions/__type_2"
 		},
 		"Partial_10": {
-			"$ref": "#/definitions/__type_26"
+			"$ref": "#/definitions/__type_27"
 		},
 		"Partial_11": {
-			"$ref": "#/definitions/__type_40"
+			"$ref": "#/definitions/__type_41"
 		},
 		"Partial_12": {
-			"$ref": "#/definitions/__type_47"
+			"$ref": "#/definitions/__type_48"
 		},
 		"Partial_13": {
-			"$ref": "#/definitions/__type_50"
-		},
-		"Partial_14": {
 			"$ref": "#/definitions/__type_51"
 		},
-		"Partial_15": {
+		"Partial_14": {
 			"$ref": "#/definitions/__type_52"
 		},
-		"Partial_16": {
+		"Partial_15": {
 			"$ref": "#/definitions/__type_53"
 		},
+		"Partial_16": {
+			"$ref": "#/definitions/__type_54"
+		},
 		"Partial_17": {
-			"$ref": "#/definitions/__type_58"
+			"$ref": "#/definitions/__type_59"
 		},
 		"Partial_2": {
 			"$ref": "#/definitions/__type_6"
@@ -3460,22 +3481,28 @@
 			"$ref": "#/definitions/__type_14"
 		},
 		"Partial_5": {
-			"$ref": "#/definitions/__type_16"
+			"$ref": "#/definitions/__type_17"
 		},
 		"Partial_6": {
-			"$ref": "#/definitions/__type_20"
-		},
-		"Partial_7": {
 			"$ref": "#/definitions/__type_21"
 		},
-		"Partial_8": {
+		"Partial_7": {
 			"$ref": "#/definitions/__type_22"
 		},
+		"Partial_8": {
+			"$ref": "#/definitions/__type_23"
+		},
 		"Partial_9": {
-			"$ref": "#/definitions/__type_25"
+			"$ref": "#/definitions/__type_26"
+		},
+		"PerDomainSettings": {
+			"$ref": "#/definitions/__type_64"
+		},
+		"Permissions_2": {
+			"$ref": "#/definitions/__type_67"
 		},
 		"Pick": {
-			"$ref": "#/definitions/__type_32"
+			"$ref": "#/definitions/__type_33"
 		},
 		"PlatformApp": {
 			"additionalProperties": false,
@@ -3714,6 +3741,10 @@
 			"additionalProperties": false,
 			"description": "Options for the platform interop broker.",
 			"properties": {
+				"contextOptions": {
+					"$ref": "#/definitions/ContextOptions",
+					"description": "Options for when fdc3.broadcast or fin.me.interop.setContext is called."
+				},
 				"intentOptions": {
 					"$ref": "#/definitions/IntentOptions",
 					"description": "Options related to the way this platform supports intents"
@@ -3761,6 +3792,10 @@
 				},
 				"apiDiagnostics": {
 					"type": "boolean"
+				},
+				"appLogsTimezone": {
+					"$ref": "#/definitions/TimeZones",
+					"description": "Set the timezone for the app logs. When setting this value the timestamp will be in ISO 8601 format. By default, if no value is set, it will show the local time in this format: 'y-MM-dd HH:mm:ss.SSS'"
 				},
 				"aspectRatio": {
 					"type": "number"
@@ -4060,7 +4095,7 @@
 			"type": "object"
 		},
 		"Point": {
-			"$ref": "#/definitions/__type_42"
+			"$ref": "#/definitions/__type_43"
 		},
 		"PopupMenuStyles": {
 			"description": "The styles that can be used to display the popup menus.",
@@ -4130,16 +4165,19 @@
 			"$ref": "#/definitions/__type_7"
 		},
 		"Record": {
-			"$ref": "#/definitions/__type_19"
+			"$ref": "#/definitions/__type_20"
 		},
 		"Record_1": {
-			"$ref": "#/definitions/__type_54"
+			"$ref": "#/definitions/__type_55"
 		},
 		"RectangleByEdgePositions": {
-			"$ref": "#/definitions/__type_44"
+			"$ref": "#/definitions/__type_45"
 		},
 		"ResizeRegion": {
 			"$ref": "#/definitions/__type_11"
+		},
+		"RuleMatchOptions": {
+			"$ref": "#/definitions/__type_16"
 		},
 		"ScoreOrder": {
 			"description": "The order to sort scored search results in.",
@@ -4196,7 +4234,7 @@
 			"type": "object"
 		},
 		"ShowHideTabsConfig": {
-			"$ref": "#/definitions/__type_30"
+			"$ref": "#/definitions/__type_31"
 		},
 		"ShowViewOnWindowResizeOptions": {
 			"additionalProperties": false,
@@ -4246,7 +4284,7 @@
 			"type": "object"
 		},
 		"Snapshot": {
-			"$ref": "#/definitions/__type_57"
+			"$ref": "#/definitions/__type_58"
 		},
 		"SnapshotSourceConnection": {
 			"additionalProperties": false,
@@ -4622,6 +4660,10 @@
 			"required": ["themes"],
 			"type": "object"
 		},
+		"TimeZones": {
+			"enum": ["local", "utc"],
+			"type": "string"
+		},
 		"ToolbarButton": {
 			"anyOf": [
 				{
@@ -4916,11 +4958,16 @@
 			],
 			"type": "string"
 		},
+		"ViewThrottling": {
+			"description": "View throttling state.\n\n* `enabled`: Both background throttling and scheduler throttling are true. It's fully throttled.\n* `scheduler-disabled`: background throttling is true, but scheduler throttling is disabled.",
+			"enum": ["enabled", "scheduler-disabled"],
+			"type": "string"
+		},
 		"ViewVisibilityOption": {
-			"$ref": "#/definitions/__type_24"
+			"$ref": "#/definitions/__type_25"
 		},
 		"ViewVisibilityOptions": {
-			"$ref": "#/definitions/__type_23"
+			"$ref": "#/definitions/__type_24"
 		},
 		"WPSManifest": {
 			"additionalProperties": false,
@@ -5288,6 +5335,9 @@
 					"description": "The window’s _backfill_ color as a hexadecimal value. Not to be confused with the content background color\n(`document.body.style.backgroundColor`),\nthis color briefly fills a window’s (a) content area before its content is loaded as well as (b) newly exposed\nareas when growing a window. Setting\nthis value to the anticipated content background color can help improve user experience.\nDefault is white.",
 					"type": "string"
 				},
+				"backgroundThrottling": {
+					"type": "boolean"
+				},
 				"closeOnLastViewRemoved": {
 					"type": "boolean"
 				},
@@ -5457,7 +5507,8 @@
 					"type": "number"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_6"
+					"$ref": "#/definitions/Partial_6",
+					"description": "API permissions for code running in the window."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -5519,6 +5570,10 @@
 					"description": "Specify a taskbar group for the window.\n_If omitted, defaults to app's uuid (`fin.Application.getCurrentSync().identity.uuid`)._",
 					"type": "string"
 				},
+				"throttling": {
+					"$ref": "#/definitions/WindowThrottling",
+					"description": "{@inheritDoc WindowThrottling}"
+				},
 				"url": {
 					"type": "string"
 				},
@@ -5560,6 +5615,7 @@
 				"autoShow",
 				"autoplayPolicy",
 				"backgroundColor",
+				"backgroundThrottling",
 				"closeOnLastViewRemoved",
 				"contentCreation",
 				"contentNavigation",
@@ -5609,6 +5665,7 @@
 				"state",
 				"taskbarIcon",
 				"taskbarIconGroup",
+				"throttling",
 				"url",
 				"uuid",
 				"viewsPreventingClose",
@@ -5690,6 +5747,11 @@
 			"required": ["buttons"],
 			"type": "object"
 		},
+		"WindowThrottling": {
+			"description": "Window throttling state.\n\n* `enabled`: Both background throttling and scheduler throttling are true. It's fully throttled.\n* `scheduler-disabled`: The background throttling is true, but scheduler throttling is disabled.\n* `disabled`: The background throttling is false. The throttling is fully disabled.",
+			"enum": ["disabled", "enabled", "scheduler-disabled"],
+			"type": "string"
+		},
 		"WindowType": {
 			"enum": ["browser", "platform"],
 			"type": "string"
@@ -5764,6 +5826,9 @@
 				"backgroundColor": {
 					"description": "The window’s _backfill_ color as a hexadecimal value. Not to be confused with the content background color\n(`document.body.style.backgroundColor`),\nthis color briefly fills a window’s (a) content area before its content is loaded as well as (b) newly exposed\nareas when growing a window. Setting\nthis value to the anticipated content background color can help improve user experience.\nDefault is white.",
 					"type": "string"
+				},
+				"backgroundThrottling": {
+					"type": "boolean"
 				},
 				"closeOnLastViewRemoved": {
 					"type": "boolean"
@@ -5934,7 +5999,8 @@
 					"type": "number"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_6"
+					"$ref": "#/definitions/Partial_6",
+					"description": "API permissions for code running in the window."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -5998,6 +6064,10 @@
 				"taskbarIconGroup": {
 					"description": "Specify a taskbar group for the window.\n_If omitted, defaults to app's uuid (`fin.Application.getCurrentSync().identity.uuid`)._",
 					"type": "string"
+				},
+				"throttling": {
+					"$ref": "#/definitions/WindowThrottling",
+					"description": "{@inheritDoc WindowThrottling}"
 				},
 				"updateStateIfExists": {
 					"type": "boolean"
@@ -6199,6 +6269,10 @@
 					},
 					"type": "array"
 				},
+				"matchOptions": {
+					"$ref": "#/definitions/RuleMatchOptions",
+					"description": "Options to use when comparing URIs to the `allowlist` and `denylist` patterns."
+				},
 				"whitelist": {
 					"items": {
 						"type": "string"
@@ -6209,6 +6283,17 @@
 			"type": "object"
 		},
 		"__type_16": {
+			"additionalProperties": false,
+			"description": "Controls the behavior of the navigation URI pattern matching algorithm.",
+			"properties": {
+				"matchAllSchemes": {
+					"description": "Matches all schemes rather than just http and https when a wild card is specified. For example, `'*://*.site.com'` will\nonly match urls which begin with `'http:'` or `'https:'` unless this setting is `true`.",
+					"type": "boolean"
+				}
+			},
+			"type": "object"
+		},
+		"__type_17": {
 			"additionalProperties": false,
 			"properties": {
 				"allowlist": {
@@ -6231,6 +6316,10 @@
 					},
 					"type": "array"
 				},
+				"matchOptions": {
+					"$ref": "#/definitions/RuleMatchOptions",
+					"description": "Options to use when comparing URIs to the `allowlist` and `denylist` patterns."
+				},
 				"whitelist": {
 					"items": {
 						"type": "string"
@@ -6240,7 +6329,7 @@
 			},
 			"type": "object"
 		},
-		"__type_17": {
+		"__type_18": {
 			"additionalProperties": false,
 			"properties": {
 				"border": {
@@ -6266,7 +6355,7 @@
 			"required": ["enabled"],
 			"type": "object"
 		},
-		"__type_18": {
+		"__type_19": {
 			"additionalProperties": false,
 			"properties": {
 				"layouts": {
@@ -6274,10 +6363,6 @@
 				}
 			},
 			"required": ["layouts"],
-			"type": "object"
-		},
-		"__type_19": {
-			"additionalProperties": false,
 			"type": "object"
 		},
 		"__type_2": {
@@ -6425,7 +6510,8 @@
 					"type": "string"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_6"
+					"$ref": "#/definitions/Partial_6",
+					"description": "API permissions for code running in the view."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -6462,6 +6548,10 @@
 					"$ref": "#/definitions/Identity_5",
 					"description": "The identity of the window this view should be attached to."
 				},
+				"throttling": {
+					"$ref": "#/definitions/ViewThrottling",
+					"description": "{@inheritDoc ViewThrottling}"
+				},
 				"url": {
 					"type": "string"
 				},
@@ -6472,6 +6562,10 @@
 			"type": "object"
 		},
 		"__type_20": {
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"__type_21": {
 			"additionalProperties": false,
 			"properties": {
 				"Application": {
@@ -6505,7 +6599,7 @@
 			},
 			"type": "object"
 		},
-		"__type_21": {
+		"__type_22": {
 			"additionalProperties": false,
 			"properties": {
 				"getFileDownloadLocation": {
@@ -6517,7 +6611,7 @@
 			},
 			"type": "object"
 		},
-		"__type_22": {
+		"__type_23": {
 			"additionalProperties": false,
 			"properties": {
 				"getAllExternalWindows": {
@@ -6724,7 +6818,7 @@
 			},
 			"type": "object"
 		},
-		"__type_23": {
+		"__type_24": {
 			"additionalProperties": false,
 			"description": "_Platform Windows Only_. Controls behavior for showing views when they are being resized by the user.",
 			"properties": {
@@ -6743,7 +6837,7 @@
 			},
 			"type": "object"
 		},
-		"__type_24": {
+		"__type_25": {
 			"additionalProperties": false,
 			"description": "Configuration for view visibility settings",
 			"properties": {
@@ -6753,7 +6847,7 @@
 			},
 			"type": "object"
 		},
-		"__type_25": {
+		"__type_26": {
 			"additionalProperties": false,
 			"properties": {
 				"customContext": {
@@ -6771,7 +6865,7 @@
 			},
 			"type": "object"
 		},
-		"__type_26": {
+		"__type_27": {
 			"additionalProperties": false,
 			"properties": {
 				"_internalWorkspaceData": {},
@@ -6916,7 +7010,8 @@
 					"type": "string"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_6"
+					"$ref": "#/definitions/Partial_6",
+					"description": "API permissions for code running in the view."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -6953,6 +7048,10 @@
 					"$ref": "#/definitions/Identity_5",
 					"description": "The identity of the window this view should be attached to."
 				},
+				"throttling": {
+					"$ref": "#/definitions/ViewThrottling",
+					"description": "{@inheritDoc ViewThrottling}"
+				},
 				"url": {
 					"type": "string"
 				},
@@ -6962,7 +7061,7 @@
 			},
 			"type": "object"
 		},
-		"__type_27": {
+		"__type_28": {
 			"additionalProperties": false,
 			"properties": {
 				"height": {
@@ -6981,7 +7080,7 @@
 			"required": ["height", "left", "top", "width"],
 			"type": "object"
 		},
-		"__type_28": {
+		"__type_29": {
 			"additionalProperties": false,
 			"properties": {
 				"height": {
@@ -7003,7 +7102,36 @@
 			},
 			"type": "object"
 		},
-		"__type_29": {
+		"__type_3": {
+			"additionalProperties": false,
+			"description": "Configurations for API injection.",
+			"properties": {
+				"fin": {
+					"$ref": "#/definitions/InjectionType",
+					"description": "Configure injection of the `fin` API in this context.\n\n* 'none': The `fin` API will be not available in this context.\n* 'global': The entire `fin` API will be available in this context."
+				},
+				"iframe": {
+					"additionalProperties": false,
+					"description": "Configure conditional injection of OpenFin API into iframes",
+					"properties": {
+						"crossOriginInjection": {
+							"description": "Inject OpenFin API into cross-origin iframes",
+							"type": "boolean"
+						},
+						"enableDeprecatedSharedName": {
+							"type": "boolean"
+						},
+						"sameOriginInjection": {
+							"description": "Inject OpenFin API into same-origin iframes",
+							"type": "boolean"
+						}
+					},
+					"type": "object"
+				}
+			},
+			"type": "object"
+		},
+		"__type_30": {
 			"additionalProperties": false,
 			"properties": {
 				"_internalWorkspaceData": {},
@@ -7144,7 +7272,8 @@
 					"type": "string"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_6"
+					"$ref": "#/definitions/Partial_6",
+					"description": "API permissions for code running in the view."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -7177,6 +7306,10 @@
 					"description": "String tag that attempts to group like-tagged renderers together. Will only be used if pages are on the same origin.",
 					"type": "string"
 				},
+				"throttling": {
+					"$ref": "#/definitions/ViewThrottling",
+					"description": "{@inheritDoc ViewThrottling}"
+				},
 				"url": {
 					"type": "string"
 				},
@@ -7186,36 +7319,7 @@
 			},
 			"type": "object"
 		},
-		"__type_3": {
-			"additionalProperties": false,
-			"description": "Configurations for API injection.",
-			"properties": {
-				"fin": {
-					"$ref": "#/definitions/InjectionType",
-					"description": "Configure injection of the `fin` API in this context.\n\n* 'none': The `fin` API will be not available in this context.\n* 'global': The entire `fin` API will be available in this context."
-				},
-				"iframe": {
-					"additionalProperties": false,
-					"description": "Configure conditional injection of OpenFin API into iframes",
-					"properties": {
-						"crossOriginInjection": {
-							"description": "Inject OpenFin API into cross-origin iframes",
-							"type": "boolean"
-						},
-						"enableDeprecatedSharedName": {
-							"type": "boolean"
-						},
-						"sameOriginInjection": {
-							"description": "Inject OpenFin API into same-origin iframes",
-							"type": "boolean"
-						}
-					},
-					"type": "object"
-				}
-			},
-			"type": "object"
-		},
-		"__type_30": {
+		"__type_31": {
 			"additionalProperties": false,
 			"description": "Configuration Object for the show/hide tabs button within the browser toolbar",
 			"properties": {
@@ -7257,7 +7361,7 @@
 			"required": ["type"],
 			"type": "object"
 		},
-		"__type_31": {
+		"__type_32": {
 			"additionalProperties": false,
 			"description": "Configuration Object for the page lock/unlock button within the browser toolbar",
 			"properties": {
@@ -7277,7 +7381,7 @@
 			"required": ["type"],
 			"type": "object"
 		},
-		"__type_32": {
+		"__type_33": {
 			"additionalProperties": false,
 			"properties": {
 				"closeButton": {
@@ -7311,7 +7415,7 @@
 			},
 			"type": "object"
 		},
-		"__type_33": {
+		"__type_34": {
 			"additionalProperties": false,
 			"properties": {
 				"conditions": {
@@ -7353,7 +7457,7 @@
 			"required": ["display"],
 			"type": "object"
 		},
-		"__type_34": {
+		"__type_35": {
 			"additionalProperties": false,
 			"properties": {
 				"appId": {
@@ -7383,7 +7487,7 @@
 			"required": ["appId"],
 			"type": "object"
 		},
-		"__type_35": {
+		"__type_36": {
 			"additionalProperties": false,
 			"properties": {
 				"action": {
@@ -7424,7 +7528,7 @@
 			"required": ["action"],
 			"type": "object"
 		},
-		"__type_36": {
+		"__type_37": {
 			"additionalProperties": false,
 			"properties": {
 				"conditions": {
@@ -7474,7 +7578,7 @@
 			"required": ["options"],
 			"type": "object"
 		},
-		"__type_37": {
+		"__type_38": {
 			"additionalProperties": false,
 			"properties": {
 				"clientAPIVersion": {
@@ -7532,7 +7636,7 @@
 			},
 			"type": "object"
 		},
-		"__type_38": {
+		"__type_39": {
 			"additionalProperties": false,
 			"properties": {
 				"name": {
@@ -7544,22 +7648,6 @@
 					"type": "string"
 				}
 			},
-			"type": "object"
-		},
-		"__type_39": {
-			"additionalProperties": false,
-			"description": "Options for using privately hosted notification service.",
-			"properties": {
-				"manifestUrl": {
-					"description": "A custom manifest location to start the notification service from.\nThe UUID cannot be OpenFin hosted Notification Service UUID, 'notifications-service'.",
-					"type": "string"
-				},
-				"manifestUuid": {
-					"description": "The UUID of the provided custom notifications service manifest.\nThis value **MUST** match the UUID of the manifest provided in `manifestUrl`.",
-					"type": "string"
-				}
-			},
-			"required": ["manifestUrl", "manifestUuid"],
 			"type": "object"
 		},
 		"__type_4": {
@@ -7579,6 +7667,22 @@
 			"type": "object"
 		},
 		"__type_40": {
+			"additionalProperties": false,
+			"description": "Options for using privately hosted notification service.",
+			"properties": {
+				"manifestUrl": {
+					"description": "A custom manifest location to start the notification service from.\nThe UUID cannot be OpenFin hosted Notification Service UUID, 'notifications-service'.",
+					"type": "string"
+				},
+				"manifestUuid": {
+					"description": "The UUID of the provided custom notifications service manifest.\nThis value **MUST** match the UUID of the manifest provided in `manifestUrl`.",
+					"type": "string"
+				}
+			},
+			"required": ["manifestUrl", "manifestUuid"],
+			"type": "object"
+		},
+		"__type_41": {
 			"additionalProperties": false,
 			"properties": {
 				"interopSnapshotDetails": {
@@ -7617,7 +7721,7 @@
 			},
 			"type": "object"
 		},
-		"__type_41": {
+		"__type_42": {
 			"additionalProperties": false,
 			"properties": {
 				"deviceScaleFactor": {
@@ -7708,7 +7812,7 @@
 			],
 			"type": "object"
 		},
-		"__type_42": {
+		"__type_43": {
 			"additionalProperties": false,
 			"properties": {
 				"x": {
@@ -7723,7 +7827,7 @@
 			"required": ["x", "y"],
 			"type": "object"
 		},
-		"__type_43": {
+		"__type_44": {
 			"additionalProperties": false,
 			"properties": {
 				"dipRect": {
@@ -7736,7 +7840,7 @@
 			"required": ["dipRect", "scaledRect"],
 			"type": "object"
 		},
-		"__type_44": {
+		"__type_45": {
 			"additionalProperties": false,
 			"properties": {
 				"bottom": {
@@ -7755,7 +7859,7 @@
 			"required": ["bottom", "left", "right", "top"],
 			"type": "object"
 		},
-		"__type_45": {
+		"__type_46": {
 			"additionalProperties": false,
 			"properties": {
 				"available": {
@@ -7807,7 +7911,7 @@
 			],
 			"type": "object"
 		},
-		"__type_46": {
+		"__type_47": {
 			"additionalProperties": {
 				"additionalProperties": {
 					"additionalProperties": false,
@@ -7836,7 +7940,7 @@
 			},
 			"type": "object"
 		},
-		"__type_47": {
+		"__type_48": {
 			"additionalProperties": false,
 			"properties": {
 				"alias": {
@@ -7873,11 +7977,26 @@
 			},
 			"type": "object"
 		},
-		"__type_48": {
+		"__type_49": {
 			"additionalProperties": false,
 			"type": "object"
 		},
-		"__type_49": {
+		"__type_5": {
+			"additionalProperties": false,
+			"description": "Configures how new content (e,g, from `window.open` or a link) is opened.",
+			"properties": {
+				"rules": {
+					"description": "List of rules for creation of new content.",
+					"items": {
+						"$ref": "#/definitions/ContentCreationRule<ContentCreationBehavior>"
+					},
+					"type": "array"
+				}
+			},
+			"required": ["rules"],
+			"type": "object"
+		},
+		"__type_50": {
 			"additionalProperties": false,
 			"properties": {
 				"publickey": {
@@ -7898,22 +8017,7 @@
 			},
 			"type": "object"
 		},
-		"__type_5": {
-			"additionalProperties": false,
-			"description": "Configures how new content (e,g, from `window.open` or a link) is opened.",
-			"properties": {
-				"rules": {
-					"description": "List of rules for creation of new content.",
-					"items": {
-						"$ref": "#/definitions/ContentCreationRule<ContentCreationBehavior>"
-					},
-					"type": "array"
-				}
-			},
-			"required": ["rules"],
-			"type": "object"
-		},
-		"__type_50": {
+		"__type_51": {
 			"additionalProperties": false,
 			"properties": {
 				"alias": {
@@ -7943,7 +8047,7 @@
 			},
 			"type": "object"
 		},
-		"__type_51": {
+		"__type_52": {
 			"additionalProperties": false,
 			"properties": {
 				"height": {
@@ -7957,21 +8061,6 @@
 				},
 				"width": {
 					"type": "number"
-				}
-			},
-			"type": "object"
-		},
-		"__type_52": {
-			"additionalProperties": false,
-			"properties": {
-				"customData": {
-					"description": "A field that the user can attach serializable data to be ferried around with the window options.\n_When omitted, _inherits_ from the parent application._"
-				},
-				"interop": {
-					"$ref": "#/definitions/InteropConfig"
-				},
-				"url": {
-					"type": "string"
 				}
 			},
 			"type": "object"
@@ -7993,6 +8082,17 @@
 		},
 		"__type_54": {
 			"additionalProperties": false,
+			"properties": {
+				"customData": {
+					"description": "A field that the user can attach serializable data to be ferried around with the window options.\n_When omitted, _inherits_ from the parent application._"
+				},
+				"interop": {
+					"$ref": "#/definitions/InteropConfig"
+				},
+				"url": {
+					"type": "string"
+				}
+			},
 			"type": "object"
 		},
 		"__type_55": {
@@ -8000,6 +8100,10 @@
 			"type": "object"
 		},
 		"__type_56": {
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"__type_57": {
 			"additionalProperties": false,
 			"properties": {
 				"alias": {
@@ -8030,7 +8134,7 @@
 			"required": ["alias", "src", "version"],
 			"type": "object"
 		},
-		"__type_57": {
+		"__type_58": {
 			"additionalProperties": false,
 			"properties": {
 				"interopSnapshotDetails": {
@@ -8070,7 +8174,7 @@
 			"required": ["windows"],
 			"type": "object"
 		},
-		"__type_58": {
+		"__type_59": {
 			"additionalProperties": false,
 			"properties": {
 				"_internalWorkspaceData": {},
@@ -8106,6 +8210,9 @@
 				"backgroundColor": {
 					"description": "The window’s _backfill_ color as a hexadecimal value. Not to be confused with the content background color\n(`document.body.style.backgroundColor`),\nthis color briefly fills a window’s (a) content area before its content is loaded as well as (b) newly exposed\nareas when growing a window. Setting\nthis value to the anticipated content background color can help improve user experience.\nDefault is white.",
 					"type": "string"
+				},
+				"backgroundThrottling": {
+					"type": "boolean"
 				},
 				"closeOnLastViewRemoved": {
 					"type": "boolean"
@@ -8276,7 +8383,8 @@
 					"type": "number"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_6"
+					"$ref": "#/definitions/Partial_6",
+					"description": "API permissions for code running in the window."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -8342,6 +8450,10 @@
 					"description": "Specify a taskbar group for the window.\n_If omitted, defaults to app's uuid (`fin.Application.getCurrentSync().identity.uuid`)._",
 					"type": "string"
 				},
+				"throttling": {
+					"$ref": "#/definitions/WindowThrottling",
+					"description": "{@inheritDoc WindowThrottling}"
+				},
 				"url": {
 					"type": "string"
 				},
@@ -8370,34 +8482,6 @@
 				},
 				"y": {
 					"type": "number"
-				}
-			},
-			"type": "object"
-		},
-		"__type_59": {
-			"additionalProperties": false,
-			"properties": {
-				"contextGroups": {
-					"items": {
-						"additionalProperties": false,
-						"description": "Information for a Context Group. Contains metadata for displaying the group properly.",
-						"properties": {
-							"displayMetadata": {
-								"$ref": "#/definitions/DisplayMetadata_3",
-								"description": "Metadata for the Context Group. Contains the group's human-readable name, color, and an image, as defined by the Interop Broker."
-							},
-							"id": {
-								"description": "Unique identifier of the context group.",
-								"type": "string"
-							}
-						},
-						"required": ["id"],
-						"type": "object"
-					},
-					"type": "array"
-				},
-				"logging": {
-					"$ref": "#/definitions/InteropLoggingOptions"
 				}
 			},
 			"type": "object"
@@ -8438,6 +8522,9 @@
 				"backgroundColor": {
 					"description": "The window’s _backfill_ color as a hexadecimal value. Not to be confused with the content background color\n(`document.body.style.backgroundColor`),\nthis color briefly fills a window’s (a) content area before its content is loaded as well as (b) newly exposed\nareas when growing a window. Setting\nthis value to the anticipated content background color can help improve user experience.\nDefault is white.",
 					"type": "string"
+				},
+				"backgroundThrottling": {
+					"type": "boolean"
 				},
 				"closeOnLastViewRemoved": {
 					"type": "boolean"
@@ -8608,7 +8695,8 @@
 					"type": "number"
 				},
 				"permissions": {
-					"$ref": "#/definitions/Partial_6"
+					"$ref": "#/definitions/Partial_6",
+					"description": "API permissions for code running in the window."
 				},
 				"preloadScripts": {
 					"description": "Scripts that run before page load.  When omitted, inherits from the parent application.",
@@ -8670,6 +8758,10 @@
 					"description": "Specify a taskbar group for the window.\n_If omitted, defaults to app's uuid (`fin.Application.getCurrentSync().identity.uuid`)._",
 					"type": "string"
 				},
+				"throttling": {
+					"$ref": "#/definitions/WindowThrottling",
+					"description": "{@inheritDoc WindowThrottling}"
+				},
 				"url": {
 					"type": "string"
 				},
@@ -8704,6 +8796,34 @@
 		},
 		"__type_60": {
 			"additionalProperties": false,
+			"properties": {
+				"contextGroups": {
+					"items": {
+						"additionalProperties": false,
+						"description": "Information for a Context Group. Contains metadata for displaying the group properly.",
+						"properties": {
+							"displayMetadata": {
+								"$ref": "#/definitions/DisplayMetadata",
+								"description": "Metadata for the Context Group. Contains the group's human-readable name, color, and an image, as defined by the Interop Broker."
+							},
+							"id": {
+								"description": "Unique identifier of the context group.",
+								"type": "string"
+							}
+						},
+						"required": ["id"],
+						"type": "object"
+					},
+					"type": "array"
+				},
+				"logging": {
+					"$ref": "#/definitions/InteropLoggingOptions"
+				}
+			},
+			"type": "object"
+		},
+		"__type_61": {
+			"additionalProperties": false,
 			"description": "The display data for a context group.",
 			"properties": {
 				"color": {
@@ -8721,7 +8841,7 @@
 			},
 			"type": "object"
 		},
-		"__type_61": {
+		"__type_62": {
 			"additionalProperties": false,
 			"properties": {
 				"afterAction": {
@@ -8750,9 +8870,13 @@
 			"required": ["afterAction", "beforeAction"],
 			"type": "object"
 		},
-		"__type_62": {
+		"__type_63": {
 			"additionalProperties": false,
 			"properties": {
+				"default": {
+					"$ref": "#/definitions/PerDomainSettings",
+					"description": "Default values for settings in {@link DomainSettingsRule}."
+				},
 				"rules": {
 					"description": "{@inheritDoc DomainSettingsRule}",
 					"items": {
@@ -8765,23 +8889,16 @@
 								},
 								"type": "array"
 							},
+							"matchOptions": {
+								"$ref": "#/definitions/RuleMatchOptions",
+								"description": "Options to use when comparing URIs to the `match` patterns."
+							},
 							"options": {
-								"additionalProperties": false,
-								"description": "Settings applied when a webcontents has been navigated to a matched domain.",
-								"properties": {
-									"api": {
-										"$ref": "#/definitions/DomainApiSettings",
-										"description": "{@inheritDoc ApiInjection}"
-									},
-									"downloadSettings": {
-										"$ref": "#/definitions/FileDownloadSettings",
-										"description": "{@inheritDoc FileDownloadSettings}"
-									}
-								},
-								"type": "object"
+								"$ref": "#/definitions/PerDomainSettings",
+								"description": "Settings applied when a webcontents has been navigated to a matched domain."
 							}
 						},
-						"required": ["match", "options"],
+						"required": ["options"],
 						"type": "object"
 					},
 					"type": "array"
@@ -8790,7 +8907,25 @@
 			"required": ["rules"],
 			"type": "object"
 		},
-		"__type_63": {
+		"__type_64": {
+			"additionalProperties": false,
+			"properties": {
+				"api": {
+					"$ref": "#/definitions/DomainApiSettings",
+					"description": "{@inheritDoc ApiInjection}"
+				},
+				"content": {
+					"$ref": "#/definitions/ContentPermission",
+					"description": "Whether DOM content can be loaded (by navigation or redirect)."
+				},
+				"downloadSettings": {
+					"$ref": "#/definitions/FileDownloadSettings",
+					"description": "{@inheritDoc FileDownloadSettings}"
+				}
+			},
+			"type": "object"
+		},
+		"__type_65": {
 			"additionalProperties": false,
 			"description": "Domain-conditional rules for file downloads.",
 			"properties": {
@@ -8820,15 +8955,52 @@
 			"required": ["rules"],
 			"type": "object"
 		},
-		"__type_64": {
+		"__type_66": {
 			"additionalProperties": false,
 			"properties": {
 				"fin": {
 					"$ref": "#/definitions/InjectionType",
 					"description": "Injection setting for the `fin` API for contexts on a matched domain.\n\n* 'none': The `fin` API will be not available.\n* 'global': The entire `fin` API will be available."
+				},
+				"permissions": {
+					"$ref": "#/definitions/Permissions_2",
+					"description": "API permissions for domains matched to the current {@link DomainSettingsRule}."
 				}
 			},
-			"required": ["fin"],
+			"type": "object"
+		},
+		"__type_67": {
+			"additionalProperties": false,
+			"properties": {
+				"Application": {
+					"$ref": "#/definitions/Partial_7"
+				},
+				"System": {
+					"$ref": "#/definitions/Partial_8"
+				},
+				"devices": {
+					"items": {
+						"additionalProperties": false,
+						"properties": {
+							"productId": {
+								"type": ["string", "number"]
+							},
+							"vendorId": {
+								"type": ["string", "number"]
+							}
+						},
+						"required": ["productId", "vendorId"],
+						"type": "object"
+					},
+					"type": "array"
+				},
+				"webAPIs": {
+					"items": {
+						"$ref": "#/definitions/WebPermission"
+					},
+					"type": "array"
+				}
+			},
 			"type": "object"
 		},
 		"__type_7": {


### PR DESCRIPTION
Something that has come up is use cases where you have a context listener that never wants any context that has been sent from the same webpage and instance.

There are ways of doing this so you ignore context messages sent from yourself (and we updated the doc for this) but now we also have a configuration option so you can specify that you do not want the originator of a context message to receive it.