### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/automation-testing-full.yml
+++ b/.github/workflows/automation-testing-full.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Setup Node 24
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
@@ -22,7 +22,7 @@ jobs:
 
       - name: Restore root node_modules from cache
         id: node-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/automation-testing.yml
+++ b/.github/workflows/automation-testing.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Setup Node 24
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
@@ -22,7 +22,7 @@ jobs:
 
       - name: Restore root node_modules from cache
         id: node-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Setup Node 24
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
@@ -20,7 +20,7 @@ jobs:
 
       - name: Restore root node_modules from cache
         id: node-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Setup Node 24
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
@@ -20,7 +20,7 @@ jobs:
 
       - name: Restore root node_modules from cache
         id: node-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/publish-HOWTOs.yml
+++ b/.github/workflows/publish-HOWTOs.yml
@@ -15,10 +15,10 @@ jobs:
       RELEASE_BRANCH_PREFIX: 'workspace/'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
@@ -26,7 +26,7 @@ jobs:
 
       - name: Restore root node_modules from cache
         id: node-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}
@@ -53,7 +53,7 @@ jobs:
           PKG_HOWTOS_PATH: ${{ github.ref_name }}
 
       - name: Upload artifacts (GitHub Pages)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           if-no-files-found: error
           name: workflow-howtos-github
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload artifacts (AWS s3 CDN)
         if: ${{ startsWith(github.ref_name, env.RELEASE_BRANCH_PREFIX) }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           if-no-files-found: error
           name: workflow-howtos-aws
@@ -75,16 +75,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: workflow-howtos-github
           path: public-github/
 
       - name: Publish
-        uses: JamesIves/github-pages-deploy-action@4.1.7
+        uses: JamesIves/github-pages-deploy-action@4
         with:
           branch: gh-pages # Target branch to deploy to
           folder: public-github # Source folder to deploy
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: workflow-howtos-aws
           path: public-aws/

--- a/.github/workflows/publish-HOWTOs.yml
+++ b/.github/workflows/publish-HOWTOs.yml
@@ -84,7 +84,7 @@ jobs:
           path: public-github/
 
       - name: Publish
-        uses: JamesIves/github-pages-deploy-action@4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages # Target branch to deploy to
           folder: public-github # Source folder to deploy
@@ -110,7 +110,7 @@ jobs:
           target: public-aws/
 
       - name: Publish
-        uses: jakejarvis/s3-sync-action@master
+        uses: jakejarvis/s3-sync-action@v0.5.1
         with:
           args: --acl public-read --follow-symlinks --delete
         env:

--- a/.github/workflows/publish-NPM.yaml
+++ b/.github/workflows/publish-NPM.yaml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Setup Node 24
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
@@ -16,7 +16,7 @@ jobs:
 
       - name: Restore root node_modules from cache
         id: node-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Setup Node 24
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
@@ -22,7 +22,7 @@ jobs:
 
       - name: Restore root node_modules from cache
         id: node-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
Update all GitHub Actions to their latest major 
versions across all workflow files.

 `automation-testing-full.yml`
- `actions/checkout` v3 → `@v7`
- `actions/setup-node` v3 → `@v7`
- `actions/cache` v3 → `@v6`

 `automation-testing.yml`
- `actions/checkout` v3 → `@v7`
- `actions/setup-node` v3 → `@v7`
- `actions/cache` v3 → `@v6`

 `e2e.yml`
- `actions/checkout` v3 → `@v7`
- `actions/setup-node` v3 → `@v7`
- `actions/cache` v3 → `@v6`

`lint.yml`
- `actions/checkout` v3 → `@v7`
- `actions/setup-node` v3 → `@v7`
- `actions/cache` v3 → `@v6`

`publish-HOWTOs.yml`
- `actions/checkout` v4 → `@v7`
- `actions/setup-node` v4 → `@v7`
- `actions/cache` v4 → `@v6`
- `actions/upload-artifact` v4 → `@v7`
- `actions/download-artifact` v4 → `@v8`
- `JamesIves/github-pages-deploy-action` 4.1.7 → `@v4`

`publish-NPM.yaml`
- `actions/checkout` v3 → `@v7`
- `actions/setup-node` v3 → `@v7`
- `actions/cache` v3 → `@v6`

`test.yml`
- `actions/checkout` v3 → `@v7`
- `actions/setup-node` v3 → `@v7`
- `actions/cache` v3 → `@v6`

Ref - [DEVOP-2670](https://openfin.jira.com/browse/DEVOP-2670)