### PR TITLE
Updated preload with a new option for people wanting to test snap and state quickly

### DIFF
--- a/how-to/integrate-with-snap/README.md
+++ b/how-to/integrate-with-snap/README.md
@@ -165,6 +165,29 @@ If you want the debug version with the debug window automatically showing then y
   "preloadScripts": [{ "url": "https://built-on-openfin.github.io/workspace-starter/workspace/v20.1.0/integrate-with-snap/js/snap.preload.debug.bundle.js" }],
 ```
 
+If you want the channel version with the a channel name of `${fin.me.identity.uuid}-snap-layout` as the name that has two functions getLayout and applyLayout (if you want to quickly validate including snap data in state without having to modify your project to reference the SnapSDK npm package) then you can reference this preload script:
+
+```json
+  "preloadScripts": [{ "url": "https://built-on-openfin.github.io/workspace-starter/workspace/v20.1.0/integrate-with-snap/js/snap.preload.channel.bundle.js" }],
+```
+
+To reference the channel you can do the following in your main page or platform provider:
+
+```javascript
+const clientChannelName = `${fin.me.identity.uuid}-snap-layout`;
+const snapPreloadClient = await fin.InterApplicationBus.Channel.connect(clientChannelName);
+
+// fetch the current snap layout
+const layout = await snapPreloadClient.dispatch("getLayout") as Snap.SnapLayout;
+console.log("Got layout from Snap", layout);
+
+// apply the layout
+await snapPreloadClient.dispatch("applyLayout", layout);
+console.log("Applied layout to Snap");
+```
+
+This approach is just for quick, low touch evaluation. If you are looking to use Snap in production we recommend using the SnapSDK directly in your codebase to take advantage of all of it's capabilities.
+
 #### Permissions
 
 These permissions need to be added at the platform or startup_app level depending on the type of application you are building. The example below is using the restrictive permission model so it only allows launch external process for an app asset that comes from a particular url.

--- a/how-to/integrate-with-snap/client/src/preload/preload.channel.ts
+++ b/how-to/integrate-with-snap/client/src/preload/preload.channel.ts
@@ -1,0 +1,14 @@
+import type { SnapProviderOptions } from "../shapes";
+import { initialize } from "./preload.common";
+
+if (window === window.top) {
+	console.log("Adding snap support through a preload with layout support.");
+
+	window.addEventListener("DOMContentLoaded", async () => {
+		const snapOptions: SnapProviderOptions = {
+			platformId: fin.me.identity.uuid,
+			serverOptions: { showDebug: true }
+		};
+		await initialize(snapOptions, true);
+	});
+}

--- a/how-to/integrate-with-snap/client/src/preload/preload.channel.ts
+++ b/how-to/integrate-with-snap/client/src/preload/preload.channel.ts
@@ -6,8 +6,7 @@ if (window === window.top) {
 
 	window.addEventListener("DOMContentLoaded", async () => {
 		const snapOptions: SnapProviderOptions = {
-			platformId: fin.me.identity.uuid,
-			serverOptions: { showDebug: true }
+			platformId: fin.me.identity.uuid
 		};
 		await initialize(snapOptions, true);
 	});

--- a/how-to/integrate-with-snap/client/src/preload/preload.common.ts
+++ b/how-to/integrate-with-snap/client/src/preload/preload.common.ts
@@ -26,42 +26,58 @@ export async function initialize(
 			if (createLayoutChannel) {
 				try {
 					const channelName = `${fin.me.identity.uuid}-snap-layout`;
-					console.log(`Creating snap preload layout channel: ${channelName}`);
+					console.log(`Channel Service: Creating snap preload layout channel: ${channelName}`);
 					const channel = await fin.InterApplicationBus.Channel.create(channelName);
 					channel.register("getLayout", async () => {
-						console.log("Getting layout from Snap");
+						console.log("Channel Service: Getting layout from Snap");
 						const layout = await server.getLayout();
-						console.log("Got layout from Snap", layout);
+						console.log("Channel Service: Got layout from Snap", layout);
 						return layout;
 					});
 					channel.register("applyLayout", async (payload: unknown) => {
-						console.log("Applying layout to Snap", payload);
-						console.log("Preparing to apply snapshot");
+						console.log("Channel Service: Applying layout to Snap", payload);
+						console.log("Channel Service: Preparing to apply snapshot");
 						await server.prepareToApplySnapshot();
-						console.log("Applying snapshot");
+						console.log("Channel Service: Applying snapshot");
 						await server.applySnapshot(payload as Snap.SnapSnapshot);
-						console.log("Applied snapshot");
+						console.log("Channel Service: Applied snapshot");
+					});
+					channel.onConnection(async (identity) => {
+						console.log("Channel Service: Connection request from:", identity);
+					});
+					channel.onDisconnection(async (identity) => {
+						console.log("Channel Service: Disconnection request from:", identity);
 					});
 
 					setTimeout(async () => {
 						try {
-							console.log("Connecting to snap preload layout channel to validate connection.");
+							console.log(
+								"Channel Client: Connecting to snap preload layout channel to validate connection."
+							);
 							const clientChannelName = `${fin.me.identity.uuid}-snap-layout`;
 							const snapPreloadClient = await fin.InterApplicationBus.Channel.connect(clientChannelName);
 
 							// fetch the current snap layout
+							console.log("Channel Client: Requesting layout from Snap");
 							const layout = (await snapPreloadClient.dispatch("getLayout")) as Snap.SnapLayout;
-							console.log("Got layout from Snap", layout);
+							console.log("Channel Client: Got layout from Snap", layout);
 
 							// apply the layout
+							console.log("Channel Client: Applying layout to Snap");
 							await snapPreloadClient.dispatch("applyLayout", layout);
-							console.log("Applied layout to Snap");
+							console.log("Channel Client: Applied layout to Snap");
+
+							console.log("Channel Client: Disconnecting from snap preload Channel Service");
+							await snapPreloadClient.disconnect();
 						} catch (clientError) {
-							console.error("Error connecting to snap preload layout channel", clientError);
+							console.error(
+								"Channel Client: Error connecting to snap preload layout Channel Service",
+								clientError
+							);
 						}
 					}, 1000);
 				} catch (err) {
-					console.error("Error creating snap layout channel", err);
+					console.error("Channel Service: Error creating snap layout channel", err);
 				}
 			}
 			const app = fin.Application.getCurrentSync();

--- a/how-to/integrate-with-snap/client/src/preload/preload.common.ts
+++ b/how-to/integrate-with-snap/client/src/preload/preload.common.ts
@@ -44,6 +44,12 @@ export async function initialize(
 					});
 					channel.onConnection(async (identity) => {
 						console.log("Channel Service: Connection request from:", identity);
+						// eslint-disable-next-line prefer-template
+						if (identity.uuid !== fin.me.identity.uuid) {
+							const message = `Channel Service: Rejecting connection request as it is not coming from within the application. Identity should be: ${fin.me.identity.uuid} and connection request is coming from: ${identity.uuid}`;
+							console.error(message);
+							throw new Error(message);
+						}
 					});
 					channel.onDisconnection(async (identity) => {
 						console.log("Channel Service: Disconnection request from:", identity);
@@ -67,7 +73,7 @@ export async function initialize(
 							await snapPreloadClient.dispatch("applyLayout", layout);
 							console.log("Channel Client: Applied layout to Snap");
 
-							console.log("Channel Client: Disconnecting from snap preload Channel Service");
+							console.log("Channel Client: Intentionally disconnecting from snap preload Channel Service");
 							await snapPreloadClient.disconnect();
 						} catch (clientError) {
 							console.error(

--- a/how-to/integrate-with-snap/client/src/preload/preload.common.ts
+++ b/how-to/integrate-with-snap/client/src/preload/preload.common.ts
@@ -6,8 +6,12 @@ import type { SnapProviderOptions } from "../shapes";
 /**
  * Initialize the snap components.
  * @param options The options for initializing the snap provider.
+ * @param createLayoutChannel Whether to create a simple channel api service that exposes the getLayout and applyLayout functionality of snap.
  */
-export async function initialize(options: SnapProviderOptions): Promise<void> {
+export async function initialize(
+	options: SnapProviderOptions,
+	createLayoutChannel: boolean = false
+): Promise<void> {
 	const settings = await getSettings();
 	const settingsServerOptions = settings?.serverOptions ?? {};
 	const passedOptions = options?.serverOptions ?? {};
@@ -19,6 +23,47 @@ export async function initialize(options: SnapProviderOptions): Promise<void> {
 			const server = new Snap.SnapServer(finalPlatformId);
 			console.log("Enabling debug window:", finalOptions.showDebug ?? false);
 			await server.start(finalOptions);
+			if (createLayoutChannel) {
+				try {
+					const channelName = `${fin.me.identity.uuid}-snap-layout`;
+					console.log(`Creating snap preload layout channel: ${channelName}`);
+					const channel = await fin.InterApplicationBus.Channel.create(channelName);
+					channel.register("getLayout", async () => {
+						console.log("Getting layout from Snap");
+						const layout = await server.getLayout();
+						console.log("Got layout from Snap", layout);
+						return layout;
+					});
+					channel.register("applyLayout", async (payload: unknown) => {
+						console.log("Applying layout to Snap", payload);
+						console.log("Preparing to apply snapshot");
+						await server.prepareToApplySnapshot();
+						console.log("Applying snapshot");
+						await server.applySnapshot(payload as Snap.SnapSnapshot);
+						console.log("Applied snapshot");
+					});
+
+					setTimeout(async () => {
+						try {
+							console.log("Connecting to snap preload layout channel to validate connection.");
+							const clientChannelName = `${fin.me.identity.uuid}-snap-layout`;
+							const snapPreloadClient = await fin.InterApplicationBus.Channel.connect(clientChannelName);
+
+							// fetch the current snap layout
+							const layout = (await snapPreloadClient.dispatch("getLayout")) as Snap.SnapLayout;
+							console.log("Got layout from Snap", layout);
+
+							// apply the layout
+							await snapPreloadClient.dispatch("applyLayout", layout);
+							console.log("Applied layout to Snap");
+						} catch (clientError) {
+							console.error("Error connecting to snap preload layout channel", clientError);
+						}
+					}, 1000);
+				} catch (err) {
+					console.error("Error creating snap layout channel", err);
+				}
+			}
 			const app = fin.Application.getCurrentSync();
 			await app.on("window-created", async (e) => {
 				const win = fin.Window.wrapSync(e);

--- a/how-to/integrate-with-snap/client/webpack.config.js
+++ b/how-to/integrate-with-snap/client/webpack.config.js
@@ -60,5 +60,25 @@ module.exports = [
 			filename: 'snap.preload.debug.bundle.js',
 			path: path.resolve(__dirname, '..', 'public', 'js')
 		}
+	},
+	{
+		entry: './client/src/preload/preload.channel.ts',
+		devtool: 'inline-source-map',
+		module: {
+			rules: [
+				{
+					test: /\.tsx?$/,
+					use: 'ts-loader',
+					exclude: /node_modules/
+				}
+			]
+		},
+		resolve: {
+			extensions: ['.tsx', '.ts', '.js']
+		},
+		output: {
+			filename: 'snap.preload.channel.bundle.js',
+			path: path.resolve(__dirname, '..', 'public', 'js')
+		}
 	}
 ];


### PR DESCRIPTION
There is a third preload that exposes an easy way for someone to quickly request or apply a layout from Snap without having to use the snapsdk directly by using a channel (see readme). This logic has extensive logging and it performs a client connection test before disconnecting. There is a defensive check to ensure only clients from within the app can connect.