### PR TITLE
Add persist-on-click notification example to use-notifications

### DIFF
--- a/how-to/use-notifications/client/src/provider.ts
+++ b/how-to/use-notifications/client/src/provider.ts
@@ -8,6 +8,11 @@ const PLATFORM_TITLE = "Use Notifications";
 
 const NOTIFICATION_SOUND_URL = "http://localhost:8080/assets/notification.mp3";
 
+// Keep track of persist-on-click notification click counts
+const persistOnClickNotifications: {
+	[id: string]: { clickCount: number };
+} = {};
+
 // Keep track of notifications we are updating
 const updatableNotifications: {
 	[id: string]: Notifications.TemplateMarkdown & { customData: { count: number } };
@@ -195,6 +200,11 @@ async function initializeDom(): Promise<void> {
 		btnNotificationActionable.addEventListener("click", async () => showActionableNotification());
 	}
 
+	const btnNotificationPersistOnClick = document.querySelector("#btnNotificationPersistOnClick");
+	if (btnNotificationPersistOnClick) {
+		btnNotificationPersistOnClick.addEventListener("click", async () => showPersistOnClickNotification());
+	}
+
 	const btnNotificationForm = document.querySelector("#btnNotificationForm");
 	if (btnNotificationForm) {
 		btnNotificationForm.addEventListener("click", async () => showFormNotification());
@@ -327,11 +337,29 @@ async function initializeListeners(): Promise<void> {
 				cancelReminderTimer = undefined;
 			}
 		}
+
+		if (persistOnClickNotifications[event.notification.id]) {
+			delete persistOnClickNotifications[event.notification.id];
+		}
 	});
 
 	await Notifications.addEventListener("notification-action", async (event) => {
 		if (event?.result?.actionId === "open-web-site") {
 			await fin.System.openUrlWithBrowser(event?.result?.url as string);
+		} else if (event?.result?.task === "persist-action") {
+			const notificationId = event.notification.id;
+			const clickCount = persistOnClickNotifications[notificationId]
+				? ++persistOnClickNotifications[notificationId].clickCount
+				: 0;
+
+			loggingAddEntry(`Action: ${notificationId}`);
+			loggingAddEntry(`\tTask: ${event?.result?.task ?? "None"}`);
+			loggingAddEntry(
+				`\tData: ${event?.result?.customData ? JSON.stringify(event.result.customData) : "None"}`
+			);
+			if (clickCount > 0) {
+				loggingAddEntry(`\tPersist action (click ${clickCount}) — notification remains visible`);
+			}
 		} else if (event?.result?.BODY_CLICK === "dismiss_event") {
 			if (event.notification?.customData?.action) {
 				loggingAddEntry(
@@ -523,6 +551,53 @@ async function showActionableNotification(): Promise<void> {
 			}
 		]
 	};
+
+	codeShowExample(notification);
+	await Notifications.create(notification);
+}
+
+/**
+ * Buttons for the persist-on-click scenario.
+ * @returns The button configuration for persist-on-click notifications.
+ */
+function getPersistOnClickButtons(): Notifications.ButtonOptions[] {
+	return [
+		{
+			title: "Run Action",
+			type: "button",
+			cta: true,
+			persistOnClick: true,
+			onClick: {
+				task: "persist-action",
+				customData: {
+					message: "Action without dismiss"
+				}
+			}
+		},
+		{
+			title: "Dismiss",
+			type: "button"
+		}
+	];
+}
+
+/**
+ * Show a notification with a button that performs an action without dismissing.
+ */
+async function showPersistOnClickNotification(): Promise<void> {
+	const id = randomUUID();
+	const notification: Notifications.NotificationOptions = {
+		title: "Persist On Click Notification",
+		body: "Click Run Action to trigger an action without dismissing. Check the Logging panel for feedback. Use Dismiss or X to close.",
+		toast: "sticky",
+		category: "default",
+		template: "markdown",
+		id,
+		platform: PLATFORM_ID,
+		buttons: getPersistOnClickButtons()
+	};
+
+	persistOnClickNotifications[id] = { clickCount: 0 };
 
 	codeShowExample(notification);
 	await Notifications.create(notification);

--- a/how-to/use-notifications/public/platform/provider.html
+++ b/how-to/use-notifications/public/platform/provider.html
@@ -31,6 +31,9 @@
 					Body Click Dismiss Custom Action Notification
 				</button>
 				<button id="btnNotificationActionable" class="secondary" disabled>Actionable Notification</button>
+				<button id="btnNotificationPersistOnClick" class="secondary" disabled>
+					Persist On Click Notification
+				</button>
 				<button id="btnNotificationForm" class="secondary" disabled>Form Notification</button>
 				<button id="btnNotificationFormAdvanced" class="secondary" disabled>
 					Form Advanced Notification


### PR DESCRIPTION
Add a notification demonstrating the new "Persist on Click" notification button setting to the use-notifications example app. Clicking the button will increment a counter, loggin the current count to the log window.