### PR TITLE
Remove theme definitions from non-theme examples

### DIFF
--- a/how-to/customize-home-templates/client/src/provider.ts
+++ b/how-to/customize-home-templates/client/src/provider.ts
@@ -12,7 +12,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 	await platform.once("platform-api-ready", async () => initializeWorkspaceComponents());
 
 	// The DOM is ready so initialize the platform
-	// Provide default icons and default theme for the browser windows
+	// Provide default icons for the browser windows
 	await initializeWorkspacePlatform();
 });
 
@@ -30,18 +30,7 @@ async function initializeWorkspacePlatform(): Promise<void> {
 					favicon: PLATFORM_ICON
 				}
 			}
-		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palette: {
-					brandPrimary: "#0A76D3",
-					brandSecondary: "#383A40",
-					backgroundPrimary: "#1E1F23"
-				}
-			}
-		]
+		}
 	});
 }
 

--- a/how-to/integrate-server-authentication/client/src/provider.ts
+++ b/how-to/integrate-server-authentication/client/src/provider.ts
@@ -28,18 +28,7 @@ async function initializeWorkspacePlatform(): Promise<void> {
 					favicon: PLATFORM_ICON
 				}
 			}
-		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palette: {
-					brandPrimary: "#0A76D3",
-					brandSecondary: "#383A40",
-					backgroundPrimary: "#1E1F23"
-				}
-			}
-		]
+		}
 	});
 }
 

--- a/how-to/integrate-with-bloomberg-basic/client/src/provider.ts
+++ b/how-to/integrate-with-bloomberg-basic/client/src/provider.ts
@@ -10,7 +10,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 	await platform.once("platform-api-ready", async () => initializeWorkspaceComponents());
 
 	// The DOM is ready so initialize the platform
-	// Provide default icons and default theme for the browser windows
+	// Provide default icons for the browser windows
 	await initializeWorkspacePlatform();
 });
 
@@ -30,17 +30,6 @@ async function initializeWorkspacePlatform(): Promise<void> {
 				}
 			}
 		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palette: {
-					brandPrimary: "#0A76D3",
-					brandSecondary: "#383A40",
-					backgroundPrimary: "#1E1F23"
-				}
-			}
-		],
 		// Override the platform interop so that we can handle intents
 		interopOverride
 	});

--- a/how-to/integrate-with-excel/client/src/provider.ts
+++ b/how-to/integrate-with-excel/client/src/provider.ts
@@ -53,18 +53,7 @@ async function initializeWorkspacePlatform(): Promise<void> {
 					favicon: PLATFORM_ICON
 				}
 			}
-		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palette: {
-					brandPrimary: "#0A76D3",
-					brandSecondary: "#383A40",
-					backgroundPrimary: "#1E1F23"
-				}
-			}
-		]
+		}
 	});
 }
 

--- a/how-to/integrate-with-ms365/client/src/provider.ts
+++ b/how-to/integrate-with-ms365/client/src/provider.ts
@@ -66,14 +66,7 @@ async function initializeWorkspacePlatform(): Promise<void> {
 					favicon: PLATFORM_ICON
 				}
 			}
-		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palettes: templateHelpers.DEFAULT_PALETTES
-			}
-		]
+		}
 	});
 }
 

--- a/how-to/integrate-with-openid-connect/client/src/provider.ts
+++ b/how-to/integrate-with-openid-connect/client/src/provider.ts
@@ -17,7 +17,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 	await platform.once("platform-api-ready", async () => initializeWorkspaceComponents());
 
 	// The DOM is ready so initialize the platform
-	// Provide default icons and default theme for the browser windows
+	// Provide default icons for the browser windows
 	await initializeWorkspacePlatform();
 
 	// If the custom settings contain auth then initialize it
@@ -57,18 +57,7 @@ async function initializeWorkspacePlatform(): Promise<void> {
 					favicon: PLATFORM_ICON
 				}
 			}
-		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palette: {
-					brandPrimary: "#0A76D3",
-					brandSecondary: "#383A40",
-					backgroundPrimary: "#1E1F23"
-				}
-			}
-		]
+		}
 	});
 }
 

--- a/how-to/integrate-with-rss/client/src/provider.ts
+++ b/how-to/integrate-with-rss/client/src/provider.ts
@@ -32,7 +32,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 	});
 
 	// The DOM is ready so initialize the platform
-	// Provide default icons and default theme for the browser windows
+	// Provide default icons for the browser windows
 	await initializeWorkspacePlatform();
 });
 
@@ -50,18 +50,7 @@ async function initializeWorkspacePlatform(): Promise<void> {
 					favicon: PLATFORM_ICON
 				}
 			}
-		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palette: {
-					brandPrimary: "#0A76D3",
-					brandSecondary: "#383A40",
-					backgroundPrimary: "#1E1F23"
-				}
-			}
-		]
+		}
 	});
 }
 

--- a/how-to/integrate-with-salesforce-basic/client/src/provider.ts
+++ b/how-to/integrate-with-salesforce-basic/client/src/provider.ts
@@ -32,7 +32,7 @@ let username: HTMLDivElement | null;
 // Wait for the DOM to finish loading
 window.addEventListener("DOMContentLoaded", async () => {
 	// The DOM is ready so initialize the platform
-	// Provide default icons and default theme for the browser windows
+	// Provide default icons for the browser windows
 	await initializeWorkspacePlatform();
 
 	// Platform has loaded so initialize the DOM
@@ -53,18 +53,7 @@ async function initializeWorkspacePlatform(): Promise<void> {
 					favicon: PLATFORM_ICON
 				}
 			}
-		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palette: {
-					brandPrimary: "#0A76D3",
-					brandSecondary: "#383A40",
-					backgroundPrimary: "#1E1F23"
-				}
-			}
-		]
+		}
 	});
 }
 

--- a/how-to/integrate-with-salesforce/client/src/provider.ts
+++ b/how-to/integrate-with-salesforce/client/src/provider.ts
@@ -62,13 +62,6 @@ async function initializeWorkspacePlatform(): Promise<void> {
 				}
 			}
 		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palette: templateHelpers.DEFAULT_PALETTES.dark
-			}
-		],
 		// Override the interop so that we can handle intent messages from Salesforce
 		interopOverride
 	});

--- a/how-to/integrate-with-servicenow-basic/client/src/provider.ts
+++ b/how-to/integrate-with-servicenow-basic/client/src/provider.ts
@@ -32,7 +32,7 @@ let username: HTMLDivElement | null;
 // Wait for the DOM to finish loading
 window.addEventListener("DOMContentLoaded", async () => {
 	// The DOM is ready so initialize the platform
-	// Provide default icons and default theme for the browser windows
+	// Provide default icons for the browser windows
 	await initializeWorkspacePlatform();
 
 	// Platform has loaded so initialize the DOM
@@ -53,18 +53,7 @@ async function initializeWorkspacePlatform(): Promise<void> {
 					favicon: PLATFORM_ICON
 				}
 			}
-		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palette: {
-					brandPrimary: "#0A76D3",
-					brandSecondary: "#383A40",
-					backgroundPrimary: "#1E1F23"
-				}
-			}
-		]
+		}
 	});
 }
 

--- a/how-to/integrate-with-servicenow/client/src/provider.ts
+++ b/how-to/integrate-with-servicenow/client/src/provider.ts
@@ -67,14 +67,7 @@ async function initializeWorkspacePlatform(): Promise<void> {
 					favicon: PLATFORM_ICON
 				}
 			}
-		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palettes: templateHelpers.DEFAULT_PALETTES
-			}
-		]
+		}
 	});
 }
 

--- a/how-to/integrate-with-snap/client/src/provider.ts
+++ b/how-to/integrate-with-snap/client/src/provider.ts
@@ -12,7 +12,7 @@ const PLATFORM_ICON = "http://localhost:8080/favicon.ico";
 
 window.addEventListener("DOMContentLoaded", async () => {
 	// The DOM is ready so initialize the platform
-	// Provide default icons and default theme for the browser windows
+	// Provide default icons for the browser windows
 	await initializeWorkspacePlatform();
 
 	// Initialize dummy HERE Core UI Components.
@@ -40,17 +40,6 @@ async function initializeWorkspacePlatform(): Promise<void> {
 				}
 			}
 		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palette: {
-					brandPrimary: "#0A76D3",
-					brandSecondary: "#383A40",
-					backgroundPrimary: "#1E1F23"
-				}
-			}
-		],
 		overrideCallback
 	});
 }

--- a/how-to/register-with-browser/client/src/provider.ts
+++ b/how-to/register-with-browser/client/src/provider.ts
@@ -35,7 +35,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 	const customSettings = await getManifestCustomSettings();
 
 	// The DOM is ready so initialize the platform
-	// Provide default icons and default theme for the browser windows
+	// Provide default icons for the browser windows
 	await initializeWorkspacePlatform(customSettings);
 
 	// If we have launch bar settings then open the window
@@ -62,17 +62,6 @@ async function initializeWorkspacePlatform(customSettings: CustomSettings): Prom
 				}
 			}
 		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palette: {
-					brandPrimary: "#0A76D3",
-					brandSecondary: "#383A40",
-					backgroundPrimary: "#1E1F23"
-				}
-			}
-		],
 		// Get the custom action used the launched windows.
 		customActions: getCustomActions(),
 		// Implement an override of some of the platform callback methods.

--- a/how-to/register-with-dock-basic/client/src/provider.ts
+++ b/how-to/register-with-dock-basic/client/src/provider.ts
@@ -33,7 +33,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 	await platform.once("platform-api-ready", async () => initializeWorkspaceComponents());
 
 	// The DOM is ready so initialize the platform
-	// Provide default icons and default theme for the browser windows
+	// Provide default icons for the browser windows
 	await initializeWorkspacePlatform();
 
 	// Get the DOM elements from the provider.html page and initialize them
@@ -55,17 +55,6 @@ async function initializeWorkspacePlatform(): Promise<void> {
 				}
 			}
 		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palette: {
-					brandPrimary: "#0A76D3",
-					brandSecondary: "#383A40",
-					backgroundPrimary: "#1E1F23"
-				}
-			}
-		],
 		// Get the custom actions from the dock which will be triggered
 		// when the buttons are clicked
 		customActions: dockGetCustomActions()

--- a/how-to/register-with-dock/client/src/provider.ts
+++ b/how-to/register-with-dock/client/src/provider.ts
@@ -17,7 +17,7 @@ const NEW_TAB_URL = "http://localhost:8080/common/views/platform/new-tab/new-tab
 
 window.addEventListener("DOMContentLoaded", async () => {
 	// The DOM is ready so initialize the platform
-	// Provide default icons and default theme for the browser windows
+	// Provide default icons for the browser windows
 	await initializeWorkspacePlatform();
 
 	// Initialize dummy HERE Core UI Components so that the buttons show in the dock.
@@ -40,17 +40,6 @@ async function initializeWorkspacePlatform(): Promise<void> {
 				}
 			}
 		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palette: {
-					brandPrimary: "#0A76D3",
-					brandSecondary: "#383A40",
-					backgroundPrimary: "#1E1F23"
-				}
-			}
-		],
 		// Get the custom actions from the dock which will be triggered
 		// when the buttons are clicked
 		customActions: dockGetCustomActions(),

--- a/how-to/register-with-dock3-basic/client/src/provider.ts
+++ b/how-to/register-with-dock3-basic/client/src/provider.ts
@@ -37,7 +37,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 	await platform.once("platform-api-ready", async () => initializeWorkspaceComponents());
 
 	// The DOM is ready so initialize the platform
-	// Provide default icons and default theme for the browser windows
+	// Provide default icons for the browser windows
 	const app = await fin.Application.getCurrent();
 	const manifest = await app.getManifest();
 	let workspaceAsar: { alias: string } | undefined;
@@ -67,17 +67,6 @@ async function initializeWorkspacePlatform(workspaceAsar?: { alias: string }): P
 				}
 			}
 		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palette: {
-					brandPrimary: "#0A76D3",
-					brandSecondary: "#383A40",
-					backgroundPrimary: "#1E1F23"
-				}
-			}
-		],
 		workspaceAsar
 	});
 }

--- a/how-to/register-with-home-basic/client/src/provider.ts
+++ b/how-to/register-with-home-basic/client/src/provider.ts
@@ -14,7 +14,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 	await platform.once("platform-api-ready", async () => initializeWorkspaceComponents());
 
 	// The DOM is ready so initialize the platform
-	// Provide default icons and default theme for the browser windows
+	// Provide default icons for the browser windows
 	await initializeWorkspacePlatform();
 
 	// Get the DOM elements from the provider.html page and initialize them
@@ -35,18 +35,7 @@ async function initializeWorkspacePlatform(): Promise<void> {
 					favicon: PLATFORM_ICON
 				}
 			}
-		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palette: {
-					brandPrimary: "#0A76D3",
-					brandSecondary: "#383A40",
-					backgroundPrimary: "#1E1F23"
-				}
-			}
-		]
+		}
 	});
 }
 

--- a/how-to/register-with-home/client/src/provider.ts
+++ b/how-to/register-with-home/client/src/provider.ts
@@ -13,7 +13,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 	await platform.once("platform-api-ready", async () => initializeWorkspaceComponents(customSettings));
 
 	// The DOM is ready so initialize the platform
-	// Provide default icons and default theme for the browser windows
+	// Provide default icons for the browser windows
 	await initializeWorkspacePlatform(customSettings);
 });
 
@@ -32,18 +32,7 @@ async function initializeWorkspacePlatform(customSettings: CustomSettings): Prom
 					favicon: customSettings.homeProvider?.icon
 				}
 			}
-		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palette: {
-					brandPrimary: "#0A76D3",
-					brandSecondary: "#383A40",
-					backgroundPrimary: "#1E1F23"
-				}
-			}
-		]
+		}
 	});
 }
 

--- a/how-to/register-with-platform-windows/client/src/provider.ts
+++ b/how-to/register-with-platform-windows/client/src/provider.ts
@@ -12,7 +12,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 	await platform.once("platform-api-ready", async () => initializeWorkspaceComponents());
 
 	// The DOM is ready so initialize the platform
-	// Provide default icons and default theme for the browser windows
+	// Provide default icons for the browser windows
 	await initializeWorkspacePlatform();
 
 	// The apps that are launch from home will use the defaultWindowOptions
@@ -36,18 +36,7 @@ async function initializeWorkspacePlatform(): Promise<void> {
 					favicon: PLATFORM_ICON
 				}
 			}
-		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palette: {
-					brandPrimary: "#0A76D3",
-					brandSecondary: "#383A40",
-					backgroundPrimary: "#1E1F23"
-				}
-			}
-		]
+		}
 	});
 }
 

--- a/how-to/register-with-store-basic/client/src/provider.ts
+++ b/how-to/register-with-store-basic/client/src/provider.ts
@@ -14,7 +14,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 	await platform.once("platform-api-ready", async () => initializeWorkspaceComponents());
 
 	// The DOM is ready so initialize the platform
-	// Provide default icons and default theme for the browser windows
+	// Provide default icons for the browser windows
 	await initializeWorkspacePlatform();
 
 	// Get the DOM elements from the provider.html page and initialize them
@@ -36,17 +36,6 @@ async function initializeWorkspacePlatform(): Promise<void> {
 				}
 			}
 		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palette: {
-					brandPrimary: "#0A76D3",
-					brandSecondary: "#383A40",
-					backgroundPrimary: "#1E1F23"
-				}
-			}
-		],
 		// Get the custom actions from the store which will be triggered
 		// when the buttons are clicked
 		customActions: storeGetCustomActions()

--- a/how-to/register-with-store/client/src/provider.ts
+++ b/how-to/register-with-store/client/src/provider.ts
@@ -13,7 +13,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 	const customSettings = await getManifestCustomSettings();
 
 	// The DOM is ready so initialize the platform
-	// Provide default icons and default theme for the browser windows
+	// Provide default icons for the browser windows
 	await initializeWorkspacePlatform(customSettings);
 });
 
@@ -33,19 +33,6 @@ async function initializeWorkspacePlatform(customSettings: CustomSettings): Prom
 				}
 			}
 		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palette: {
-					brandPrimary: "#0A76D3",
-					brandSecondary: "#383A40",
-					backgroundPrimary: "#1E1F23",
-					// This additional color is used to theme the hero background in store
-					contentBackground1: "#0A76D3"
-				}
-			}
-		],
 		// Get the custom actions from the store which will be triggered
 		// when the buttons are clicked
 		customActions: storeGetCustomActions()

--- a/how-to/support-context-and-intents/client/src/provider.ts
+++ b/how-to/support-context-and-intents/client/src/provider.ts
@@ -19,7 +19,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 	await platform.once("platform-api-ready", async () => initializeWorkspaceComponents(customSettings));
 
 	// The DOM is ready so initialize the platform
-	// Provide default icons and default theme for the browser windows
+	// Provide default icons for the browser windows
 	await initializeWorkspacePlatform(customSettings);
 });
 
@@ -54,17 +54,6 @@ async function initializeWorkspacePlatform(customSettings: CustomSettings): Prom
 				}
 			}
 		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palette: {
-					brandPrimary: "#0A76D3",
-					brandSecondary: "#383A40",
-					backgroundPrimary: "#1E1F23"
-				}
-			}
-		],
 		// Use an override for the platform interop to handle the context and intents
 		interopOverride
 	});

--- a/how-to/use-notifications/client/src/provider.ts
+++ b/how-to/use-notifications/client/src/provider.ts
@@ -41,7 +41,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 	await initializeDom();
 
 	// The DOM is ready so initialize the platform
-	// Provide default icons and default theme for the browser windows
+	// Provide default icons for the browser windows
 	await initializeWorkspacePlatform();
 
 	await initializeNotifications();
@@ -61,41 +61,7 @@ async function initializeWorkspacePlatform(): Promise<void> {
 					favicon: PLATFORM_ICON
 				}
 			}
-		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palettes: {
-					dark: {
-						brandPrimary: "#0A76D3",
-						brandSecondary: "#383A40",
-						backgroundPrimary: "#1E1F23"
-					},
-					light: {
-						brandPrimary: "#0A76D3",
-						brandSecondary: "#1E1F23",
-						backgroundPrimary: "#FAFBFE",
-						// Demonstrate changing the link color for notifications
-						linkDefault: "#FF0000",
-						linkHover: "#00FF00"
-					}
-				},
-				notificationIndicatorColors: {
-					// This custom indicator color will be used in the Notification with Custom Indicator
-					"custom-indicator": {
-						dark: {
-							background: "#FF0000",
-							foreground: "#FFFFDD"
-						},
-						light: {
-							background: "#FF0000",
-							foreground: "#FFFFDD"
-						}
-					}
-				}
-			}
-		]
+		}
 	});
 }
 

--- a/how-to/workspace-platform-starter-basic/client/src/provider.ts
+++ b/how-to/workspace-platform-starter-basic/client/src/provider.ts
@@ -20,7 +20,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 	);
 
 	// The DOM is ready so initialize the platform
-	// Provide default icons and default theme for the browser windows
+	// Provide default icons for the browser windows
 	await initializeWorkspacePlatform(settings.platformSettings, settings.customSettings ?? {});
 });
 
@@ -58,17 +58,6 @@ async function initializeWorkspacePlatform(
 				}
 			}
 		},
-		theme: [
-			{
-				label: "Default",
-				default: "dark",
-				palette: {
-					brandPrimary: "#0A76D3",
-					brandSecondary: "#383A40",
-					backgroundPrimary: "#1E1F23"
-				}
-			}
-		],
 		customActions: {
 			"launch-app": async (e): Promise<void> => {
 				if (


### PR DESCRIPTION
Most of the how-to examples included explicit theme declarations in the platform initialization logic. Removed that for all non-theming examples to use default theme across the board.

Related Jira ticket: https://openfin.jira.com/browse/CSE-1251