### PR TITLE
Fix bug in customize-home-templates

### DIFF
--- a/how-to/customize-home-templates/client/src/sources/tree-inline/tree-inline-source.ts
+++ b/how-to/customize-home-templates/client/src/sources/tree-inline/tree-inline-source.ts
@@ -150,8 +150,15 @@ export class TreeInlineSource {
 	): Promise<HomeSearchResponse> {
 		this._lastResults = [];
 
-		if (query.length > 0) {
-			const queryOrg = new RegExp(query, "i");
+		let searchQuery = "";
+		if (query.startsWith("/tree-inline ")) {
+			searchQuery = query.slice("/tree-inline ".length);
+		} else if (!query.startsWith("/tree-inline")) {
+			searchQuery = query;
+		}
+
+		if (searchQuery.length > 0) {
+			const queryOrg = new RegExp(searchQuery, "i");
 			const matchingOrgs: EntityOrganization[] | undefined = this._orgData?.filter(
 				(o) => queryOrg.test(o.id) || queryOrg.test(o.name)
 			);

--- a/how-to/customize-home-templates/client/src/sources/tree-query/tree-query-source.ts
+++ b/how-to/customize-home-templates/client/src/sources/tree-query/tree-query-source.ts
@@ -156,8 +156,15 @@ export class TreeQuerySource {
 	): Promise<HomeSearchResponse> {
 		let results: HomeSearchResult[] = [];
 
-		if (query.length > 0) {
-			const parts = query.split("/");
+		let pathQuery = "";
+		if (query.startsWith("/tree-query ")) {
+			pathQuery = query.slice("/tree-query ".length);
+		} else if (!query.startsWith("/tree-query")) {
+			pathQuery = query;
+		}
+
+		if (pathQuery.length > 0) {
+			const parts = pathQuery.split("/");
 
 			const queryOrg = new RegExp(parts[0], "i");
 			const matchingOrgs: EntityOrganization[] | undefined = this._orgData?.filter(


### PR DESCRIPTION
The tree-inline and tree-query commands in home were not working as expected due to the command prefixes (ie /tree-inline) being included in the search query. Solved the problem by stripping that part of the query out, similar to what other commands (ie /emoji) were already doing.