### PR TITLE
Remove enable/disable shortcut demo from use-notifications.

### DIFF
--- a/how-to/use-notifications/README.md
+++ b/how-to/use-notifications/README.md
@@ -10,16 +10,6 @@ This application you are about to install is a simple example of plugging in you
 
 The example is a simple view that shows launching, interacting and auditing notifications.
 
-## Notification Center shortcut
-
-Notification Center has a default keyboard shortcut for toggling the center. This example customizes that shortcut so it does not collide with another use of the same combination:
-
-- On startup the example calls `setDefaultPlatformShortcut("CmdOrCtrl+Shift+Y")`. Press that combination to toggle Notification Center.
-- **Set Custom Shortcut (CmdOrCtrl+Alt+N)** uses `setShortcut` to apply a user-priority override (the same effect as changing the shortcut in Notification Center Advanced Settings).
-- **Disable Keyboard Shortcut** / **Enable Keyboard Shortcut** use `setShortcutEnabled` to turn the hotkey off or back on without losing the configured combination.
-
-After Disable, the accelerator should no longer toggle Notification Center. Enable restores it.
-
 ## Running the Sample
 
 To run this sample you can:

--- a/how-to/use-notifications/client/src/provider.ts
+++ b/how-to/use-notifications/client/src/provider.ts
@@ -7,8 +7,6 @@ const PLATFORM_ICON = "http://localhost:8080/images/icon-dot.png";
 const PLATFORM_TITLE = "Use Notifications";
 
 const NOTIFICATION_SOUND_URL = "http://localhost:8080/assets/notification.mp3";
-const DEFAULT_NOTIFICATION_CENTER_SHORTCUT = "CmdOrCtrl+Shift+Y";
-const CUSTOM_NOTIFICATION_CENTER_SHORTCUT = "CmdOrCtrl+Alt+N";
 
 // Keep track of persist-on-click notification click counts
 const persistOnClickNotifications: {
@@ -83,13 +81,6 @@ async function initializeNotifications(): Promise<void> {
 			title: PLATFORM_TITLE
 		}
 	});
-
-	try {
-		await Notifications.setDefaultPlatformShortcut(DEFAULT_NOTIFICATION_CENTER_SHORTCUT);
-		loggingAddEntry(`Default Notification Center shortcut set to: ${DEFAULT_NOTIFICATION_CENTER_SHORTCUT}`);
-	} catch (err) {
-		loggingAddEntry(`Error setting default Notification Center shortcut: ${err}`);
-	}
 
 	showNotificationCount(await Notifications.getNotificationsCount());
 
@@ -245,29 +236,6 @@ async function initializeDom(): Promise<void> {
 	if (btnNotificationCenterUserSettings) {
 		btnNotificationCenterUserSettings.addEventListener("click", async () =>
 			getNotificationCenterUserSettings()
-		);
-	}
-
-	const btnNotificationCenterSetShortcut = document.querySelector("#btnNotificationCenterSetShortcut");
-	if (btnNotificationCenterSetShortcut) {
-		btnNotificationCenterSetShortcut.addEventListener("click", async () =>
-			setNotificationCenterShortcut(CUSTOM_NOTIFICATION_CENTER_SHORTCUT)
-		);
-	}
-
-	const btnNotificationCenterDisableShortcut = document.querySelector(
-		"#btnNotificationCenterDisableShortcut"
-	);
-	if (btnNotificationCenterDisableShortcut) {
-		btnNotificationCenterDisableShortcut.addEventListener("click", async () =>
-			setNotificationCenterShortcutEnabled(false)
-		);
-	}
-
-	const btnNotificationCenterEnableShortcut = document.querySelector("#btnNotificationCenterEnableShortcut");
-	if (btnNotificationCenterEnableShortcut) {
-		btnNotificationCenterEnableShortcut.addEventListener("click", async () =>
-			setNotificationCenterShortcutEnabled(true)
 		);
 	}
 
@@ -1199,33 +1167,6 @@ async function showSoundNotification(notificationSoundUrl: string): Promise<void
 async function getNotificationCenterUserSettings(): Promise<void> {
 	const status = await Notifications.getUserSettingStatus(Notifications.UserSettings.SOUND_ENABLED);
 	loggingAddEntry(`Sound Enabled: ${status}`);
-}
-
-/**
- * Set the Notification Center keyboard shortcut at user-level priority.
- * This is the programmatic equivalent of changing the shortcut in Notification Center Advanced Settings.
- * @param shortcut The accelerator to use, e.g. CmdOrCtrl+Alt+N.
- */
-async function setNotificationCenterShortcut(shortcut: string): Promise<void> {
-	try {
-		await Notifications.setShortcut(shortcut);
-		loggingAddEntry(`Notification Center shortcut set to: ${shortcut}`);
-	} catch (err) {
-		loggingAddEntry(`Error setting Notification Center shortcut: ${err}`);
-	}
-}
-
-/**
- * Enable or disable the Notification Center keyboard shortcut.
- * @param enabled Whether the shortcut should be enabled.
- */
-async function setNotificationCenterShortcutEnabled(enabled: boolean): Promise<void> {
-	try {
-		await Notifications.setShortcutEnabled(enabled);
-		loggingAddEntry(`Notification Center shortcut enabled: ${enabled}`);
-	} catch (err) {
-		loggingAddEntry(`Error updating Notification Center shortcut enabled state: ${err}`);
-	}
 }
 
 /**

--- a/how-to/use-notifications/public/platform/provider.html
+++ b/how-to/use-notifications/public/platform/provider.html
@@ -49,23 +49,14 @@
 				<button id="btnNotificationWithSound" class="secondary" disabled>
 					Notification with Custom Sound
 				</button>
+				<button id="btnNotificationCenterUserSettings" class="secondary" disabled>
+					Get Notification Center User Settings
+				</button>
 				<button id="btnNotificationWithReminder" class="secondary" disabled>
 					Notification with Set Reminder
 				</button>
 				<button id="btnNotificationWithReminderCancel" class="secondary" disabled>
 					Notification with Set and Cancel Reminder
-				</button>
-				<button id="btnNotificationCenterUserSettings" class="secondary" disabled>
-					Get Notification Center User Settings
-				</button>
-				<button id="btnNotificationCenterSetShortcut" class="secondary" disabled>
-					Set Custom Shortcut (CmdOrCtrl+Alt+N)
-				</button>
-				<button id="btnNotificationCenterDisableShortcut" class="secondary" disabled>
-					Disable Keyboard Shortcut
-				</button>
-				<button id="btnNotificationCenterEnableShortcut" class="secondary" disabled>
-					Enable Keyboard Shortcut
 				</button>
 			</div>
 			<div class="col fill gap20">


### PR DESCRIPTION
The original request only covered customizing the Notification Center shortcut. setShortcutEnabled can be added later on v46 as a follow-up so it does not diverge from the v45 example.