### PR TITLE
Convert style-changed-preload to theme-changed script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ chromedriver*
 how-to/workspace-platform-starter/public/common/snapshots/XYZten-windows.snapshot.fin.json
 how-to/workspace-platform-starter/public/common/snapshots/old-ten-windows.snapshot.fin.json
 how-to/workspace-platform-starter-basic/public/common/snapshots/forty-windows.snapshot.fin.json
+.idea

--- a/how-to/workspace-platform-starter/public/common/style/theme-changed.js
+++ b/how-to/workspace-platform-starter/public/common/style/theme-changed.js
@@ -1,0 +1,128 @@
+/**
+ * This script can be included by any view that wants to keep track
+ * of the currently selected, it listens for a channel message of platform.theme
+ * which contains the scheme "dark" or "light" and the current palette.
+ * By default this will create add a CSS class to the body of "theme-dark" or "theme-light"
+ * and will also create a set of CSS root variable for the theme colors.
+ * An example of the theme vars will be
+ * --theme-scheme: light;
+ * --theme-brand-primary: #0A76D3;
+ * --theme-brand-secondary: #1E1F23;
+ * --theme-background-primary: #FAFBFE;
+ * --theme-background1: #FFFFFF;
+ * --theme-background2: #FAFBFE;
+ * --theme-background3: #F3F5F8;
+ * --theme-background4: #ECEEF1;
+ * --theme-background5: #DDDFE4;
+ * --theme-background6: #C9CBD2;
+ * --theme-status-success: #35C759;
+ * --theme-status-warning: #F48F00;
+ * --theme-status-critical: #BE1D1F;
+ * --theme-status-active: #0498FB;
+ * --theme-input-background: #ECEEF1;
+ * --theme-input-color: #1E1F23;
+ * --theme-input-placeholder: #383A40;
+ * --theme-input-disabled: #7D808A;
+ * --theme-input-focused: #C9CBD2;
+ * --theme-text-default: #1E1F23;
+ * --theme-text-help: #2F3136;
+ * --theme-text-inactive: #7D808A;
+ * --theme-content-background1: #0A76D3;
+ * --theme-content-background2: #000000;
+ * --theme-content-background3: #000000;
+ * --theme-content-background4: #000000;
+ * --theme-content-background5: #000000;
+ */
+document.addEventListener('DOMContentLoaded', async () => {
+	try {
+		console.log('Style Change script activated');
+
+		checkThemeQueryParam();
+
+		if (
+			window.fin !== undefined &&
+			fin.me.interop !== undefined &&
+			fin.me.interop.joinSessionContextGroup !== undefined
+		) {
+			const appSessionContextGroup = await fin.me.interop.joinSessionContextGroup('platform/events');
+
+			appSessionContextGroup.addContextHandler((context) => {
+				if (context.type === 'platform.theme') {
+					console.log('Received platform.theme context', context);
+					const prefix = context?.prefix ?? 'theme';
+					const darkScheme = context?.schemeNames?.dark ?? 'theme-dark';
+					const lightScheme = context?.schemeNames?.light ?? 'theme-light';
+					setColorScheme(context.schemeType, darkScheme, lightScheme);
+					convertPaletteToCss(prefix, context.schemeType, context.palette);
+				}
+			});
+		}
+	} catch (err) {
+		console.error('Error encountered while listening for platform events via interop.', err);
+	}
+});
+
+/**
+ * Checks URL parameters for a pre-defined theme on the url and applies the corresponding styles.
+ */
+function checkThemeQueryParam() {
+	const urlParams = new URLSearchParams(window.location.search);
+	const theme = urlParams.get('theme');
+	if (theme) {
+		const darkScheme = theme === 'dark' ? 'theme-dark' : 'theme-light';
+		const lightScheme = theme === 'light' ? 'theme-light' : 'theme-dark';
+		setColorScheme(theme, darkScheme, lightScheme);
+	}
+}
+
+/**
+ * Set the color scheme class on the document body.
+ * @param schemeType The type of the scheme dark or light.
+ * @param darkScheme The class name to add for dark scheme.
+ * @param lightScheme The class name to add for light scheme.
+ */
+function setColorScheme(schemeType, darkScheme, lightScheme) {
+	if (schemeType === 'light') {
+		document.body.classList.remove(darkScheme);
+		document.body.classList.add(lightScheme);
+	} else {
+		document.body.classList.remove(lightScheme);
+		document.body.classList.add(darkScheme);
+	}
+}
+
+/**
+ * Convert a camel case property name to kebab case for the css properties.
+ * @param input The input name to convert.
+ * @returns The name in kebab case.
+ */
+function kebabCase(input) {
+	if (typeof input === 'string' && input.length > 0) {
+		return (
+			input
+				.replace(/([A-Z])/g, ' $1')
+				.trim()
+				.match(/[^\u0000-\u002F\u003A-\u0040\u005B-\u0060\u007B-\u007F]+/g) ?? []
+		)
+			.join('-')
+			.toLowerCase();
+	}
+	return '';
+}
+
+/**
+ * Create all the css vars from the palette properties.
+ * @param prefix The prefix to add to the property names.
+ * @param scheme The scheme dark or light.
+ * @param palette The palette to convert to properties.
+ */
+function convertPaletteToCss(prefix, scheme, palette) {
+	const root = document.querySelector(':root');
+	if (root) {
+		root.style.setProperty(`--${prefix}-scheme`, scheme);
+		const keys = Object.keys(palette);
+		for (const key of keys) {
+			root.style.setProperty(`--${prefix}-${kebabCase(key)}`, palette[key]);
+		}
+	}
+}

--- a/how-to/workspace-platform-starter/public/common/views/contact/call-app.view.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/contact/call-app.view.fin.json
@@ -3,10 +3,5 @@
 	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
-	},
-	"preloadScripts": [
-		{
-			"url": "http://localhost:8080/common/style/style-changed-preload.js"
-		}
-	]
+	}
 }

--- a/how-to/workspace-platform-starter/public/common/views/contact/call-app/index.html
+++ b/how-to/workspace-platform-starter/public/common/views/contact/call-app/index.html
@@ -8,6 +8,7 @@
 		<link rel="stylesheet" href="../../../style/app.css" />
 		<script src="https://built-on-openfin.github.io/web-starter/web/v21.0.0/web-client-api/js/shim.api.bundle.js"></script>
 		<script defer="defer" src="./index.js"></script>
+		<script src="../../../style/theme-changed.js"></script>
 	</head>
 
 	<body class="col fill gap20">

--- a/how-to/workspace-platform-starter/public/common/views/contact/investments-and-models.view.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/contact/investments-and-models.view.fin.json
@@ -3,10 +3,5 @@
 	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
-	},
-	"preloadScripts": [
-		{
-			"url": "http://localhost:8080/common/style/style-changed-preload.js"
-		}
-	]
+	}
 }

--- a/how-to/workspace-platform-starter/public/common/views/contact/investments-and-models/index.html
+++ b/how-to/workspace-platform-starter/public/common/views/contact/investments-and-models/index.html
@@ -8,6 +8,7 @@
 		<link rel="stylesheet" href="../../../style/app.css" />
 		<script src="https://built-on-openfin.github.io/web-starter/web/v21.0.0/web-client-api/js/shim.api.bundle.js"></script>
 		<script defer="defer" src="./index.js"></script>
+		<script src="../../../style/theme-changed.js"></script>
 	</head>
 
 	<body class="small col fill gap20">

--- a/how-to/workspace-platform-starter/public/common/views/contact/participant-history.view.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/contact/participant-history.view.fin.json
@@ -3,10 +3,5 @@
 	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
-	},
-	"preloadScripts": [
-		{
-			"url": "http://localhost:8080/common/style/style-changed-preload.js"
-		}
-	]
+	}
 }

--- a/how-to/workspace-platform-starter/public/common/views/contact/participant-history/index.html
+++ b/how-to/workspace-platform-starter/public/common/views/contact/participant-history/index.html
@@ -8,6 +8,7 @@
 		<link rel="stylesheet" href="../../../style/app.css" />
 		<script src="https://built-on-openfin.github.io/web-starter/web/v21.0.0/web-client-api/js/shim.api.bundle.js"></script>
 		<script defer="defer" src="./index.js"></script>
+		<script src="../../../style/theme-changed.js"></script>
 	</head>
 
 	<body class="small col fill gap20">

--- a/how-to/workspace-platform-starter/public/common/views/contact/participant-selection.view.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/contact/participant-selection.view.fin.json
@@ -3,10 +3,5 @@
 	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
-	},
-	"preloadScripts": [
-		{
-			"url": "http://localhost:8080/common/style/style-changed-preload.js"
-		}
-	]
+	}
 }

--- a/how-to/workspace-platform-starter/public/common/views/contact/participant-selection/index.html
+++ b/how-to/workspace-platform-starter/public/common/views/contact/participant-selection/index.html
@@ -8,6 +8,7 @@
 		<link rel="stylesheet" href="../../../style/app.css" />
 		<script src="https://built-on-openfin.github.io/web-starter/web/v21.0.0/web-client-api/js/shim.api.bundle.js"></script>
 		<script defer="defer" src="./index.js" type="module"></script>
+		<script src="../../../style/theme-changed.js"></script>
 		<style>
 			.profile-pic {
 				border-radius: 5px;

--- a/how-to/workspace-platform-starter/public/common/views/contact/participant-summary.view.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/contact/participant-summary.view.fin.json
@@ -3,10 +3,5 @@
 	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
-	},
-	"preloadScripts": [
-		{
-			"url": "http://localhost:8080/common/style/style-changed-preload.js"
-		}
-	]
+	}
 }

--- a/how-to/workspace-platform-starter/public/common/views/contact/participant-summary.window.fin.json
+++ b/how-to/workspace-platform-starter/public/common/views/contact/participant-summary.window.fin.json
@@ -3,10 +3,5 @@
 	"fdc3InteropApi": "2.0",
 	"interop": {
 		"currentContextGroup": "green"
-	},
-	"preloadScripts": [
-		{
-			"url": "http://localhost:8080/common/style/style-changed-preload.js"
-		}
-	]
+	}
 }

--- a/how-to/workspace-platform-starter/public/common/views/contact/participant-summary/index.html
+++ b/how-to/workspace-platform-starter/public/common/views/contact/participant-summary/index.html
@@ -8,6 +8,7 @@
 		<link rel="stylesheet" href="../../../style/app.css" />
 		<script src="https://built-on-openfin.github.io/web-starter/web/v21.0.0/web-client-api/js/shim.api.bundle.js"></script>
 		<script defer="defer" src="./index.js" type="module"></script>
+		<script src="../../../style/theme-changed.js"></script>
 		<script type="module" src="../../../lib/wc-fin/wc-fin.esm.js"></script>
 		<style>
 			.profile-pic {


### PR DESCRIPTION
Switches workspace-platform-starter style-changed-preload.js to use a regular script that looks for a query param to set the initial light/dark theme. If not found retains the existing theming behaviour.