### PR TITLE
Added protection against log modules logging against themselves when using createLogger

### DIFF
--- a/how-to/workspace-platform-starter/CHANGELOG.md
+++ b/how-to/workspace-platform-starter/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Updated example-notification-source so that you can specify a url to post notifications to (it will wrap the request in a message property and send it to the server you specify via post: { url: "" } settings. Our example node-starter supports messages being posted to <http://localhost:6060/api/messages>.
 - Updated the notification service example app so that if you select the endpoint example action it will post a notification to the notification source create endpoint.
 - BUGFIX - Updated Snapshot launching logic as there was a bug when updating a page's layout (to ensure view names are regenerated when using app naming conventions) in a multi page window which resulted in the page layout being assigned at the wrong level.
+- Enhancement - Previously if you were generating a log module you needed to avoid using the injected createLogger function as you would end up calling yourself and ending up in a loop. The module logic has been updated to pass an alternative createLogger function to log modules that only logs to the console (so that it can still be used for debugging) but doesn't call itself or other log sinks (log modules).
 
 ## v19.0.0
 

--- a/how-to/workspace-platform-starter/client/src/framework/shapes/module-shapes.ts
+++ b/how-to/workspace-platform-starter/client/src/framework/shapes/module-shapes.ts
@@ -69,6 +69,11 @@ export interface ModuleDefinition<O = unknown> {
 	 * Custom data for the module.
 	 */
 	data?: O;
+
+	/**
+	 * This is specified by the provider while loading the modules.
+	 */
+	moduleType?: ModuleTypes;
 }
 
 /**

--- a/how-to/workspace-platform-starter/client/types/module/shapes/module-shapes.d.ts
+++ b/how-to/workspace-platform-starter/client/types/module/shapes/module-shapes.d.ts
@@ -60,6 +60,10 @@ export interface ModuleDefinition<O = unknown> {
 	 * Custom data for the module.
 	 */
 	data?: O;
+	/**
+	 * This is specified by the provider while loading the modules.
+	 */
+	moduleType?: ModuleTypes;
 }
 /**
  * Helper methods and data to pass to the modules during initialization.

--- a/how-to/workspace-platform-starter/public/schemas/settings.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/settings.schema.json
@@ -2075,6 +2075,10 @@
                     "description": "Url to more information.",
                     "type": "string"
                 },
+                "moduleType": {
+                    "$ref": "#/definitions/ModuleTypes",
+                    "description": "This is specified by the provider while loading the modules."
+                },
                 "moduleUrl": {
                     "description": "This is the old property, it will be remapped to url.",
                     "type": "string"
@@ -2312,6 +2316,10 @@
                 "info": {
                     "description": "Url to more information.",
                     "type": "string"
+                },
+                "moduleType": {
+                    "$ref": "#/definitions/ModuleTypes",
+                    "description": "This is specified by the provider while loading the modules."
                 },
                 "title": {
                     "description": "The title of the module.",
@@ -3081,6 +3089,10 @@
                     "description": "Url to more information.",
                     "type": "string"
                 },
+                "moduleType": {
+                    "$ref": "#/definitions/ModuleTypes",
+                    "description": "This is specified by the provider while loading the modules."
+                },
                 "title": {
                     "description": "The title of the module.",
                     "type": "string"
@@ -3209,6 +3221,26 @@
                 }
             },
             "type": "object"
+        },
+        "ModuleTypes": {
+            "description": "The possible module types.",
+            "enum": [
+                "actions",
+                "analytics",
+                "auth",
+                "conditions",
+                "contentCreation",
+                "endpoint",
+                "initOptions",
+                "integrations",
+                "interopOverride",
+                "lifecycle",
+                "log",
+                "menus",
+                "platformOverride",
+                "share"
+            ],
+            "type": "string"
         },
         "MonitorDetails": {
             "$ref": "#/definitions/__type_49"

--- a/how-to/workspace-platform-starter/public/schemas/wps.manifest.schema.json
+++ b/how-to/workspace-platform-starter/public/schemas/wps.manifest.schema.json
@@ -1948,6 +1948,10 @@
 					"description": "Url to more information.",
 					"type": "string"
 				},
+				"moduleType": {
+					"$ref": "#/definitions/ModuleTypes",
+					"description": "This is specified by the provider while loading the modules."
+				},
 				"moduleUrl": {
 					"description": "This is the old property, it will be remapped to url.",
 					"type": "string"
@@ -2179,6 +2183,10 @@
 				"info": {
 					"description": "Url to more information.",
 					"type": "string"
+				},
+				"moduleType": {
+					"$ref": "#/definitions/ModuleTypes",
+					"description": "This is specified by the provider while loading the modules."
 				},
 				"title": {
 					"description": "The title of the module.",
@@ -2879,6 +2887,10 @@
 					"description": "Url to more information.",
 					"type": "string"
 				},
+				"moduleType": {
+					"$ref": "#/definitions/ModuleTypes",
+					"description": "This is specified by the provider while loading the modules."
+				},
 				"title": {
 					"description": "The title of the module.",
 					"type": "string"
@@ -2999,6 +3011,26 @@
 				}
 			},
 			"type": "object"
+		},
+		"ModuleTypes": {
+			"description": "The possible module types.",
+			"enum": [
+				"actions",
+				"analytics",
+				"auth",
+				"conditions",
+				"contentCreation",
+				"endpoint",
+				"initOptions",
+				"integrations",
+				"interopOverride",
+				"lifecycle",
+				"log",
+				"menus",
+				"platformOverride",
+				"share"
+			],
+			"type": "string"
 		},
 		"MonitorDetails": {
 			"$ref": "#/definitions/__type_49"


### PR DESCRIPTION
A log module is a log sink. It is passed a createLogger function as it is a module but if used it would result in the logged messages being passed back to itself (as well as other log sinks).

An additional check has been done when initialising log modules to prevent the log sink linked logger being passed. A local logger is returned that logs just to the console (for debugging purposes) when called from a log module.