### PR TITLE
Add option to suppress save/switch workspace indicators to browser example

### DIFF
--- a/how-to/register-with-browser/README.md
+++ b/how-to/register-with-browser/README.md
@@ -6,9 +6,9 @@
 
 HERE Core UI empowers you to take advantage of our browser component by using our HERE Core UI Platform SDK to control the behavior of the HERE Browser independent of the Home and Storefront components. The control window (`public/platform/provider.html`) loads **without** calling `WorkspacePlatform.init()`. Configure a scenario and settings, then use the lifecycle buttons:
 
-1. **Initialize Platform** — calls `init({ allowDuplicatePageTitles, ... })` using the current checkbox value.
+1. **Initialize Platform** — calls `init({ allowDuplicatePageTitles, indicators, ... })` using the current checkbox values.
 2. **Launch Browser** — runs the selected scenario from `client/src/browser-scenarios.ts` (enabled after initialize).
-3. **Restart Demo** — restarts the application without initializing the platform so you can change settings (including Allow Duplicate Page Titles) and click **Initialize Platform** again.
+3. **Restart Demo** — restarts the application without initializing the platform so you can change settings (including Allow Duplicate Page Titles and suppress workspace indicator flags) and click **Initialize Platform** again.
 4. **Quit** — exits the application (works before or after initialize).
 
 Scenarios you can try:
@@ -27,6 +27,18 @@ Scenarios you can try:
 Set **Allow Duplicate Page Titles** before **Initialize Platform** (the checkbox is disabled while the platform is initialized). On create, the second tab may still receive a suffix such as `(1)` even when the option is enabled — that is expected. To observe duplicate titles: enable the checkbox, initialize, launch the duplicate page titles scenario, then **rename one page tab** so it matches the other (for example, both `Shared Page Title`). To try a different setting, click **Restart Demo**, change the checkbox, and **Initialize Platform** again.
 
 To try pinned tabs: initialize the platform, select **Launch Browser With Pinned Pages**, and click **Launch Browser**. The window opens with three developer-locked platform pins (`pinned: "platform"`), three user pins (`pinned: "user"`) that can be unpinned from the tab context menu, and one regular unpinned tab for comparison.
+
+## Suppress workspace indicators (24.0+)
+
+`BrowserInitConfig.indicators` is an opt-in platform setting (defaults remain unchanged: indicators are shown). Set these checkboxes **before** **Initialize Platform** (they are locked while initialized):
+
+- **Suppress Workspace Switched Indicator** — `suppressWorkspaceSwitched`
+- **Suppress Workspace Saved Indicator** — `suppressWorkspaceSaved` (regular save only; save-as and rename still show success indicators)
+
+To compare behavior:
+
+1. Leave both unchecked → **Initialize Platform** → **Launch Browser** → use the browser main menu **Save Workspace** (expect “Workspace Saved”) and **Switch Workspace** after at least one workspace exists (expect “Workspace Switched”).
+2. **Restart Demo** → enable one or both suppress checkboxes → **Initialize Platform** → **Launch Browser** → repeat Save / Switch Workspace → the corresponding success indicators are suppressed.
 
 This example assumes you have already [set up your development environment](https://resources.here.io/docs/core/develop/)
 
@@ -80,9 +92,9 @@ npm run client
 ```
 
 1. The client command opens the provider window (`public/platform/provider.html`, `client/src/provider.ts`) with scenario and settings only.
-2. **Initialize Platform** bootstraps the HERE Core UI Platform SDK with `allowDuplicatePageTitles` from the checkbox.
+2. **Initialize Platform** bootstraps the HERE Core UI Platform SDK with `allowDuplicatePageTitles` and `browser.indicators` from the checkboxes.
 3. **Launch Browser** creates the selected browser window; scenario can be changed between launches without restarting.
-4. **Restart Demo** closes browser windows, calls `Application.restart()`, and on load restores the control panel in an uninitialized state (checkbox value is restored from **`localStorage`** so you can adjust it before initializing again).
+4. **Restart Demo** closes browser windows, calls `Application.restart()`, and on load restores the control panel in an uninitialized state (checkbox values are restored from **`localStorage`** so you can adjust them before initializing again).
 
 ![Register With Browser](./assets/register-with-browser.gif)
 

--- a/how-to/register-with-browser/client/src/provider.ts
+++ b/how-to/register-with-browser/client/src/provider.ts
@@ -30,32 +30,62 @@ import type { CustomSettings } from "./shapes";
 const PLATFORM_ICON = "http://localhost:8080/favicon.ico";
 
 /**
- * Restores the duplicate-titles checkbox after Restart Demo; does not auto-initialize the platform.
+ * Restores init-option checkboxes after Restart Demo; does not auto-initialize the platform.
  */
-const STORAGE_KEY_RESTART_DEMO_ALLOW_DUP = "register-with-browser.restartDemoAllowDupTitles";
+const STORAGE_KEY_RESTART_DEMO_INIT_OPTIONS = "register-with-browser.restartDemoInitOptions";
+
+/**
+ * Init-time control panel options snapshotted by the Workspace SDK inside init().
+ */
+interface BrowserInitOptionsFromDOM {
+	/** Whether duplicate page titles are allowed. */
+	allowDuplicatePageTitles: boolean;
+	/** Suppress the Workspace Switched success indicator. */
+	suppressWorkspaceSwitched: boolean;
+	/** Suppress the Workspace Saved success indicator (save only). */
+	suppressWorkspaceSaved: boolean;
+}
 
 let manifestCustomSettings: CustomSettings = {};
 let isPlatformInitialized = false;
 
 /**
- * Read whether duplicate page titles are allowed from the control panel checkbox.
- * @returns True when the allow duplicate page titles checkbox is checked.
+ * Read init-time browser options from the control panel checkboxes.
+ * @returns The checkbox values for platform init.
  */
-function getAllowDuplicatePageTitlesFromDOM(): boolean {
-	return document.querySelector<HTMLInputElement>("#allowDuplicatePageTitles")?.checked ?? false;
+function getBrowserInitOptionsFromDOM(): BrowserInitOptionsFromDOM {
+	return {
+		allowDuplicatePageTitles:
+			document.querySelector<HTMLInputElement>("#allowDuplicatePageTitles")?.checked ?? false,
+		suppressWorkspaceSwitched:
+			document.querySelector<HTMLInputElement>("#suppressWorkspaceSwitched")?.checked ?? false,
+		suppressWorkspaceSaved:
+			document.querySelector<HTMLInputElement>("#suppressWorkspaceSaved")?.checked ?? false
+	};
 }
 
 /**
- * Align the duplicate-titles checkbox after Restart Demo (restore from localStorage).
- * @param allowed Whether duplicate titles are allowed for the upcoming init.
+ * Align init-option checkboxes after Restart Demo (restore from localStorage).
+ * @param options The options to restore for the upcoming init.
  */
-function syncAllowDuplicateCheckboxFromString(allowed: boolean): void {
+function syncInitOptionCheckboxesFromOptions(options: BrowserInitOptionsFromDOM): void {
 	const scenarioSelect = document.querySelector<HTMLSelectElement>("#scenario");
 	const allowDuplicatePageTitlesCheckbox =
 		document.querySelector<HTMLInputElement>("#allowDuplicatePageTitles");
+	const suppressWorkspaceSwitchedCheckbox = document.querySelector<HTMLInputElement>(
+		"#suppressWorkspaceSwitched"
+	);
+	const suppressWorkspaceSavedCheckbox = document.querySelector<HTMLInputElement>("#suppressWorkspaceSaved");
 	const duplicateTitlesHint = document.querySelector<HTMLParagraphElement>("#duplicate-titles-hint");
+
 	if (allowDuplicatePageTitlesCheckbox) {
-		allowDuplicatePageTitlesCheckbox.checked = allowed;
+		allowDuplicatePageTitlesCheckbox.checked = options.allowDuplicatePageTitles;
+	}
+	if (suppressWorkspaceSwitchedCheckbox) {
+		suppressWorkspaceSwitchedCheckbox.checked = options.suppressWorkspaceSwitched;
+	}
+	if (suppressWorkspaceSavedCheckbox) {
+		suppressWorkspaceSavedCheckbox.checked = options.suppressWorkspaceSaved;
 	}
 	if (scenarioSelect && allowDuplicatePageTitlesCheckbox && duplicateTitlesHint) {
 		updateDuplicatePageTitlesHintTextOnly(
@@ -70,8 +100,8 @@ function syncAllowDuplicateCheckboxFromString(allowed: boolean): void {
  * Initialize the workspace platform from the control panel.
  */
 async function handleInitializePlatformClick(): Promise<void> {
-	const allowDup = getAllowDuplicatePageTitlesFromDOM();
-	await initializeWorkspacePlatform(manifestCustomSettings, allowDup);
+	const initOptions = getBrowserInitOptionsFromDOM();
+	await initializeWorkspacePlatform(manifestCustomSettings, initOptions);
 	isPlatformInitialized = true;
 	setControlState("initialized");
 }
@@ -80,7 +110,41 @@ async function handleInitializePlatformClick(): Promise<void> {
  * Drop session markers so Quit starts a cold session next time.
  */
 function clearWorkspaceSessionMarkers(): void {
-	localStorage.removeItem(STORAGE_KEY_RESTART_DEMO_ALLOW_DUP);
+	localStorage.removeItem(STORAGE_KEY_RESTART_DEMO_INIT_OPTIONS);
+	// Remove legacy Restart Demo key used before indicator suppress options were added.
+	localStorage.removeItem("register-with-browser.restartDemoAllowDupTitles");
+}
+
+/**
+ * Parse restart-demo init options from localStorage.
+ * @param raw The raw localStorage value.
+ * @returns Parsed options, or null when the value is missing or invalid.
+ */
+function parseRestartDemoInitOptions(raw: string | null): BrowserInitOptionsFromDOM | null {
+	if (raw === null) {
+		return null;
+	}
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		if (parsed !== null && typeof parsed === "object") {
+			const record = parsed as { [key: string]: unknown };
+			return {
+				allowDuplicatePageTitles: record.allowDuplicatePageTitles === true,
+				suppressWorkspaceSwitched: record.suppressWorkspaceSwitched === true,
+				suppressWorkspaceSaved: record.suppressWorkspaceSaved === true
+			};
+		}
+	} catch {
+		// Legacy Restart Demo stored only the duplicate-titles boolean as "true"/"false".
+		if (raw === "true" || raw === "false") {
+			return {
+				allowDuplicatePageTitles: raw === "true",
+				suppressWorkspaceSwitched: false,
+				suppressWorkspaceSaved: false
+			};
+		}
+	}
+	return null;
 }
 
 window.addEventListener("DOMContentLoaded", async () => {
@@ -91,30 +155,37 @@ window.addEventListener("DOMContentLoaded", async () => {
 
 	manifestCustomSettings = await getManifestCustomSettings();
 
-	const restartDemoAllowDup = localStorage.getItem(STORAGE_KEY_RESTART_DEMO_ALLOW_DUP);
+	const restartDemoInitOptions =
+		parseRestartDemoInitOptions(localStorage.getItem(STORAGE_KEY_RESTART_DEMO_INIT_OPTIONS)) ??
+		parseRestartDemoInitOptions(localStorage.getItem("register-with-browser.restartDemoAllowDupTitles"));
 
 	await initializeDOM();
 
-	if (restartDemoAllowDup !== null) {
-		localStorage.removeItem(STORAGE_KEY_RESTART_DEMO_ALLOW_DUP);
-		syncAllowDuplicateCheckboxFromString(restartDemoAllowDup === "true");
+	if (restartDemoInitOptions !== null) {
+		localStorage.removeItem(STORAGE_KEY_RESTART_DEMO_INIT_OPTIONS);
+		localStorage.removeItem("register-with-browser.restartDemoAllowDupTitles");
+		syncInitOptionCheckboxesFromOptions(restartDemoInitOptions);
 	}
 });
 
 /**
- * Initialize the HERE Core UI Platform with an explicit duplicate-title flag.
+ * Initialize the HERE Core UI Platform with explicit browser init options.
  * The Workspace SDK snapshots browser config inside init(); a getter is not reliably re-read later.
  * @param customSettings The custom settings from the manifest.
- * @param allowDuplicatePageTitles Whether duplicate page titles are allowed for this workspace session.
+ * @param initOptions Init-time browser options from the control panel.
  */
 async function initializeWorkspacePlatform(
 	customSettings: CustomSettings,
-	allowDuplicatePageTitles: boolean
+	initOptions: BrowserInitOptionsFromDOM
 ): Promise<void> {
-	console.log("Initializing HERE Core UI Platform", { allowDuplicatePageTitles });
+	console.log("Initializing HERE Core UI Platform", initOptions);
 	await init({
 		browser: {
-			allowDuplicatePageTitles,
+			allowDuplicatePageTitles: initOptions.allowDuplicatePageTitles,
+			indicators: {
+				suppressWorkspaceSwitched: initOptions.suppressWorkspaceSwitched,
+				suppressWorkspaceSaved: initOptions.suppressWorkspaceSaved
+			},
 			browserIconSize: customSettings.browserIconSize,
 			defaultWindowOptions: {
 				icon: PLATFORM_ICON,
@@ -216,6 +287,10 @@ function setControlState(state: ControlState): void {
 	const scenarioSelect = document.querySelector<HTMLSelectElement>("#scenario");
 	const allowDuplicatePageTitlesCheckbox =
 		document.querySelector<HTMLInputElement>("#allowDuplicatePageTitles");
+	const suppressWorkspaceSwitchedCheckbox = document.querySelector<HTMLInputElement>(
+		"#suppressWorkspaceSwitched"
+	);
+	const suppressWorkspaceSavedCheckbox = document.querySelector<HTMLInputElement>("#suppressWorkspaceSaved");
 
 	const initialized = state === "initialized";
 
@@ -228,6 +303,12 @@ function setControlState(state: ControlState): void {
 		if (allowDuplicatePageTitlesCheckbox) {
 			allowDuplicatePageTitlesCheckbox.disabled = initialized;
 		}
+		if (suppressWorkspaceSwitchedCheckbox) {
+			suppressWorkspaceSwitchedCheckbox.disabled = initialized;
+		}
+		if (suppressWorkspaceSavedCheckbox) {
+			suppressWorkspaceSavedCheckbox.disabled = initialized;
+		}
 	}
 }
 
@@ -238,8 +319,7 @@ async function restartDemo(): Promise<void> {
 	if (!isPlatformInitialized) {
 		return;
 	}
-	const allowDup = getAllowDuplicatePageTitlesFromDOM();
-	localStorage.setItem(STORAGE_KEY_RESTART_DEMO_ALLOW_DUP, allowDup ? "true" : "false");
+	localStorage.setItem(STORAGE_KEY_RESTART_DEMO_INIT_OPTIONS, JSON.stringify(getBrowserInitOptionsFromDOM()));
 	const platform = getCurrentSync();
 	const browserWindows = await platform.Browser.getAllWindows();
 	await Promise.all(browserWindows.map(async (browserWindow) => browserWindow.openfinWindow.close()));

--- a/how-to/register-with-browser/public/platform/provider.html
+++ b/how-to/register-with-browser/public/platform/provider.html
@@ -23,9 +23,9 @@
 		<main class="col fill gap20 scroll-vertical">
 			<p>
 				Select a browser scenario and options below, then click Initialize Platform. After initialization, use
-				Launch Browser to open the selected scenario. Set Allow Duplicate Page Titles before initializing (it
-				is locked while initialized). Use Restart Demo to restart without initializing so you can change
-				settings and initialize again.
+				Launch Browser to open the selected scenario. Set init options (Allow Duplicate Page Titles and
+				suppress workspace indicators) before initializing — they are locked while initialized. Use Restart
+				Demo to restart without initializing so you can change settings and initialize again.
 			</p>
 			<div class="col gap10">
 				<fieldset class="col gap10">
@@ -37,6 +37,19 @@
 					<label for="allowDuplicatePageTitles">Allow Duplicate Page Titles</label>
 				</fieldset>
 				<p id="duplicate-titles-hint" class="tag" hidden></p>
+				<fieldset class="row">
+					<input type="checkbox" id="suppressWorkspaceSwitched" />
+					<label for="suppressWorkspaceSwitched">Suppress Workspace Switched Indicator</label>
+				</fieldset>
+				<fieldset class="row">
+					<input type="checkbox" id="suppressWorkspaceSaved" />
+					<label for="suppressWorkspaceSaved">Suppress Workspace Saved Indicator</label>
+				</fieldset>
+				<p id="workspace-indicators-hint" class="tag">
+					Set suppress flags before Initialize Platform. After Launch Browser, use the browser main menu Save
+					Workspace / Switch Workspace to compare with and without suppression. Save-as and rename still show
+					success indicators when Suppress Workspace Saved is enabled.
+				</p>
 				<div class="row gap10">
 					<button id="initialize-platform">Initialize Platform</button>
 					<button id="restart-demo" disabled>Restart Demo</button>


### PR DESCRIPTION
Add settings to the how-to/register-with-browser launcher that enable/disable suppression of the "Save Workspace" or "Switch Workspace" success indicators. 

Jira ticket: https://openfin.jira.com/jira/polaris/projects/PRODM/ideas/view/e2a4773d-a85a-499c-99f7-68ccd974a244?selectedIssue=PRODM-639