### PR TITLE
Updated samples to fdc3 2.0 & enhanced broker and notification service

### DIFF
--- a/how-to/register-with-home/public/common/apps-contact.json
+++ b/how-to/register-with-home/public/common/apps-contact.json
@@ -187,6 +187,7 @@
 		"name": "client-overview",
 		"title": "Client Overview",
 		"manifestType": "snapshot",
+		"instanceMode": "new",
 		"description": "Provides a summary of the current client",
 		"manifest": "http://localhost:8080/common/snapshots/contact-overview.snapshot.fin.json",
 		"icons": [

--- a/how-to/register-with-home/public/common/snapshots/contact-overview.snapshot.fin.json
+++ b/how-to/register-with-home/public/common/snapshots/contact-overview.snapshot.fin.json
@@ -186,6 +186,7 @@
 													{
 														"type": "component",
 														"componentName": "view",
+
 														"componentState": {
 															"bounds": {
 																"x": 1,
@@ -199,7 +200,7 @@
 															"preventDragOut": false,
 															"url": "http://localhost:8080/common/views/contact/participant-summary/index.html",
 															"componentName": "view",
-															"fdc3InteropApi": "1.2",
+															"fdc3InteropApi": "2.0",
 															"interop": {
 																"currentContextGroup": "green"
 															},
@@ -334,7 +335,7 @@
 															"preventDragOut": false,
 															"url": "http://localhost:8080/common/views/contact/investments-and-models/index.html",
 															"componentName": "view",
-															"fdc3InteropApi": "1.2",
+															"fdc3InteropApi": "2.0",
 															"interop": {
 																"currentContextGroup": "green"
 															},
@@ -485,7 +486,7 @@
 																	"preventDragOut": false,
 																	"url": "http://localhost:8080/common/views/contact/participant-history/index.html",
 																	"componentName": "view",
-																	"fdc3InteropApi": "1.2",
+																	"fdc3InteropApi": "2.0",
 																	"interop": {
 																		"currentContextGroup": "green"
 																	},

--- a/how-to/register-with-home/public/common/views/contact/common/contacts.js
+++ b/how-to/register-with-home/public/common/views/contact/common/contacts.js
@@ -7,7 +7,9 @@ let avatarRoot = '../data/avatars/';
 export async function initialize() {
 	const customSettings = await getManifestCustomSettings();
 
-	const response = await fetch(customSettings.contactsProvider?.url ?? '../data/contacts.json');
+	const contactsProviderUrl = getContactsProviderUrl() ?? customSettings.contactsProvider?.url;
+	console.log(`contactsProviderUrl = ${contactsProviderUrl}`);
+	const response = await fetch(contactsProviderUrl ?? '../data/contacts.json');
 
 	avatarRoot = customSettings.contactsProvider?.avatarRoot ?? avatarRoot;
 
@@ -92,4 +94,32 @@ async function getManifestCustomSettings() {
 		// not inside of an OpenFin container or there isn't app support.
 	}
 	return {};
+}
+
+/**
+ * Tries to get a url from the query string to override the contacts provider.
+ * @returns The contacts provider url if found.
+ */
+function getContactsProviderUrl() {
+	// Get the URL parameters
+	console.log('Attempting to get URL Params...');
+	const urlParams = new URLSearchParams(window.location.search);
+	const contactsProviderUrl = urlParams.get('contactsProviderUrl');
+
+	if (!contactsProviderUrl) {
+		return;
+	}
+
+	try {
+		const url = new URL(contactsProviderUrl);
+		const validDomains = ['openfin.github.io', 'built-on-openfin.github.io'];
+
+		if (validDomains.includes(url.hostname)) {
+			console.log('Valid contactsProviderUrl override url provided:', contactsProviderUrl);
+			return url.href;
+		}
+		console.error('Invalid domain in contactsProviderUrl:', url.hostname);
+	} catch {
+		console.error('Invalid contactsProviderUrl URL:', contactsProviderUrl);
+	}
 }

--- a/how-to/register-with-home/public/common/views/contact/investments-and-models.view.fin.json
+++ b/how-to/register-with-home/public/common/views/contact/investments-and-models.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/contact/investments-and-models/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/register-with-home/public/common/views/contact/participant-selection.view.fin.json
+++ b/how-to/register-with-home/public/common/views/contact/participant-selection.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/contact/participant-selection/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/register-with-home/public/common/views/contact/participant-summary.view.fin.json
+++ b/how-to/register-with-home/public/common/views/contact/participant-summary.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/contact/participant-summary/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/register-with-home/public/common/views/contact/participant-summary.window.fin.json
+++ b/how-to/register-with-home/public/common/views/contact/participant-summary.window.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/contact/participant-summary/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/register-with-home/public/common/views/contact/participant-summary/index.js
+++ b/how-to/register-with-home/public/common/views/contact/participant-summary/index.js
@@ -6,11 +6,6 @@ window.addEventListener('DOMContentLoaded', initializeDOM);
  * Initialize the DOM.
  */
 async function initializeDOM() {
-	const contextPicker = document.querySelector('#context-group-picker');
-	if (window.fin) {
-		contextPicker.style.display = fin.me.isWindow ? 'block' : 'none';
-	}
-
 	if (window.fdc3 !== undefined) {
 		setupListeners();
 	} else {
@@ -25,6 +20,10 @@ async function initializeDOM() {
  */
 async function setupListeners() {
 	try {
+		const contextPicker = document.querySelector('#context-group-picker');
+		if (window.fin && contextPicker !== null) {
+			contextPicker.style.display = fin.me.isWindow ? 'block' : 'none';
+		}
 		await usersModule.initialize();
 
 		window.fdc3.addContextListener(contextHandler);

--- a/how-to/register-with-store/public/common/apps-contact.json
+++ b/how-to/register-with-store/public/common/apps-contact.json
@@ -187,6 +187,7 @@
 		"name": "client-overview",
 		"title": "Client Overview",
 		"manifestType": "snapshot",
+		"instanceMode": "new",
 		"description": "Provides a summary of the current client",
 		"manifest": "http://localhost:8080/common/snapshots/contact-overview.snapshot.fin.json",
 		"icons": [

--- a/how-to/register-with-store/public/common/snapshots/contact-overview.snapshot.fin.json
+++ b/how-to/register-with-store/public/common/snapshots/contact-overview.snapshot.fin.json
@@ -186,6 +186,7 @@
 													{
 														"type": "component",
 														"componentName": "view",
+
 														"componentState": {
 															"bounds": {
 																"x": 1,
@@ -199,7 +200,7 @@
 															"preventDragOut": false,
 															"url": "http://localhost:8080/common/views/contact/participant-summary/index.html",
 															"componentName": "view",
-															"fdc3InteropApi": "1.2",
+															"fdc3InteropApi": "2.0",
 															"interop": {
 																"currentContextGroup": "green"
 															},
@@ -334,7 +335,7 @@
 															"preventDragOut": false,
 															"url": "http://localhost:8080/common/views/contact/investments-and-models/index.html",
 															"componentName": "view",
-															"fdc3InteropApi": "1.2",
+															"fdc3InteropApi": "2.0",
 															"interop": {
 																"currentContextGroup": "green"
 															},
@@ -485,7 +486,7 @@
 																	"preventDragOut": false,
 																	"url": "http://localhost:8080/common/views/contact/participant-history/index.html",
 																	"componentName": "view",
-																	"fdc3InteropApi": "1.2",
+																	"fdc3InteropApi": "2.0",
 																	"interop": {
 																		"currentContextGroup": "green"
 																	},

--- a/how-to/register-with-store/public/common/views/contact/common/contacts.js
+++ b/how-to/register-with-store/public/common/views/contact/common/contacts.js
@@ -7,7 +7,9 @@ let avatarRoot = '../data/avatars/';
 export async function initialize() {
 	const customSettings = await getManifestCustomSettings();
 
-	const response = await fetch(customSettings.contactsProvider?.url ?? '../data/contacts.json');
+	const contactsProviderUrl = getContactsProviderUrl() ?? customSettings.contactsProvider?.url;
+	console.log(`contactsProviderUrl = ${contactsProviderUrl}`);
+	const response = await fetch(contactsProviderUrl ?? '../data/contacts.json');
 
 	avatarRoot = customSettings.contactsProvider?.avatarRoot ?? avatarRoot;
 
@@ -92,4 +94,32 @@ async function getManifestCustomSettings() {
 		// not inside of an OpenFin container or there isn't app support.
 	}
 	return {};
+}
+
+/**
+ * Tries to get a url from the query string to override the contacts provider.
+ * @returns The contacts provider url if found.
+ */
+function getContactsProviderUrl() {
+	// Get the URL parameters
+	console.log('Attempting to get URL Params...');
+	const urlParams = new URLSearchParams(window.location.search);
+	const contactsProviderUrl = urlParams.get('contactsProviderUrl');
+
+	if (!contactsProviderUrl) {
+		return;
+	}
+
+	try {
+		const url = new URL(contactsProviderUrl);
+		const validDomains = ['openfin.github.io', 'built-on-openfin.github.io'];
+
+		if (validDomains.includes(url.hostname)) {
+			console.log('Valid contactsProviderUrl override url provided:', contactsProviderUrl);
+			return url.href;
+		}
+		console.error('Invalid domain in contactsProviderUrl:', url.hostname);
+	} catch {
+		console.error('Invalid contactsProviderUrl URL:', contactsProviderUrl);
+	}
 }

--- a/how-to/register-with-store/public/common/views/contact/investments-and-models.view.fin.json
+++ b/how-to/register-with-store/public/common/views/contact/investments-and-models.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/contact/investments-and-models/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/register-with-store/public/common/views/contact/participant-selection.view.fin.json
+++ b/how-to/register-with-store/public/common/views/contact/participant-selection.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/contact/participant-selection/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/register-with-store/public/common/views/contact/participant-summary.view.fin.json
+++ b/how-to/register-with-store/public/common/views/contact/participant-summary.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/contact/participant-summary/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/register-with-store/public/common/views/contact/participant-summary.window.fin.json
+++ b/how-to/register-with-store/public/common/views/contact/participant-summary.window.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/contact/participant-summary/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/register-with-store/public/common/views/contact/participant-summary/index.js
+++ b/how-to/register-with-store/public/common/views/contact/participant-summary/index.js
@@ -6,11 +6,6 @@ window.addEventListener('DOMContentLoaded', initializeDOM);
  * Initialize the DOM.
  */
 async function initializeDOM() {
-	const contextPicker = document.querySelector('#context-group-picker');
-	if (window.fin) {
-		contextPicker.style.display = fin.me.isWindow ? 'block' : 'none';
-	}
-
 	if (window.fdc3 !== undefined) {
 		setupListeners();
 	} else {
@@ -25,6 +20,10 @@ async function initializeDOM() {
  */
 async function setupListeners() {
 	try {
+		const contextPicker = document.querySelector('#context-group-picker');
+		if (window.fin && contextPicker !== null) {
+			contextPicker.style.display = fin.me.isWindow ? 'block' : 'none';
+		}
 		await usersModule.initialize();
 
 		window.fdc3.addContextListener(contextHandler);

--- a/how-to/support-context-and-intents/public/common/apps-contact.json
+++ b/how-to/support-context-and-intents/public/common/apps-contact.json
@@ -187,6 +187,7 @@
 		"name": "client-overview",
 		"title": "Client Overview",
 		"manifestType": "snapshot",
+		"instanceMode": "new",
 		"description": "Provides a summary of the current client",
 		"manifest": "http://localhost:8080/common/snapshots/contact-overview.snapshot.fin.json",
 		"icons": [

--- a/how-to/support-context-and-intents/public/common/snapshots/contact-overview.snapshot.fin.json
+++ b/how-to/support-context-and-intents/public/common/snapshots/contact-overview.snapshot.fin.json
@@ -186,6 +186,7 @@
 													{
 														"type": "component",
 														"componentName": "view",
+
 														"componentState": {
 															"bounds": {
 																"x": 1,
@@ -199,7 +200,7 @@
 															"preventDragOut": false,
 															"url": "http://localhost:8080/common/views/contact/participant-summary/index.html",
 															"componentName": "view",
-															"fdc3InteropApi": "1.2",
+															"fdc3InteropApi": "2.0",
 															"interop": {
 																"currentContextGroup": "green"
 															},
@@ -334,7 +335,7 @@
 															"preventDragOut": false,
 															"url": "http://localhost:8080/common/views/contact/investments-and-models/index.html",
 															"componentName": "view",
-															"fdc3InteropApi": "1.2",
+															"fdc3InteropApi": "2.0",
 															"interop": {
 																"currentContextGroup": "green"
 															},
@@ -485,7 +486,7 @@
 																	"preventDragOut": false,
 																	"url": "http://localhost:8080/common/views/contact/participant-history/index.html",
 																	"componentName": "view",
-																	"fdc3InteropApi": "1.2",
+																	"fdc3InteropApi": "2.0",
 																	"interop": {
 																		"currentContextGroup": "green"
 																	},

--- a/how-to/support-context-and-intents/public/common/views/contact/common/contacts.js
+++ b/how-to/support-context-and-intents/public/common/views/contact/common/contacts.js
@@ -7,7 +7,9 @@ let avatarRoot = '../data/avatars/';
 export async function initialize() {
 	const customSettings = await getManifestCustomSettings();
 
-	const response = await fetch(customSettings.contactsProvider?.url ?? '../data/contacts.json');
+	const contactsProviderUrl = getContactsProviderUrl() ?? customSettings.contactsProvider?.url;
+	console.log(`contactsProviderUrl = ${contactsProviderUrl}`);
+	const response = await fetch(contactsProviderUrl ?? '../data/contacts.json');
 
 	avatarRoot = customSettings.contactsProvider?.avatarRoot ?? avatarRoot;
 
@@ -92,4 +94,32 @@ async function getManifestCustomSettings() {
 		// not inside of an OpenFin container or there isn't app support.
 	}
 	return {};
+}
+
+/**
+ * Tries to get a url from the query string to override the contacts provider.
+ * @returns The contacts provider url if found.
+ */
+function getContactsProviderUrl() {
+	// Get the URL parameters
+	console.log('Attempting to get URL Params...');
+	const urlParams = new URLSearchParams(window.location.search);
+	const contactsProviderUrl = urlParams.get('contactsProviderUrl');
+
+	if (!contactsProviderUrl) {
+		return;
+	}
+
+	try {
+		const url = new URL(contactsProviderUrl);
+		const validDomains = ['openfin.github.io', 'built-on-openfin.github.io'];
+
+		if (validDomains.includes(url.hostname)) {
+			console.log('Valid contactsProviderUrl override url provided:', contactsProviderUrl);
+			return url.href;
+		}
+		console.error('Invalid domain in contactsProviderUrl:', url.hostname);
+	} catch {
+		console.error('Invalid contactsProviderUrl URL:', contactsProviderUrl);
+	}
 }

--- a/how-to/support-context-and-intents/public/common/views/contact/investments-and-models.view.fin.json
+++ b/how-to/support-context-and-intents/public/common/views/contact/investments-and-models.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/contact/investments-and-models/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/support-context-and-intents/public/common/views/contact/participant-selection.view.fin.json
+++ b/how-to/support-context-and-intents/public/common/views/contact/participant-selection.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/contact/participant-selection/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/support-context-and-intents/public/common/views/contact/participant-summary.view.fin.json
+++ b/how-to/support-context-and-intents/public/common/views/contact/participant-summary.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/contact/participant-summary/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/support-context-and-intents/public/common/views/contact/participant-summary.window.fin.json
+++ b/how-to/support-context-and-intents/public/common/views/contact/participant-summary.window.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/contact/participant-summary/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/support-context-and-intents/public/common/views/contact/participant-summary/index.js
+++ b/how-to/support-context-and-intents/public/common/views/contact/participant-summary/index.js
@@ -6,11 +6,6 @@ window.addEventListener('DOMContentLoaded', initializeDOM);
  * Initialize the DOM.
  */
 async function initializeDOM() {
-	const contextPicker = document.querySelector('#context-group-picker');
-	if (window.fin) {
-		contextPicker.style.display = fin.me.isWindow ? 'block' : 'none';
-	}
-
 	if (window.fdc3 !== undefined) {
 		setupListeners();
 	} else {
@@ -25,6 +20,10 @@ async function initializeDOM() {
  */
 async function setupListeners() {
 	try {
+		const contextPicker = document.querySelector('#context-group-picker');
+		if (window.fin && contextPicker !== null) {
+			contextPicker.style.display = fin.me.isWindow ? 'block' : 'none';
+		}
 		await usersModule.initialize();
 
 		window.fdc3.addContextListener(contextHandler);

--- a/how-to/support-context-and-intents/public/common/views/google/preload-google.view.fin.json
+++ b/how-to/support-context-and-intents/public/common/views/google/preload-google.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "https://www.google.com/search?q=aapl",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/support-context-and-intents/public/common/views/tradingview/preload-tradingview.view.fin.json
+++ b/how-to/support-context-and-intents/public/common/views/tradingview/preload-tradingview.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "https://www.tradingview.com/chart/?symbol=AAPL",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/use-theming-basic/public/common/style/style-view.json
+++ b/how-to/use-theming-basic/public/common/style/style-view.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/style/style.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"customData": {},
 	"preloadScripts": [
 		{

--- a/how-to/use-theming/public/common/style/style-view.json
+++ b/how-to/use-theming/public/common/style/style-view.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/style/style.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"customData": {},
 	"preloadScripts": [
 		{

--- a/how-to/workspace-platform-starter-basic/public/common/snapshots/contact-overview.snapshot.fin.json
+++ b/how-to/workspace-platform-starter-basic/public/common/snapshots/contact-overview.snapshot.fin.json
@@ -186,6 +186,7 @@
 													{
 														"type": "component",
 														"componentName": "view",
+
 														"componentState": {
 															"bounds": {
 																"x": 1,
@@ -199,7 +200,7 @@
 															"preventDragOut": false,
 															"url": "http://localhost:8080/common/views/contact/participant-summary/index.html",
 															"componentName": "view",
-															"fdc3InteropApi": "1.2",
+															"fdc3InteropApi": "2.0",
 															"interop": {
 																"currentContextGroup": "green"
 															},
@@ -334,7 +335,7 @@
 															"preventDragOut": false,
 															"url": "http://localhost:8080/common/views/contact/investments-and-models/index.html",
 															"componentName": "view",
-															"fdc3InteropApi": "1.2",
+															"fdc3InteropApi": "2.0",
 															"interop": {
 																"currentContextGroup": "green"
 															},
@@ -485,7 +486,7 @@
 																	"preventDragOut": false,
 																	"url": "http://localhost:8080/common/views/contact/participant-history/index.html",
 																	"componentName": "view",
-																	"fdc3InteropApi": "1.2",
+																	"fdc3InteropApi": "2.0",
 																	"interop": {
 																		"currentContextGroup": "green"
 																	},

--- a/how-to/workspace-platform-starter-basic/public/common/views/contact/common/contacts.js
+++ b/how-to/workspace-platform-starter-basic/public/common/views/contact/common/contacts.js
@@ -7,7 +7,9 @@ let avatarRoot = '../data/avatars/';
 export async function initialize() {
 	const customSettings = await getManifestCustomSettings();
 
-	const response = await fetch(customSettings.contactsProvider?.url ?? '../data/contacts.json');
+	const contactsProviderUrl = getContactsProviderUrl() ?? customSettings.contactsProvider?.url;
+	console.log(`contactsProviderUrl = ${contactsProviderUrl}`);
+	const response = await fetch(contactsProviderUrl ?? '../data/contacts.json');
 
 	avatarRoot = customSettings.contactsProvider?.avatarRoot ?? avatarRoot;
 
@@ -92,4 +94,32 @@ async function getManifestCustomSettings() {
 		// not inside of an OpenFin container or there isn't app support.
 	}
 	return {};
+}
+
+/**
+ * Tries to get a url from the query string to override the contacts provider.
+ * @returns The contacts provider url if found.
+ */
+function getContactsProviderUrl() {
+	// Get the URL parameters
+	console.log('Attempting to get URL Params...');
+	const urlParams = new URLSearchParams(window.location.search);
+	const contactsProviderUrl = urlParams.get('contactsProviderUrl');
+
+	if (!contactsProviderUrl) {
+		return;
+	}
+
+	try {
+		const url = new URL(contactsProviderUrl);
+		const validDomains = ['openfin.github.io', 'built-on-openfin.github.io'];
+
+		if (validDomains.includes(url.hostname)) {
+			console.log('Valid contactsProviderUrl override url provided:', contactsProviderUrl);
+			return url.href;
+		}
+		console.error('Invalid domain in contactsProviderUrl:', url.hostname);
+	} catch {
+		console.error('Invalid contactsProviderUrl URL:', contactsProviderUrl);
+	}
 }

--- a/how-to/workspace-platform-starter-basic/public/common/views/contact/investments-and-models.view.fin.json
+++ b/how-to/workspace-platform-starter-basic/public/common/views/contact/investments-and-models.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/contact/investments-and-models/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/workspace-platform-starter-basic/public/common/views/contact/participant-selection.view.fin.json
+++ b/how-to/workspace-platform-starter-basic/public/common/views/contact/participant-selection.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/contact/participant-selection/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/workspace-platform-starter-basic/public/common/views/contact/participant-summary.view.fin.json
+++ b/how-to/workspace-platform-starter-basic/public/common/views/contact/participant-summary.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/contact/participant-summary/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/workspace-platform-starter-basic/public/common/views/contact/participant-summary.window.fin.json
+++ b/how-to/workspace-platform-starter-basic/public/common/views/contact/participant-summary.window.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/contact/participant-summary/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/workspace-platform-starter-basic/public/common/views/contact/participant-summary/index.js
+++ b/how-to/workspace-platform-starter-basic/public/common/views/contact/participant-summary/index.js
@@ -6,11 +6,6 @@ window.addEventListener('DOMContentLoaded', initializeDOM);
  * Initialize the DOM.
  */
 async function initializeDOM() {
-	const contextPicker = document.querySelector('#context-group-picker');
-	if (window.fin) {
-		contextPicker.style.display = fin.me.isWindow ? 'block' : 'none';
-	}
-
 	if (window.fdc3 !== undefined) {
 		setupListeners();
 	} else {
@@ -25,6 +20,10 @@ async function initializeDOM() {
  */
 async function setupListeners() {
 	try {
+		const contextPicker = document.querySelector('#context-group-picker');
+		if (window.fin && contextPicker !== null) {
+			contextPicker.style.display = fin.me.isWindow ? 'block' : 'none';
+		}
 		await usersModule.initialize();
 
 		window.fdc3.addContextListener(contextHandler);

--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -19,6 +19,13 @@
 - Moved some of the modules that were in webpack.config.js into the right webpack file starter-modules.webpack.config.js so it doesn't slow down your npm builds when you run build-client-modules (which only builds modules you have generated).
 - Added an example notification service app with actions to send messages to the example notification service.
 - Added extra checks to the platform overrides related to fetching pages and workspace from custom storage (an endpoint). They now perform additional checks in case the server doesn't return any values but does return an empty object.
+- Updated samples to use fdc3 2.0 instead of 1.2 to support richer getInfo calls.
+- Updated WPS docs to promote 2.0 instead of 1.2 in the examples.
+- Updated WPS Interop Override:
+  - FDC3 open now supports passing context to all views it opens in a snapshot and not just the first one. We also check to see if it registers before firing based on a specified timeout. We don't await this so as not to slow down the response to the raiser.
+  - FDC3 Intent Firing when targeting a snapshot now waits to fire the intent until each view registers an intent handler or times out. We don't await this so as not to slow down the response to the raiser.
+- Example notification service launch-app action now supports passing the appId and instanceId (id in the root of customData still needs to be specified) in the target field of customData. Context can also be passed now. This will use fdc3.open. If you specify an instanceId and a timeout error is thrown (if the instance is no longer running) then it falls back to launching a new instance of the app and passing it the context if specified. Updated documentation.
+- Updated example-notification-service-app to show raising a notification that has a call to action that passes data back to itself (or a new instance if it is closed) though a context listener.
 
 ## v19.0.0
 

--- a/how-to/workspace-platform-starter/client/src/modules/composite/developer/actions.ts
+++ b/how-to/workspace-platform-starter/client/src/modules/composite/developer/actions.ts
@@ -85,7 +85,7 @@ export class DeveloperActions implements Actions {
 						const options = await view.getOptions();
 						const info = await view.getInfo();
 						const name = options.name;
-						const fdc3InteropApi = isStringValue(options.fdc3InteropApi) ? options.fdc3InteropApi : "1.2";
+						const fdc3InteropApi = isStringValue(options.fdc3InteropApi) ? options.fdc3InteropApi : "2.0";
 						const preloads =
 							Array.isArray(options.preloadScripts) && options.preloadScripts.length > 0
 								? options.preloadScripts

--- a/how-to/workspace-platform-starter/client/src/modules/lifecycle/example-notification-service/README.md
+++ b/how-to/workspace-platform-starter/client/src/modules/lifecycle/example-notification-service/README.md
@@ -255,6 +255,44 @@ let launchAppNotification = {
 };
 ```
 
+How to specify a notification that launches an app, targets a specific instance (e.g. itself) and passes context to the apps context handler (so you don't need an intent to be registered to get some data back):
+
+```js
+let launchAppNotification = {
+  type: 'openfin.notificationoptions',
+  notification: {
+    id: 'guid-goes-here',
+    title: 'Example Launches App',
+    body: 'Click the button to launch an app.',
+    buttons: [
+      {
+        onClick: {
+          task: 'launch-app',
+          customData: {
+            id: 'call-app',
+            context: {
+              type: 'fdc3.contact',
+              name: 'John Example',
+              id: {
+                email: 'john@example.com',
+                phone: 'Number goes here'
+              }
+            },
+            target: {
+              appId: 'call-app',
+              instanceId: 'instanceId if available'
+            }
+          }
+        },
+        cta: true,
+        title: 'Open Call App',
+        type: 'button'
+      }
+    ]
+  }
+};
+```
+
 How to specify a notification that launches saved content i.e. a page:
 
 ```js

--- a/how-to/workspace-platform-starter/docs/how-to-add-context-support-to-your-app.md
+++ b/how-to/workspace-platform-starter/docs/how-to-add-context-support-to-your-app.md
@@ -11,7 +11,7 @@ The first thing your app should do is to highlight that it supports the FDC3 sta
 ```json
 {
     "url": "https://fdc3.finos.org/toolbox/fdc3-workbench/",
-    "fdc3InteropApi": "1.2"
+    "fdc3InteropApi": "2.0"
 },
 ```
 
@@ -20,7 +20,7 @@ A workspace platform can define a set of contextual groups (system channels). Yo
 ```json
 {
     "url": "https://fdc3.finos.org/toolbox/fdc3-workbench/",
-    "fdc3InteropApi": "1.2",
+    "fdc3InteropApi": "2.0",
     "interop": {
         "currentContextGroup": "green"
     }
@@ -263,7 +263,7 @@ Yes, to make development easier you can define a view that uses our app. We foll
 ```javascript
 {
     "url": "https://samples.openfin.co/dev-extensions/extensions/v19.1.0/interop/fdc3/context/fdc3-broadcast-view.html",
-    "fdc3InteropApi": "1.2",
+    "fdc3InteropApi": "2.0",
     "customData": {
         "contextData": null,
         "customChannel": ""

--- a/how-to/workspace-platform-starter/docs/how-to-add-intent-support-to-your-app.md
+++ b/how-to/workspace-platform-starter/docs/how-to-add-intent-support-to-your-app.md
@@ -11,7 +11,7 @@ The first thing your app should do is to highlight that it supports the FDC3 sta
 ```json
 {
     "url": "https://fdc3.finos.org/toolbox/fdc3-workbench/",
-    "fdc3InteropApi": "1.2"
+    "fdc3InteropApi": "2.0"
 },
 ```
 

--- a/how-to/workspace-platform-starter/docs/how-to-add-open-support-to-your-app.md
+++ b/how-to/workspace-platform-starter/docs/how-to-add-open-support-to-your-app.md
@@ -11,7 +11,7 @@ The first thing your app should do is to highlight that it supports the FDC3 sta
 ```json
 {
     "url": "https://fdc3.finos.org/toolbox/fdc3-workbench/",
-    "fdc3InteropApi": "1.2"
+    "fdc3InteropApi": "2.0"
 },
 ```
 

--- a/how-to/workspace-platform-starter/public/common/apps-contact.json
+++ b/how-to/workspace-platform-starter/public/common/apps-contact.json
@@ -187,6 +187,7 @@
 		"name": "client-overview",
 		"title": "Client Overview",
 		"manifestType": "snapshot",
+		"instanceMode": "new",
 		"description": "Provides a summary of the current client",
 		"manifest": "http://localhost:8080/common/snapshots/contact-overview.snapshot.fin.json",
 		"icons": [

--- a/how-to/workspace-platform-starter/public/common/snapshots/contact-overview.snapshot.fin.json
+++ b/how-to/workspace-platform-starter/public/common/snapshots/contact-overview.snapshot.fin.json
@@ -200,7 +200,7 @@
 															"preventDragOut": false,
 															"url": "http://localhost:8080/common/views/contact/participant-summary/index.html",
 															"componentName": "view",
-															"fdc3InteropApi": "1.2",
+															"fdc3InteropApi": "2.0",
 															"interop": {
 																"currentContextGroup": "green"
 															},
@@ -335,7 +335,7 @@
 															"preventDragOut": false,
 															"url": "http://localhost:8080/common/views/contact/investments-and-models/index.html",
 															"componentName": "view",
-															"fdc3InteropApi": "1.2",
+															"fdc3InteropApi": "2.0",
 															"interop": {
 																"currentContextGroup": "green"
 															},
@@ -486,7 +486,7 @@
 																	"preventDragOut": false,
 																	"url": "http://localhost:8080/common/views/contact/participant-history/index.html",
 																	"componentName": "view",
-																	"fdc3InteropApi": "1.2",
+																	"fdc3InteropApi": "2.0",
 																	"interop": {
 																		"currentContextGroup": "green"
 																	},

--- a/how-to/workspace-platform-starter/public/common/snapshots/template-contact-dashboard.snapshot.fin.json
+++ b/how-to/workspace-platform-starter/public/common/snapshots/template-contact-dashboard.snapshot.fin.json
@@ -66,7 +66,7 @@
 																	"componentState": {
 																		"url": "http://localhost:8080/common/views/contact/participant-summary/index.html",
 																		"componentName": "view",
-																		"fdc3InteropApi": "1.2",
+																		"fdc3InteropApi": "2.0",
 																		"interop": { "currentContextGroup": "{CONTEXT_GROUP}" },
 																		"preloadScripts": [
 																			{
@@ -82,7 +82,7 @@
 																	"componentState": {
 																		"url": "http://localhost:8080/common/views/contact/investments-and-models/index.html",
 																		"componentName": "view",
-																		"fdc3InteropApi": "1.2",
+																		"fdc3InteropApi": "2.0",
 																		"interop": { "currentContextGroup": "{CONTEXT_GROUP}" },
 																		"preloadScripts": [
 																			{
@@ -108,7 +108,7 @@
 																	"componentState": {
 																		"url": "http://localhost:8080/common/views/contact/participant-history/index.html",
 																		"componentName": "view",
-																		"fdc3InteropApi": "1.2",
+																		"fdc3InteropApi": "2.0",
 																		"interop": { "currentContextGroup": "{CONTEXT_GROUP}" },
 																		"preloadScripts": [
 																			{
@@ -124,7 +124,7 @@
 																	"componentState": {
 																		"url": "http://localhost:8080/common/views/contact/participant-selection/index.html",
 																		"componentName": "view",
-																		"fdc3InteropApi": "1.2",
+																		"fdc3InteropApi": "2.0",
 																		"interop": { "currentContextGroup": "{CONTEXT_GROUP}" },
 																		"preloadScripts": [
 																			{

--- a/how-to/workspace-platform-starter/public/common/style/style-view.json
+++ b/how-to/workspace-platform-starter/public/common/style/style-view.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/style/style.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"customData": {},
 	"preloadScripts": [
 		{

--- a/how-to/workspace-platform-starter/public/common/views/contact/investments-and-models.view.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/contact/investments-and-models.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/contact/investments-and-models/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/workspace-platform-starter/public/common/views/contact/participant-selection.view.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/contact/participant-selection.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/contact/participant-selection/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/workspace-platform-starter/public/common/views/contact/participant-summary.view.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/contact/participant-summary.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/contact/participant-summary/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/workspace-platform-starter/public/common/views/contact/participant-summary.window.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/contact/participant-summary.window.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/contact/participant-summary/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/workspace-platform-starter/public/common/views/fdc3/workbench/fdc3-workbench.view.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/fdc3/workbench/fdc3-workbench.view.fin.json
@@ -1,4 +1,4 @@
 {
 	"url": "https://fdc3.finos.org/toolbox/fdc3-workbench/",
-	"fdc3InteropApi": "1.2"
+	"fdc3InteropApi": "2.0"
 }

--- a/how-to/workspace-platform-starter/public/common/views/google/preload-google.view.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/google/preload-google.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "https://www.google.com/search?q=aapl",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/workspace-platform-starter/public/common/views/manager-portal/360-feedback.view.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/manager-portal/360-feedback.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/manager-portal/360-feedback/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "orange"
 	}

--- a/how-to/workspace-platform-starter/public/common/views/manager-portal/annual-leave.view.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/manager-portal/annual-leave.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/manager-portal/annual-leave/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "orange"
 	}

--- a/how-to/workspace-platform-starter/public/common/views/manager-portal/company-cal.view.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/manager-portal/company-cal.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/manager-portal/company-cal/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "orange"
 	}

--- a/how-to/workspace-platform-starter/public/common/views/manager-portal/company-comms.view.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/manager-portal/company-comms.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/manager-portal/company-comms/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "orange"
 	}

--- a/how-to/workspace-platform-starter/public/common/views/manager-portal/franchise-comms.view.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/manager-portal/franchise-comms.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/manager-portal/franchise-comms/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "orange"
 	}

--- a/how-to/workspace-platform-starter/public/common/views/manager-portal/keeping-track.view.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/manager-portal/keeping-track.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/manager-portal/keeping-track/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "orange"
 	}

--- a/how-to/workspace-platform-starter/public/common/views/manager-portal/manager-paths.view.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/manager-portal/manager-paths.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/manager-portal/manager-paths/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "orange"
 	}

--- a/how-to/workspace-platform-starter/public/common/views/manager-portal/manager-portal-fixed.snapshot.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/manager-portal/manager-portal-fixed.snapshot.fin.json
@@ -26,7 +26,7 @@
 														"name": "internal-generated-view-b9880bc2-2983-4b3c-a496-77d94783cb7e",
 														"url": "http://localhost:8080/common/views/manager-portal/my-team/index.html",
 														"uuid": "b9880bc2-2983-4b3c-a496-77d94783cb7e",
-														"fdc3InteropApi": "1.2",
+														"fdc3InteropApi": "2.0",
 														"interop": {
 															"currentContextGroup": "orange"
 														},
@@ -60,7 +60,7 @@
 																"name": "internal-generated-view-0dd98149-16fb-4cf0-9b2a-d5bff2519d9b",
 																"url": "http://localhost:8080/common/views/manager-portal/keeping-track/index.html",
 																"uuid": "0dd98149-16fb-4cf0-9b2a-d5bff2519d9b",
-																"fdc3InteropApi": "1.2",
+																"fdc3InteropApi": "2.0",
 																"interop": {
 																	"currentContextGroup": "orange"
 																},
@@ -74,7 +74,7 @@
 																"name": "internal-generated-view-ef70ccee-2613-4f99-8a01-8cfba31064ba",
 																"url": "http://localhost:8080/common/views/manager-portal/annual-leave/index.html",
 																"uuid": "ef70ccee-2613-4f99-8a01-8cfba31064ba",
-																"fdc3InteropApi": "1.2",
+																"fdc3InteropApi": "2.0",
 																"interop": {
 																	"currentContextGroup": "orange"
 																},
@@ -88,7 +88,7 @@
 																"name": "internal-generated-view-f898522a-5d85-4e9e-93eb-378179f0f909",
 																"url": "http://localhost:8080/common/views/manager-portal/360-feedback/index.html",
 																"uuid": "f898522a-5d85-4e9e-93eb-378179f0f909",
-																"fdc3InteropApi": "1.2",
+																"fdc3InteropApi": "2.0",
 																"interop": {
 																	"currentContextGroup": "orange"
 																},
@@ -116,7 +116,7 @@
 																		"name": "internal-generated-view-b38f525a-77a9-48d9-bd02-b895cfbbf074",
 																		"url": "http://localhost:8080/common/views/manager-portal/manager-paths/index.html",
 																		"uuid": "b38f525a-77a9-48d9-bd02-b895cfbbf074",
-																		"fdc3InteropApi": "1.2",
+																		"fdc3InteropApi": "2.0",
 																		"interop": {
 																			"currentContextGroup": "orange"
 																		},
@@ -136,7 +136,7 @@
 																		"name": "internal-generated-view-5292442d-4d19-4d71-bcf1-ca9081ec50b0",
 																		"url": "http://localhost:8080/common/views/manager-portal/company-comms/index.html",
 																		"uuid": "5292442d-4d19-4d71-bcf1-ca9081ec50b0",
-																		"fdc3InteropApi": "1.2",
+																		"fdc3InteropApi": "2.0",
 																		"interop": {
 																			"currentContextGroup": "orange"
 																		},
@@ -150,7 +150,7 @@
 																		"name": "internal-generated-view-5292442d-4d19-4d71-bcf1-ca9081ec50b1",
 																		"url": "http://localhost:8080/common/views/manager-portal/company-cal/index.html",
 																		"uuid": "5292442d-4d19-4d71-bcf1-ca9081ec50b1",
-																		"fdc3InteropApi": "1.2",
+																		"fdc3InteropApi": "2.0",
 																		"interop": {
 																			"currentContextGroup": "orange"
 																		},
@@ -164,7 +164,7 @@
 																		"name": "internal-generated-view-935bb258-ded4-4a85-ad92-0f2a742d4d42",
 																		"url": "http://localhost:8080/common/views/manager-portal/franchise-comms/index.html",
 																		"uuid": "935bb258-ded4-4a85-ad92-0f2a742d4d42",
-																		"fdc3InteropApi": "1.2",
+																		"fdc3InteropApi": "2.0",
 																		"interop": {
 																			"currentContextGroup": "orange"
 																		},

--- a/how-to/workspace-platform-starter/public/common/views/manager-portal/manager-portal.snapshot.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/manager-portal/manager-portal.snapshot.fin.json
@@ -26,7 +26,7 @@
 														"name": "internal-generated-view-b9880bc2-2983-4b3c-a496-77d94783cb7e",
 														"url": "http://localhost:8080/common/views/manager-portal/my-team/index.html",
 														"uuid": "b9880bc2-2983-4b3c-a496-77d94783cb7e",
-														"fdc3InteropApi": "1.2",
+														"fdc3InteropApi": "2.0",
 														"interop": {
 															"currentContextGroup": "orange"
 														},
@@ -60,7 +60,7 @@
 																"name": "internal-generated-view-0dd98149-16fb-4cf0-9b2a-d5bff2519d9b",
 																"url": "http://localhost:8080/common/views/manager-portal/keeping-track/index.html",
 																"uuid": "0dd98149-16fb-4cf0-9b2a-d5bff2519d9b",
-																"fdc3InteropApi": "1.2",
+																"fdc3InteropApi": "2.0",
 																"interop": {
 																	"currentContextGroup": "orange"
 																},
@@ -74,7 +74,7 @@
 																"name": "internal-generated-view-ef70ccee-2613-4f99-8a01-8cfba31064ba",
 																"url": "http://localhost:8080/common/views/manager-portal/annual-leave/index.html",
 																"uuid": "ef70ccee-2613-4f99-8a01-8cfba31064ba",
-																"fdc3InteropApi": "1.2",
+																"fdc3InteropApi": "2.0",
 																"interop": {
 																	"currentContextGroup": "orange"
 																},
@@ -88,7 +88,7 @@
 																"name": "internal-generated-view-f898522a-5d85-4e9e-93eb-378179f0f909",
 																"url": "http://localhost:8080/common/views/manager-portal/360-feedback/index.html",
 																"uuid": "f898522a-5d85-4e9e-93eb-378179f0f909",
-																"fdc3InteropApi": "1.2",
+																"fdc3InteropApi": "2.0",
 																"interop": {
 																	"currentContextGroup": "orange"
 																},
@@ -116,7 +116,7 @@
 																		"name": "internal-generated-view-b38f525a-77a9-48d9-bd02-b895cfbbf074",
 																		"url": "http://localhost:8080/common/views/manager-portal/manager-paths/index.html",
 																		"uuid": "b38f525a-77a9-48d9-bd02-b895cfbbf074",
-																		"fdc3InteropApi": "1.2",
+																		"fdc3InteropApi": "2.0",
 																		"interop": {
 																			"currentContextGroup": "orange"
 																		},
@@ -136,7 +136,7 @@
 																		"name": "internal-generated-view-5292442d-4d19-4d71-bcf1-ca9081ec50b0",
 																		"url": "http://localhost:8080/common/views/manager-portal/company-comms/index.html",
 																		"uuid": "5292442d-4d19-4d71-bcf1-ca9081ec50b0",
-																		"fdc3InteropApi": "1.2",
+																		"fdc3InteropApi": "2.0",
 																		"interop": {
 																			"currentContextGroup": "orange"
 																		},
@@ -150,7 +150,7 @@
 																		"name": "internal-generated-view-5292442d-4d19-4d71-bcf1-ca9081ec50b1",
 																		"url": "http://localhost:8080/common/views/manager-portal/company-cal/index.html",
 																		"uuid": "5292442d-4d19-4d71-bcf1-ca9081ec50b1",
-																		"fdc3InteropApi": "1.2",
+																		"fdc3InteropApi": "2.0",
 																		"interop": {
 																			"currentContextGroup": "orange"
 																		},
@@ -164,7 +164,7 @@
 																		"name": "internal-generated-view-935bb258-ded4-4a85-ad92-0f2a742d4d42",
 																		"url": "http://localhost:8080/common/views/manager-portal/franchise-comms/index.html",
 																		"uuid": "935bb258-ded4-4a85-ad92-0f2a742d4d42",
-																		"fdc3InteropApi": "1.2",
+																		"fdc3InteropApi": "2.0",
 																		"interop": {
 																			"currentContextGroup": "orange"
 																		},

--- a/how-to/workspace-platform-starter/public/common/views/manager-portal/my-team.view.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/manager-portal/my-team.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "http://localhost:8080/common/views/manager-portal/my-team/index.html",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "orange"
 	},

--- a/how-to/workspace-platform-starter/public/common/views/modules/lifecycle/example-notification-service/index.js
+++ b/how-to/workspace-platform-starter/public/common/views/modules/lifecycle/example-notification-service/index.js
@@ -131,7 +131,9 @@ async function init() {
 			const { appId, instanceId } = implementationMetadata.appMetadata;
 
 			const messageEntry = messages.find(
-				(intentEntry) => intentEntry.messageId === 'notificationRaiseIntent'
+				(entry) =>
+					entry.messageId === 'notificationRaiseIntent' ||
+					entry.messageId === 'notificationLaunchAppWithContext'
 			);
 
 			if (messageEntry !== undefined) {

--- a/how-to/workspace-platform-starter/public/common/views/modules/lifecycle/example-notification-service/messages.json
+++ b/how-to/workspace-platform-starter/public/common/views/modules/lifecycle/example-notification-service/messages.json
@@ -25,6 +25,43 @@
 		}
 	},
 	{
+		"messageId": "notificationLaunchAppWithContext",
+		"title": "Launch App With Context",
+		"message": {
+			"type": "openfin.notificationoptions",
+			"notification": {
+				"id": "guid-goes-here",
+				"title": "Example Launches App With Context",
+				"body": "Click the button to launch an app.",
+				"buttons": [
+					{
+						"onClick": {
+							"task": "launch-app",
+							"customData": {
+								"id": "example-notification-service-app",
+								"context": {
+									"type": "fdc3.contact",
+									"name": "John Example",
+									"id": {
+										"email": "john@example.com",
+										"phone": "Number goes here"
+									}
+								},
+								"target": {
+									"appId": "example-notification-service-app",
+									"instanceId": "instanceId if available"
+								}
+							}
+						},
+						"cta": true,
+						"title": "Open Call App",
+						"type": "button"
+					}
+				]
+			}
+		}
+	},
+	{
 		"messageId": "notificationLaunchContent",
 		"title": "Launch Content",
 		"message": {

--- a/how-to/workspace-platform-starter/public/common/views/template/js/index.view.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/template/js/index.view.fin.json
@@ -1,4 +1,4 @@
 {
 	"url": "http://localhost:8080/common/views/template/js/index.html",
-	"fdc3InteropApi": "1.2"
+	"fdc3InteropApi": "2.0"
 }

--- a/how-to/workspace-platform-starter/public/common/views/tradingview/preload-tradingview.view.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/tradingview/preload-tradingview.view.fin.json
@@ -1,6 +1,6 @@
 {
 	"url": "https://www.tradingview.com/chart/?symbol=AAPL",
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
 	},

--- a/how-to/workspace-platform-starter/public/common/windows/hidden-window/hidden.window.fin.json
+++ b/how-to/workspace-platform-starter/public/common/windows/hidden-window/hidden.window.fin.json
@@ -4,7 +4,7 @@
 	"includeInSnapshots": false,
 	"name": "hidden-window-example",
 	"showTaskbarIcon": false,
-	"fdc3InteropApi": "1.2",
+	"fdc3InteropApi": "2.0",
 	"height": 500,
 	"width": 800,
 	"url": "http://localhost:8080/common/windows/hidden-window/hidden.html",


### PR DESCRIPTION
Updated samples to use fdc3 2.0 instead of 1.2 to support richer getInfo calls. Updated  WPS docs to promote 2.0 instead of 1.2 in the examples.

Updated WPS Interop Override:

- FDC3 open now supports passing context to all views it opens in a snapshot and not just the first one. We also check to see if it registers before firing based on a specified timeout. We don't await this so as not to slow down the response to the raiser.

- FDC3 Intent Firing when targettng a snapshot now waits to fire the intent until each view registers an intent handler or times out. We don't await this so as not to slow down the response to the raiser.

InstanceIds are only returned for single instance views/windows (not snapshots).

Example notification service launch-app action now supports passing the appId and instanceId (id still needs to be specified) in the target field of customData. context can also be passed now. This will use fdc3.open. If you specify an instanceId and a timeout error is thrown (if the instance is no longer running) then it falls back to launching a new instance of the app and passing it the context if specified.

- Updated example-notification-service-app to show raising a notification that has a call to action that passes data back to itself (or a new instance if it is closed) though a context listener.